### PR TITLE
feat: add cached_async convenience decorator

### DIFF
--- a/src/momento/tools/cached_async.py
+++ b/src/momento/tools/cached_async.py
@@ -1,0 +1,132 @@
+import functools
+
+from ..aio.simple_cache_client import SimpleCacheClient
+from ..cache_operation_responses import CacheGetStatus
+from ..errors import SdkError
+import json
+import time
+import typing
+
+
+_TReturn = typing.TypeVar("_TReturn")
+_TArg = typing.TypeVar("_TArg")
+
+
+def cached_async(
+    client: SimpleCacheClient,
+    cache: str,
+    *,
+    is_class_method: bool = False,
+    ttl_seconds: float = None,
+    key_prefix: str = None,
+    from_string_or_bytes=json.loads,
+    to_string_or_bytes=json.dumps,
+    on_hit: typing.Callable[[int], None] = lambda load_latency_ns: None,
+    on_miss: typing.Callable[
+        [int, int, int], None
+    ] = lambda load_latency_ns, store_latency_ns, compute_latency_ns: None,
+    on_load_error: typing.Callable[[SdkError], None] = lambda error: None,
+    on_store_error: typing.Callable[[SdkError], None] = lambda error: None,
+    fail_open: bool = True,
+):
+    """
+    Decorator for a function that returns an expensive value from Momento Simple Cache.
+
+    If you have a simple function that caches a string, you'll just do:
+
+    @cached_async(client, 'function_cache', ttl_seconds=90)
+    async def load_from_database(user: str, attribute: str) -> str:
+        user_object = await database.read(table='users', user_id=user)
+        return user_object[attribute]
+
+    This will cache each user's accessed attributes for 90 seconds. Hot attributes will
+    tend to be in the cache and attributes displayed to the user won't be very stale.
+
+    :param client: your configured Simple Cache client
+    :param cache: Cache to use for this function's values
+    :param is_class_method: [default=False] OPTIONAL set this True if you're decorating something that uses self
+    :param ttl_seconds: OPTIONAL how long to store answers in Simple Cache
+    :param key_prefix: [default=function_name] OPTIONAL prefix for keys in the cache to separate them from other cached
+                       functions in the same shared cache
+    :param from_string_or_bytes: OPTIONAL strategy for loading directly into an object. If you are storing
+                                 complex objects you'll need to provide a deserializer here. You can use json,
+                                 protocol buffers, whatever you want
+    :param to_string_or_bytes: OPTIONAL strategy for writing cache values. If you are storing complex objects you'll
+                               need to provide a serializer here. You can use json, protocol buffers, whatever you want
+    :param on_hit: OPTIONAL callback for metrics
+    :param on_miss: OPTIONAL callback for metrics
+    :param on_load_error: OPTIONAL callback for metrics and tracing
+    :param on_store_error: OPTIONAL callback for metrics and tracing
+    :param fail_open: [default=True] OPTIONAL set False if you want the function to raise on error instead of invoking
+                      your loader. on_*_error notification callbacks is the default behavior
+    :return: cached or computed value
+    """
+
+    def decorator(fn: typing.Callable[[_TArg], _TReturn]):
+        actual_key_prefix = fn.__name__ if key_prefix is None else key_prefix
+
+        @functools.wraps(fn)
+        async def wrapped(*args, **kwargs) -> _TReturn:
+            try:
+                key_args = args[1:] if is_class_method else args
+                key = actual_key_prefix + "-" + json.dumps(_make_key(key_args, kwargs))
+                start = time.perf_counter_ns()
+                cached_value = await client.get(cache, key)
+                duration_load_ns = time.perf_counter_ns() - start
+            except SdkError as e:
+                on_load_error(e)
+                if fail_open:
+                    fallback = await fn(*args, **kwargs)
+                    return fallback
+                raise e
+
+            if cached_value.status() == CacheGetStatus.HIT:
+                value = from_string_or_bytes(cached_value.value_as_bytes())
+                on_hit(duration_load_ns)
+                return value
+
+            start = time.perf_counter_ns()
+            fallback = await fn(*args, **kwargs)
+            duration_compute_ns = time.perf_counter_ns() - start
+            fallback_cache_value = to_string_or_bytes(fallback)
+
+            try:
+                start = time.perf_counter_ns()
+                await client.set(cache, key, fallback_cache_value, ttl_seconds)
+            except SdkError as e:
+                on_store_error(e)
+                # Continue anyway
+            duration_store_ns = time.perf_counter_ns() - start
+
+            on_miss(duration_load_ns, duration_store_ns, duration_compute_ns)
+            return fallback
+
+        return wrapped
+
+    return decorator
+
+
+def _make_key(args, kwds):
+    """Make a cache key from optionally typed positional and keyword arguments
+
+    The key is constructed in a way that is flat as possible rather than
+    as a nested structure that would take more memory.
+
+    If there is only a single argument and its data type is known to cache
+    its hash value, then that argument is returned without a wrapper.  This
+    saves space and improves lookup speed.
+
+    ~~~ Borrowed from functools and lightly modified ~~~
+    """
+    # All of code below relies on kwds preserving the order input by the user.
+    # Formerly, we sorted() the kwds before looping.  The new way is *much*
+    # faster; however, it means that f(x=1, y=2) will now be treated as a
+    # distinct call from f(y=2, x=1) which will be cached separately.
+    key = args
+    if kwds:
+        key += (None,)  # keyword mark
+        for item in kwds.items():
+            key += item
+    if len(key) == 1 and type(key[0]) in {int, str}:
+        return key[0]
+    return key

--- a/tests/test_cached_async.py
+++ b/tests/test_cached_async.py
@@ -1,0 +1,105 @@
+import asyncio
+import unittest
+import os
+from typing import List
+
+import momento.aio.simple_cache_client as aio
+import momento.errors as errors
+from momento.tools.cached_async import cached_async
+
+from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
+
+_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
+_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_DEFAULT_TTL_SECONDS = 60
+
+
+class TestCachedAsync(IsolatedAsyncioTestCase):
+    client: aio.SimpleCacheClient = None
+    invocations: List[str] = None
+
+    @classmethod
+    async def asyncSetUp(self) -> None:
+        self.invocations = []
+        if not _AUTH_TOKEN:
+            raise RuntimeError(
+                "Integration tests require TEST_AUTH_TOKEN env var; see README for more details."
+            )
+        if not _TEST_CACHE_NAME:
+            raise RuntimeError(
+                "Integration tests require TEST_CACHE_NAME env var; see README for more details."
+            )
+
+        # default client for use in tests
+        self.client = aio.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS)
+        await self.client.__aenter__()
+
+        try:
+            await self.client.delete_cache(_TEST_CACHE_NAME)
+        except errors.SdkError as e:
+            print("error deleting cache")
+            print(e)
+        # ensure test cache exists
+        try:
+            await self.client.create_cache(_TEST_CACHE_NAME)
+        except errors.AlreadyExistsError:
+            # do nothing, cache already exists
+            pass
+
+        # Dynamically late-apply the decorator with a dynamically instantiated client instead of a static client
+        # set fail_open to false so the test will fail if the client fails.
+        @cached_async(client=self.client, cache=_TEST_CACHE_NAME, fail_open=False, is_class_method=True)
+        async def slowly_double_method(self, string):
+            # Load from a database or whatever you need to do.
+            # Just doing a yield here to pretend like it's taking time.
+            await asyncio.sleep(0.01)
+            self.invocations.append(string)
+            return string + string
+
+        self.slowly_double = slowly_double_method
+
+        TestCachedAsync.slowly_double_fn_cached = cached_async(client=self.client, cache=_TEST_CACHE_NAME, fail_open=False, is_class_method=False)(TestCachedAsync.slowly_double_fn)
+
+    @classmethod
+    async def asyncTearDown(self) -> None:
+        # close client. Usually you'd expect people to
+        # async with simple_cache_client.init(auth, ttl) as simple_cache:
+        # and allow the scope manager to close the client.
+        await self.client.__aexit__(None, None, None)
+
+    @staticmethod
+    async def slowly_double_fn(string):
+        """Gets overridden during asyncSetUp()"""
+        await asyncio.sleep(0.1)
+        return string + string
+
+    async def test_cached_method(self):
+        v1 = await self.slowly_double("hello0")
+        v2 = await self.slowly_double("hello0")
+        v3 = await self.slowly_double("hello1")
+
+        for i in range(10):
+            # These will all be cached instead of loading slowly
+            await self.slowly_double("hello" + str(i % 2))
+
+        self.assertEqual("hello0hello0", v1, "it was supposed to double")
+        self.assertEqual("hello0hello0", v2, "it was supposed to double")
+        self.assertEqual("hello1hello1", v3, "it was supposed to double")
+
+        self.assertEqual(self.invocations, ["hello0", "hello1"])
+
+    async def test_cached_function(self):
+        v1 = await TestCachedAsync.slowly_double_fn_cached("hello0")
+        v2 = await TestCachedAsync.slowly_double_fn_cached("hello0")
+        v3 = await TestCachedAsync.slowly_double_fn_cached("hello1")
+
+        for i in range(10):
+            await TestCachedAsync.slowly_double_fn_cached("hello" + str(i % 2))
+
+        self.assertEqual("hello0hello0", v1, "it was supposed to double")
+        self.assertEqual("hello0hello0", v2, "it was supposed to double")
+        self.assertEqual("hello1hello1", v3, "it was supposed to double")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```
@cached_async(momento_client, cache='cache_name', ttl_seconds=90)
async def load_from_database(key) -> str:
  [...]
```
and you get a view of your database with a 90 second pressure relief
by calling `await load_from_database(key)`

Does not coordinate for thundering herd, just does a basic
hit or miss-load-set.

is_class_method parameter is a bit unfortunate but it's necessary to
disambiguate between `self` as a cache parameter and an object as the
first parameter (which would be used if you were providing a custom
serializer and deserializer)

Do we want to put tools like this in the SDK repo or do we want to make a separate "quality of life" package?

I made a toy with this; it simulates a 2 second database load with a 90 second cache ttl and randomly tries to get an item out of a key space of 1000 and a limited max concurrency of 32. Without the cache, it peaks at 16hz, because it takes 2 seconds to load from the database. With the cache this toy settles around 200hz because many of the requests get serviced from Simple Cache instead of through the 2 second loader.
```
window: 1172 | done:       1681 | rate:  168.0hz | concurrency:  31 | p999:  37.9ms | p90:  19.4ms | p50:  16.4ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1173 | done:       1798 | rate:  179.6hz | concurrency:  31 | p999:  50.8ms | p90:  18.7ms | p50:  16.2ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1174 | done:       1885 | rate:  188.4hz | concurrency:  31 | p999:  34.1ms | p90:  18.8ms | p50:  16.2ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1175 | done:       1960 | rate:  195.9hz | concurrency:  31 | p999:  38.1ms | p90:  18.9ms | p50:  16.5ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1176 | done:       2047 | rate:  204.5hz | concurrency:  31 | p999:  38.1ms | p90:  20.6ms | p50:  16.8ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1177 | done:       2010 | rate:  200.8hz | concurrency:  28 | p999:  34.6ms | p90:  19.7ms | p50:  16.4ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1178 | done:       2066 | rate:  204.7hz | concurrency:  32 | p999:  36.3ms | p90:  20.7ms | p50:  16.5ms | hit:  92.52% | throttle:   0.00% | err:   0.00%         
window: 1179 | done:       2202 | rate:  220.2hz | concurrency:  31 | p999:  35.2ms | p90:  20.2ms | p50:  16.5ms | hit:  92.52% | throttle:   0.00% | err:   0.00% 
```