### PR TITLE
fix: Specify tox environments in format from official documentation.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    python3.10
-    python3.9
-    python3.8
-    python3.7
+    py310
+    py39
+    py38
+    py37
     lint
 
 [testenv]


### PR DESCRIPTION
Closes #87

The official tox documentation (https://tox.wiki/en/latest/config.html#tox-environments) shows python versions in a short format (py37, py38, py39, py310).

The previous commit to this block (d2342f3) changed the python environment list from the preferred format to python3.x. This does not work in Linux environments. With version names in the (non-preferred) format, when running `tox`, the program cannot find the python versions and defaults to the system python for *every* version. When using the preferred (short) names, tox works as expected.