### PR TITLE
fix: Increase sleep in tests to account for TTL precisions

### DIFF
--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -218,7 +218,7 @@ class TestMomento(unittest.TestCase):
 
             self.assertEqual(simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.HIT)
 
-            time.sleep(3)
+            time.sleep(2)
             self.assertEqual(simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.MISS)
 
     def test_set_with_different_ttl(self):
@@ -231,7 +231,7 @@ class TestMomento(unittest.TestCase):
         self.assertEqual(self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.HIT)
         self.assertEqual(self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT)
 
-        time.sleep(3)
+        time.sleep(2)
         self.assertEqual(self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.MISS)
         self.assertEqual(self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT)
 

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -217,7 +217,7 @@ class TestMomentoAsync(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual((await simple_cache.get(_TEST_CACHE_NAME, key)).status(), CacheGetStatus.HIT)
 
-            time.sleep(3)
+            time.sleep(2)
             self.assertEqual((await simple_cache.get(_TEST_CACHE_NAME, key)).status(), CacheGetStatus.MISS)
 
     async def test_set_with_different_ttl(self):
@@ -230,7 +230,7 @@ class TestMomentoAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key1)).status(), CacheGetStatus.HIT)
         self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT)
 
-        time.sleep(3)
+        time.sleep(2)
         self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key1)).status(), CacheGetStatus.MISS)
         self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT)
 


### PR DESCRIPTION
In same vein as https://github.com/momentohq/canaries-java/pull/60

I am in general worried about these transient tests. 