### PR TITLE
fix: mitigate m1 incompatibility

### DIFF
--- a/src/momento/_async_utils.py
+++ b/src/momento/_async_utils.py
@@ -11,5 +11,7 @@ _TReturn = TypeVar("_TReturn")
 # 2. Kenny believes that we should be able to do this without a direct dependency on asyncio,
 #    by writing a loop that calls `send` on the coroutine and then returns on StopIteration.
 #    I was not able to get this working during my timeboxed window so left it like this for now.
-def wait_for_coroutine(loop: asyncio.AbstractEventLoop, coroutine: Awaitable[_TReturn]) -> _TReturn:
+def wait_for_coroutine(
+    loop: asyncio.AbstractEventLoop, coroutine: Awaitable[_TReturn]
+) -> _TReturn:
     return loop.run_until_complete(coroutine)

--- a/src/momento/_async_utils.py
+++ b/src/momento/_async_utils.py
@@ -1,5 +1,7 @@
 import asyncio
-from typing import Any
+from typing import Awaitable, TypeVar
+
+_TReturn = TypeVar("_TReturn")
 
 
 # NOTES:
@@ -9,6 +11,5 @@ from typing import Any
 # 2. Kenny believes that we should be able to do this without a direct dependency on asyncio,
 #    by writing a loop that calls `send` on the coroutine and then returns on StopIteration.
 #    I was not able to get this working during my timeboxed window so left it like this for now.
-def wait_for_coroutine(coroutine: Any) -> Any:  # type: ignore[misc]
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coroutine)  # type: ignore[misc]
+def wait_for_coroutine(loop: asyncio.AbstractEventLoop, coroutine: Awaitable[_TReturn]) -> _TReturn:
+    return loop.run_until_complete(coroutine)

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -13,10 +13,16 @@ except ImportError as e:
             "There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387",
             file=sys.stderr,
         )
+        print("-".join("" for _ in range(99)), file=sys.stderr)
+        print("    TO WORK AROUND:", file=sys.stderr)
+        print("    * Install Rosetta 2", file=sys.stderr)
         print(
-            "TO WORK AROUND, please install Rosetta 2 and re-run with:", file=sys.stderr
+            "    * Install Python from python.org (you might need to do this if you're using an arm-only build)",
+            file=sys.stderr,
         )
+        print("    * re-run with:", file=sys.stderr)
         print("arch -x86_64 {} {}".format(sys.executable, *sys.argv), file=sys.stderr)
+        print("-".join("" for _ in range(99)), file=sys.stderr)
     raise e
 
 from .. import _momento_endpoint_resolver

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -6,11 +6,17 @@ try:
     from ._scs_data_client import _ScsDataClient
     from .._utilities._data_validation import _validate_request_timeout
 except ImportError as e:
-    if e.name == 'cygrpc':
+    if e.name == "cygrpc":
         import sys
-        print('There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387', file=sys.stderr)
-        print('TO WORK AROUND, please install Rosetta 2 and re-run with:', file=sys.stderr)
-        print('arch -x86_64 {} {}'.format(sys.executable, *sys.argv), file=sys.stderr)
+
+        print(
+            "There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387",
+            file=sys.stderr,
+        )
+        print(
+            "TO WORK AROUND, please install Rosetta 2 and re-run with:", file=sys.stderr
+        )
+        print("arch -x86_64 {} {}".format(sys.executable, *sys.argv), file=sys.stderr)
     raise e
 
 from .. import _momento_endpoint_resolver

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -7,6 +7,7 @@ try:
     from .._utilities._data_validation import _validate_request_timeout
 except ImportError as e:
     if e.name == 'cygrpc':
+        import sys
         print('There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387', file=sys.stderr)
         print('TO WORK AROUND, please install Rosetta 2 and re-run with:', file=sys.stderr)
         print('arch -x86_64 {} {}'.format(sys.executable, *sys.argv), file=sys.stderr)

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -1,9 +1,16 @@
 from types import TracebackType
 from typing import Optional, Union, Type
 
-from ._scs_control_client import _ScsControlClient
-from ._scs_data_client import _ScsDataClient
-from .._utilities._data_validation import _validate_request_timeout
+try:
+    from ._scs_control_client import _ScsControlClient
+    from ._scs_data_client import _ScsDataClient
+    from .._utilities._data_validation import _validate_request_timeout
+except ImportError as e:
+    if e.name == 'cygrpc':
+        print('There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387', file=sys.stderr)
+        print('TO WORK AROUND, please install Rosetta 2 and re-run with:', file=sys.stderr)
+        print('arch -x86_64 {} {}'.format(sys.executable, *sys.argv), file=sys.stderr)
+    raise e
 
 from .. import _momento_endpoint_resolver
 from ..cache_operation_responses import (

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -74,7 +74,7 @@ class SimpleCacheClient:
             ClientSdkError: For any SDK checks that fail.
         """
         coroutine = self._momento_async_client.create_cache(cache_name)
-        return wait_for_coroutine(self._loop, coroutine)  # type: ignore[misc, no-any-return]
+        return wait_for_coroutine(self._loop, coroutine)
 
     def delete_cache(self, cache_name: str) -> DeleteCacheResponse:
         """Deletes a cache and all of the items within it.
@@ -93,7 +93,7 @@ class SimpleCacheClient:
             ClientSdkError: For any SDK checks that fail.
         """
         coroutine = self._momento_async_client.delete_cache(cache_name)
-        return wait_for_coroutine(self._loop, coroutine)  # type: ignore[misc, no-any-return]
+        return wait_for_coroutine(self._loop, coroutine)
 
     def list_caches(self, next_token: Optional[str] = None) -> ListCachesResponse:
         """Lists all caches.
@@ -108,7 +108,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
         """
         coroutine = self._momento_async_client.list_caches(next_token)
-        return wait_for_coroutine(self._loop, coroutine)  # type: ignore[misc, no-any-return]
+        return wait_for_coroutine(self._loop, coroutine)
 
     def set(
         self,
@@ -136,7 +136,7 @@ class SimpleCacheClient:
             InternalServerError: If server encountered an unknown error while trying to store the item.
         """
         coroutine = self._momento_async_client.set(cache_name, key, value, ttl_seconds)
-        return wait_for_coroutine(self._loop, coroutine)  # type: ignore[misc, no-any-return]
+        return wait_for_coroutine(self._loop, coroutine)
 
     def get(self, cache_name: str, key: str) -> CacheGetResponse:
         """Retrieve an item from the cache
@@ -156,7 +156,7 @@ class SimpleCacheClient:
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
         coroutine = self._momento_async_client.get(cache_name, key)
-        return wait_for_coroutine(self._loop, coroutine)  # type: ignore[misc, no-any-return]
+        return wait_for_coroutine(self._loop, coroutine)
 
 
 def init(

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -1,6 +1,8 @@
 from types import TracebackType
 from typing import Optional, Union, Type
 
+from .aio import simple_cache_client as aio
+
 from ._async_utils import wait_for_coroutine
 from .cache_operation_responses import (
     CacheGetResponse,
@@ -12,7 +14,6 @@ from .cache_operation_responses import (
 
 from ._utilities._data_validation import _validate_request_timeout
 
-from .aio import simple_cache_client as aio
 
 
 class SimpleCacheClient:

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -15,7 +15,6 @@ from .cache_operation_responses import (
 from ._utilities._data_validation import _validate_request_timeout
 
 
-
 class SimpleCacheClient:
     def __init__(
         self,

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -52,7 +52,10 @@ class SimpleCacheClient:
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        wait_for_coroutine(self._loop, self._momento_async_client.__aexit__(exc_type, exc_value, traceback))
+        wait_for_coroutine(
+            self._loop,
+            self._momento_async_client.__aexit__(exc_type, exc_value, traceback),
+        )
 
     def create_cache(self, cache_name: str) -> CreateCacheResponse:
         """Creates a new cache in your Momento account.

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -27,6 +27,8 @@ class TestMomento(unittest.TestCase):
 
         # default client for use in tests
         cls.client = simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS)
+        # Open client, like you would do normally via a scope manager `with simple_cache_client.init(..) as client:`
+        cls.client.__enter__()
 
         # ensure test cache exists
         try:
@@ -37,9 +39,8 @@ class TestMomento(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # close client
-        cls.client._momento_async_client._control_client.close()
-        cls.client._momento_async_client._data_client.close()
+        # close client, like you would do normally via a scope manager `with simple_cache_client.init(..) as client:`
+        cls.client.__exit__(None, None, None)
 
     # basic happy path test
     def test_create_cache_get_set_values_and_delete_cache(self):

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -29,6 +29,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
         # default client for use in tests
         self.client = simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS)
+        await self.client.__aenter__()
 
         # ensure test cache exists
         try:


### PR DESCRIPTION
There is a bug in grpc's packaging of native artifacts that relates
to certain versions of python 3 and the default wheel tags.
Investigation is ongoing, but in the meantime there is a simple
mitigation that users can try to get around the issue for local
development workflows.

Relates to: https://github.com/grpc/grpc/issues/28387

Example error with this change:
```
➜  python-demo venv/bin/python3 ./some_project/main.py 
There is an issue on M1 macs between GRPC native packaging and Python wheel tags. See https://github.com/grpc/grpc/issues/28387
TO WORK AROUND, please install Rosetta 2 and re-run with:
arch -x86_64 /Users/kenny/python-demo/venv/bin/python3 ./some_project/main.py
Traceback (most recent call last):
  File "/Users/kenny/python-demo/./some_project/main.py", line 5, in <module>
    import momento.aio.simple_cache_client as simple_cache_client
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/momento/aio/simple_cache_client.py", line 13, in <module>
    raise e
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/momento/aio/simple_cache_client.py", line 5, in <module>
    from ._scs_control_client import _ScsControlClient
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/momento/aio/_scs_control_client.py", line 7, in <module>
    from .._utilities._data_validation import _validate_cache_name
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/momento/_utilities/_data_validation.py", line 3, in <module>
    from grpc.aio import Metadata
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/grpc/__init__.py", line 22, in <module>
    from grpc import _compression
  File "/Users/kenny/python-demo/venv/lib/python3.10/site-packages/grpc/_compression.py", line 15, in <module>
    from grpc._cython import cygrpc
ImportError: dlopen(/Users/kenny/python-demo/venv/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so, 0x0002): tried: '/Users/kenny/python-demo/venv/lib/python3.10/site-packages/grpc/_cython/cygrpc.cpython-310-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/lib/cygrpc.cpython-310-darwin.so' (no such file)
```
Re-running with the copy/paste command from TO WORK AROUND runs with the python currently available as the default big download button from python.org.