### PR TITLE
chore: Update secret variable name for PyPI auth token

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -56,7 +56,7 @@ jobs:
           set -e
           set -x
           pushd package_index_setup
-            ./pypi_setup.sh __token__ ${{ secrets.PYPI_AUTH_TOKEN }} >> ~/.pypirc
+            ./pypi_setup.sh __token__ ${{ secrets.PYTHON_CUSTOMER_SDK_PYPI_TOKEN }} >> ~/.pypirc
           popd
         shell: bash
 


### PR DESCRIPTION
With @eaddingtonwhite help, moved the PyPI auth token to the org level secret.
Since secret names need to be unique at the org level, this repo's secret name got updated to `PYTHON_CUSTOMER_SDK_PYPI_TOKEN`.