### PR TITLE
fix: Integration tests

### DIFF
--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -242,7 +242,7 @@ class TestMomento(unittest.TestCase):
 
     def test_set_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
-        with self.assertRaises(errors.PermissionError) as cm:
+        with self.assertRaises(errors.CacheValueError) as cm:
             self.client.set("", "foo", "bar")
         self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
 
@@ -296,7 +296,7 @@ class TestMomento(unittest.TestCase):
 
     def test_get_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
-        with self.assertRaises(errors.PermissionError) as cm:
+        with self.assertRaises(errors.CacheValueError) as cm:
             self.client.get("", "foo")
         self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
 

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -239,7 +239,7 @@ class TestMomentoAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_set_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
-        with self.assertRaises(errors.PermissionError) as cm:
+        with self.assertRaises(errors.CacheValueError) as cm:
             await self.client.set("", "foo", "bar")
         self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
 
@@ -292,7 +292,7 @@ class TestMomentoAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
-        with self.assertRaises(errors.PermissionError) as cm:
+        with self.assertRaises(errors.CacheValueError) as cm:
             await self.client.get("", "foo")
         self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
 


### PR DESCRIPTION
Service now returns INVALID_ARGUMENT on empty cache header.