### PR TITLE
fix: Return explicit message for OK Responses with incorrect state

### DIFF
--- a/src/momento/_cache_service_errors_converter.py
+++ b/src/momento/_cache_service_errors_converter.py
@@ -1,17 +1,13 @@
 import grpc
 from . import errors
 from . import _momento_logger
-from momento_wire_types import cacheclient_pb2 as cache_client_types
+
 
 __rpc_to_error = {
     grpc.StatusCode.ALREADY_EXISTS: errors.CacheExistsError,
     grpc.StatusCode.INVALID_ARGUMENT: errors.CacheValueError,
     grpc.StatusCode.NOT_FOUND: errors.CacheNotFoundError,
     grpc.StatusCode.PERMISSION_DENIED: errors.PermissionError,
-}
-
-__ecache_result_to_error = {
-    cache_client_types.Invalid: errors.InternalServerError,
 }
 
 
@@ -30,9 +26,8 @@ def convert(exception):
                                  str(exception))
 
 
-def convert_ecache_result(ecache_result, message):
+def convert_ecache_result(ecache_result, message, operation_name):
     _momento_logger.debug(f'Converting ECacheResult: {ecache_result} to error.')
-    if (ecache_result in __ecache_result_to_error):
-        return __ecache_result_to_error[ecache_result](message)
     return errors.InternalServerError(
-        'CacheService failed with an internal error')
+        f'CacheService returned an unexpected result: {ecache_result}' +
+        f' for operation: {operation_name} with message: {message}')

--- a/src/momento/cache_operation_responses.py
+++ b/src/momento/cache_operation_responses.py
@@ -15,7 +15,7 @@ class CacheSetResponse:
         if (grpc_set_response.result is not cache_client_types.Ok):
             _momento_logger.debug(f'Set received unsupported ECacheResult {grpc_set_response.result}')
             raise error_converter.convert_ecache_result(
-                grpc_set_response.result, grpc_set_response.message)
+                grpc_set_response.result, grpc_set_response.message, 'SET')
 
     def str_utf8(self):
         return self._value.decode('utf-8')
@@ -32,7 +32,7 @@ class CacheGetResponse:
                 and grpc_get_response.result is not cache_client_types.Miss):
             _momento_logger.debug(f'Get received unsupported ECacheResult: {grpc_get_response.result}')
             raise error_converter.convert_ecache_result(
-                grpc_get_response.result, grpc_get_response.message)
+                grpc_get_response.result, grpc_get_response.message, 'GET')
 
         if (grpc_get_response.result == cache_client_types.Hit):
             self._result = CacheResult.HIT


### PR DESCRIPTION
Given GRPC OK Responses aren't logged (rightfully so). There are still bugs that can be encountered if the response content is incorrect.

e.g. SetResponse should only have ECacheResult.OK and GetResponse should only support ECacheResult.Hit or ECacheResult.Miss.

Any other ECacheResult is indicative of a bug in MomentoSdk or on SCS. Throwing an exception with generic message will hide the underlying issue. Hence, setting an explicitmessage for such exceptions so any reports can be easily worked on immediately instead of having to tell customers to enable debug logging in the SDK. Enabling debug logging on customer's environments will take time and also same logging related challeneges would apply.