### PR TITLE
ci: Update TEST_CACHE_NAME in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: dummy
+      TEST_CACHE_NAME: python-integration-test-cache
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since our tests run against prod-like environments, it's helpful to be able to more easily identify that these requests are coming from CI. Using a more descriptive cache name might help.

This came out of [this discussion](https://gomomento.slack.com/archives/C02H7V5EZ1V/p1643157936116600) in Slack, where we were getting alerts on preprod for error count. Ideally we need to tune alerting so tests don't trigger alerts, but in the mean time this will make it a little easier if the alerts do go off due to these tests.