### PR TITLE
fix: use != instead of is not

### DIFF
--- a/src/momento/cache_operation_responses.py
+++ b/src/momento/cache_operation_responses.py
@@ -12,7 +12,7 @@ class CacheResult(Enum):
 class CacheSetResponse:
     def __init__(self, grpc_set_response, value):
         self._value = value
-        if (grpc_set_response.result is not cache_client_types.Ok):
+        if (grpc_set_response.result != cache_client_types.Ok):
             _momento_logger.debug(f'Set received unsupported ECacheResult {grpc_set_response.result}')
             raise error_converter.convert_ecache_result(
                 grpc_set_response.result, grpc_set_response.message, 'SET')
@@ -28,16 +28,15 @@ class CacheGetResponse:
     def __init__(self, grpc_get_response):
         self._value = grpc_get_response.cache_body
 
-        if (grpc_get_response.result is not cache_client_types.Hit
-                and grpc_get_response.result is not cache_client_types.Miss):
+        if (grpc_get_response.result == cache_client_types.Hit):
+            self._result = CacheResult.HIT
+        elif (grpc_get_response.result == cache_client_types.Miss):
+            self._result = CacheResult.MISS
+        else:
             _momento_logger.debug(f'Get received unsupported ECacheResult: {grpc_get_response.result}')
             raise error_converter.convert_ecache_result(
                 grpc_get_response.result, grpc_get_response.message, 'GET')
 
-        if (grpc_get_response.result == cache_client_types.Hit):
-            self._result = CacheResult.HIT
-        if (grpc_get_response.result == cache_client_types.Miss):
-            self._result = CacheResult.MISS
 
     def str_utf8(self):
         if (self._result == CacheResult.HIT):


### PR DESCRIPTION
Based on https://realpython.com/python-is-identity-vs-equality/, `is not` operator compares if two variables refer to the same object in memory. Hence switching to != and == comparisons. Although the types being compared are `int` and fall within range, it seems like the comaprison being made is incorrect.

Why only the bug reporter can reproduce this but not any of us is still a mystery to me. So unfortunately, I cannot test this fix apart from some theoretical reading that I did.

Nonetheless, this should fix it for everyone is my solid hope.

```
>>> import momento_wire_types.cacheclient_pb2 as cache_client_types
>>> get_resp = cache_client_types.GetResponse()
>>> type(get_resp)
<class 'cacheclient_pb2.GetResponse'>
>>> type(get_resp.result)
<class 'int'>
>>> type(cache_client_types.Hit)
<class 'int'>
```