### PR TITLE
feat(#85): MVP dictionary API

### DIFF
--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -315,34 +315,33 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        mapping: Dictionary,
+        dictionary: Dictionary,
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
-        Inserts items from `mapping` into a dictionary `dictionary_name`.
+        Inserts items from `dictionary` into a dictionary `dictionary_name`.
         Updates (overwrites) values if the key already exists.
 
         Args:
-            cache_name (str): Name of the cache to store the dictionary mapping in.
-            dictionary_name (str): The name of the dictionary to store the mapping.
-            mapping (Dictionary): The items (key-value pairs) to be stored.
+            cache_name (str): Name of the cache to store the dictionary in.
+            dictionary_name (str): The name of the dictionary in the cache.
+            dictionary (Dictionary): The items (key-value pairs) to be stored.
 
         Returns:
             CacheDictionarySetResponse: data stored in the cache
         """
         dictionary_get_response = await self.get(cache_name, dictionary_name)
-        dictionary = {}
+        cached_dictionary = {}
         if dictionary_get_response.status() == CacheGetStatus.HIT:
-            dictionary = cast(
+            cached_dictionary = cast(
                 Dictionary,
                 pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes())),
             )
 
-        mapping = convert_dict_values_to_bytes(mapping)
-        dictionary.update(mapping)
+        cached_dictionary.update(convert_dict_values_to_bytes(dictionary))
 
         set_response = await self.set(
-            cache_name, dictionary_name, pickle.dumps(dictionary)
+            cache_name, dictionary_name, pickle.dumps(cached_dictionary)
         )
         return CacheDictionarySetResponse(
             key=set_response._key, value=_deserialize_stored_hash(set_response._value)

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -1,7 +1,5 @@
-import pickle
 from types import TracebackType
-from typing import cast, Optional, Union, Type, List
-import warnings
+from typing import Optional, Union, Type, List
 
 try:
     from ._scs_control_client import _ScsControlClient
@@ -37,37 +35,13 @@ from ..cache_operation_types import (
     ListSigningKeysResponse,
     CacheSetResponse,
     CacheGetResponse,
-    CacheGetStatus,
     CacheMultiSetOperation,
     CacheMultiGetOperation,
     CacheMultiSetFailureResponse,
     CacheMultiSetResponse,
     CacheMultiGetResponse,
     CacheMultiGetFailureResponse,
-    CacheDictionaryGetResponse,
-    CacheDictionarySetResponse,
-    CacheDictionaryValue,
-    CacheDictionaryGetAllResponse,
-    DictionaryKey,
-    Dictionary,
-    StoredDictionary,
 )
-
-
-INCUBATING_WARNING_MSG = "Using the incubating client: functionality and features are experimental and subject to change or deletion!"
-
-
-def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
-    return {k: v if isinstance(v, bytes) else v.encode() for k, v in dict_.items()}
-
-
-def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:
-    return {k: CacheDictionaryValue(v) for k, v in dict_.items()}
-
-
-def _deserialize_stored_hash(pickled_dict: bytes) -> StoredDictionary:
-    d = cast(Dictionary, pickle.loads(pickled_dict))
-    return dict_to_stored_hash(d)
 
 
 class SimpleCacheClient:
@@ -299,105 +273,6 @@ class SimpleCacheClient:
         return await self._data_client.get(cache_name, key)
 
 
-class SimpleCacheClientIncubating(SimpleCacheClient):
-    def __init__(
-        self,
-        auth_token: str,
-        default_ttl_seconds: int,
-        data_client_operation_timeout_ms: Optional[int],
-    ):
-        warnings.warn(INCUBATING_WARNING_MSG)
-        super().__init__(
-            auth_token, default_ttl_seconds, data_client_operation_timeout_ms
-        )
-
-    async def dictionary_set(
-        self,
-        cache_name: str,
-        dictionary_name: str,
-        dictionary: Dictionary,
-    ) -> CacheDictionarySetResponse:
-        """Store dictionary items (key-value pairs) in the cache.
-
-        Inserts items from `dictionary` into a dictionary `dictionary_name`.
-        Updates (overwrites) values if the key already exists.
-
-        Args:
-            cache_name (str): Name of the cache to store the dictionary in.
-            dictionary_name (str): The name of the dictionary in the cache.
-            dictionary (Dictionary): The items (key-value pairs) to be stored.
-
-        Returns:
-            CacheDictionarySetResponse: data stored in the cache
-        """
-        dictionary_get_response = await self.get(cache_name, dictionary_name)
-        cached_dictionary = {}
-        if dictionary_get_response.status() == CacheGetStatus.HIT:
-            cached_dictionary = cast(
-                Dictionary,
-                pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes())),
-            )
-
-        cached_dictionary.update(convert_dict_values_to_bytes(dictionary))
-
-        set_response = await self.set(
-            cache_name, dictionary_name, pickle.dumps(cached_dictionary)
-        )
-        return CacheDictionarySetResponse(
-            key=set_response._key, value=_deserialize_stored_hash(set_response._value)
-        )
-
-    async def dictionary_get(
-        self,
-        cache_name: str,
-        dictionary_name: str,
-        key: DictionaryKey,
-    ) -> CacheDictionaryGetResponse:
-        """Retrieve a dictionary value from the cache.
-
-        Args:
-            cache_name (str): Name of the cache to get the dictionary from.
-            dictionary_name (str): Name of the dictionary to query.
-            key (DictionaryKey): The item to index in the dictionary.
-
-        Returns:
-            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
-        """
-        dictionary_get_response = await self.get(cache_name, dictionary_name)
-        if dictionary_get_response.status() == CacheGetStatus.MISS:
-            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
-
-        dictionary: Dictionary = pickle.loads(
-            cast(bytes, dictionary_get_response.value_as_bytes())
-        )
-
-        try:
-            value = dictionary[key]
-        except KeyError:
-            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
-
-        return CacheDictionaryGetResponse(value=value, result=CacheGetStatus.HIT)
-
-    async def dictionary_get_all(
-        self, cache_name: str, dictionary_name: str
-    ) -> CacheDictionaryGetAllResponse:
-        """Retrieve the entire dictionary from the cache.
-
-        Args:
-            cache_name (str): Name of the cache to get the dictionary from.
-            dictionary_name (str): Name of the dictionary to retrieve.
-
-        Returns:
-            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
-        """
-        get_response = await self.get(cache_name, dictionary_name)
-        if get_response.status() == CacheGetStatus.MISS:
-            return CacheDictionaryGetAllResponse(value=None, result=CacheGetStatus.MISS)
-
-        value = _deserialize_stored_hash(cast(bytes, get_response.value_as_bytes()))
-        return CacheDictionaryGetAllResponse(value=value, result=CacheGetStatus.HIT)
-
-
 def init(
     auth_token: str,
     item_default_ttl_seconds: int,
@@ -419,29 +294,3 @@ def init(
     """
     _validate_request_timeout(request_timeout_ms)
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)
-
-
-def init_incubating(
-    auth_token: str,
-    item_default_ttl_seconds: int,
-    request_timeout_ms: Optional[int] = None,
-) -> SimpleCacheClientIncubating:
-    """Creates a SimpleCacheClientIncubating.
-    !! Includes non-final, experimental features and APIs subject to change  !!
-
-    Args:
-        auth_token: Momento Token to authenticate the requests with Simple Cache Service
-        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
-            possible to override this setting when calling the set method.
-        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
-            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
-            in TimeoutError.
-    Returns:
-        SimpleCacheClientIncubating
-    Raises:
-        IllegalArgumentError: If method arguments fail validations
-    """
-    _validate_request_timeout(request_timeout_ms)
-    return SimpleCacheClientIncubating(
-        auth_token, item_default_ttl_seconds, request_timeout_ms
-    )

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -317,13 +317,16 @@ class SimpleCacheClient:
         dictionary = {}
         if dictionary_get_response.status() == CacheGetStatus.HIT:
             dictionary = cast(
-                Dictionary, pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
+                Dictionary,
+                pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes())),
             )
 
         mapping = convert_dict_values_to_bytes(mapping)
         dictionary.update(mapping)
 
-        set_response = await self.set(cache_name, dictionary_name, pickle.dumps(dictionary))
+        set_response = await self.set(
+            cache_name, dictionary_name, pickle.dumps(dictionary)
+        )
         return CacheDictionarySetResponse(
             key=set_response._key, value=_deserialize_stored_hash(set_response._value)
         )
@@ -348,14 +351,14 @@ class SimpleCacheClient:
         if dictionary_get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
 
-        dictionary: Dictionary = pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
+        dictionary: Dictionary = pickle.loads(
+            cast(bytes, dictionary_get_response.value_as_bytes())
+        )
 
         try:
             value = dictionary[key]
         except KeyError:
-            return CacheDictionaryGetResponse(
-                value=None, result=CacheGetStatus.MISS
-            )
+            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
 
         return CacheDictionaryGetResponse(value=value, result=CacheGetStatus.HIT)
 

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -402,8 +402,6 @@ def init(
     auth_token: str,
     item_default_ttl_seconds: int,
     request_timeout_ms: Optional[int] = None,
-    *,
-    incubating: bool = False
 ) -> SimpleCacheClient:
     """Creates an async SimpleCacheClient
 
@@ -414,15 +412,36 @@ def init(
         request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
             Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result in
             TimeoutError.
-        incubating (bool): Use the incubating client. Includes non-final, experimental features and APIs.
     Returns:
         SimpleCacheClient
     Raises:
         IllegalArgumentError: If method arguments fail validations.
     """
     _validate_request_timeout(request_timeout_ms)
-    if incubating:
-        return SimpleCacheClientIncubating(
-            auth_token, item_default_ttl_seconds, request_timeout_ms
-        )
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)
+
+
+def init_incubating(
+    auth_token: str,
+    item_default_ttl_seconds: int,
+    request_timeout_ms: Optional[int] = None,
+) -> SimpleCacheClientIncubating:
+    """Creates a SimpleCacheClientIncubating.
+    !! Includes non-final, experimental features and APIs subject to change  !!
+
+    Args:
+        auth_token: Momento Token to authenticate the requests with Simple Cache Service
+        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
+            possible to override this setting when calling the set method.
+        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
+            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
+            in TimeoutError.
+    Returns:
+        SimpleCacheClientIncubating
+    Raises:
+        IllegalArgumentError: If method arguments fail validations
+    """
+    _validate_request_timeout(request_timeout_ms)
+    return SimpleCacheClientIncubating(
+        auth_token, item_default_ttl_seconds, request_timeout_ms
+    )

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -47,7 +47,7 @@ from ..cache_operation_types import (
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,
-    DictionaryKeyValue,
+    DictionaryKey,
     Dictionary,
     StoredDictionary,
 )
@@ -319,7 +319,7 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        key: DictionaryKeyValue,
+        key: DictionaryKey,
     ) -> CacheDictionaryGetResponse:
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         if dictionary_get_response.status() == CacheGetStatus.MISS:

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -44,7 +44,6 @@ from ..cache_operation_types import (
     CacheMultiGetResponse,
     CacheMultiGetFailureResponse,
     CacheDictionaryGetResponse,
-    CacheDictionaryGetStatus,
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,
@@ -324,7 +323,7 @@ class SimpleCacheClient:
     ) -> CacheDictionaryGetResponse:
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         if dictionary_get_response.status() == CacheGetStatus.MISS:
-            return CacheDictionaryGetResponse(value=None, result=CacheDictionaryGetStatus.HASH_MISS)
+            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
 
         dictionary: DictionaryType = pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
 
@@ -332,10 +331,10 @@ class SimpleCacheClient:
             value = dictionary[key]
         except KeyError:
             return CacheDictionaryGetResponse(
-                value=None, result=CacheDictionaryGetStatus.HASH_KEY_MISS
+                value=None, result=CacheGetStatus.MISS
             )
 
-        return CacheDictionaryGetResponse(value=value, result=CacheDictionaryGetStatus.HIT)
+        return CacheDictionaryGetResponse(value=value, result=CacheGetStatus.HIT)
 
     async def dictionary_get_all(
         self, cache_name: str, dictionary_name: str

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -47,22 +47,22 @@ from ..cache_operation_types import (
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,
-    DictionaryKeyValueType,
-    DictionaryType,
-    StoredDictionaryType,
+    DictionaryKeyValue,
+    Dictionary,
+    StoredDictionary,
 )
 
 
-def convert_dict_values_to_bytes(dict_: DictionaryType) -> DictionaryType:
+def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
     return {k: v if isinstance(v, bytes) else v.encode() for k, v in dict_.items()}
 
 
-def dict_to_stored_hash(dict_: DictionaryType) -> StoredDictionaryType:
+def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:
     return {k: CacheDictionaryValue(v) for k, v in dict_.items()}
 
 
-def _deserialize_stored_hash(pickled_dict: bytes) -> StoredDictionaryType:
-    d = cast(DictionaryType, pickle.loads(pickled_dict))
+def _deserialize_stored_hash(pickled_dict: bytes) -> StoredDictionary:
+    d = cast(Dictionary, pickle.loads(pickled_dict))
     return dict_to_stored_hash(d)
 
 
@@ -298,13 +298,13 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        mapping: DictionaryType,
+        mapping: Dictionary,
     ) -> CacheDictionarySetResponse:
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         dictionary = {}
         if dictionary_get_response.status() == CacheGetStatus.HIT:
             dictionary = cast(
-                DictionaryType, pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
+                Dictionary, pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
             )
 
         mapping = convert_dict_values_to_bytes(mapping)
@@ -319,13 +319,13 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        key: DictionaryKeyValueType,
+        key: DictionaryKeyValue,
     ) -> CacheDictionaryGetResponse:
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         if dictionary_get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
 
-        dictionary: DictionaryType = pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
+        dictionary: Dictionary = pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes()))
 
         try:
             value = dictionary[key]

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -302,6 +302,9 @@ class SimpleCacheClient:
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
+        Inserts items from `mapping` into a dictionary `dictionary_name`.
+        Updates (overwrites) values if the key already exists.
+
         Args:
             cache_name (str): Name of the cache to store the dictionary mapping in.
             dictionary_name (str): The name of the dictionary to store the mapping.

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -307,7 +307,9 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         data_client_operation_timeout_ms: Optional[int],
     ):
         warnings.warn(INCUBATING_WARNING_MSG)
-        super().__init__(auth_token, default_ttl_seconds, data_client_operation_timeout_ms)
+        super().__init__(
+            auth_token, default_ttl_seconds, data_client_operation_timeout_ms
+        )
 
     async def dictionary_set(
         self,
@@ -421,5 +423,7 @@ def init(
     """
     _validate_request_timeout(request_timeout_ms)
     if incubating:
-        return SimpleCacheClientIncubating(auth_token, item_default_ttl_seconds, request_timeout_ms)
+        return SimpleCacheClientIncubating(
+            auth_token, item_default_ttl_seconds, request_timeout_ms
+        )
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -300,6 +300,16 @@ class SimpleCacheClient:
         dictionary_name: str,
         mapping: Dictionary,
     ) -> CacheDictionarySetResponse:
+        """Store dictionary items (key-value pairs) in the cache.
+
+        Args:
+            cache_name (str): Name of the cache to store the dictionary mapping in.
+            dictionary_name (str): The name of the dictionary to store the mapping.
+            mapping (Dictionary): The items (key-value pairs) to be stored.
+
+        Returns:
+            CacheDictionarySetResponse: data stored in the cache
+        """
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         dictionary = {}
         if dictionary_get_response.status() == CacheGetStatus.HIT:
@@ -321,6 +331,16 @@ class SimpleCacheClient:
         dictionary_name: str,
         key: DictionaryKey,
     ) -> CacheDictionaryGetResponse:
+        """Retrieve a dictionary value from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to query.
+            key (DictionaryKey): The item to index in the dictionary.
+
+        Returns:
+            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
+        """
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         if dictionary_get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
@@ -339,6 +359,15 @@ class SimpleCacheClient:
     async def dictionary_get_all(
         self, cache_name: str, dictionary_name: str
     ) -> CacheDictionaryGetAllResponse:
+        """Retrieve the entire dictionary from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to retrieve.
+
+        Returns:
+            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
+        """
         get_response = await self.get(cache_name, dictionary_name)
         if get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetAllResponse(value=None, result=CacheGetStatus.MISS)

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import cast, Any, Dict, Optional, List, Union
+from typing import cast, Any, Optional, List, Union
 from dataclasses import dataclass
 
 from momento_wire_types import cacheclient_pb2 as cache_client_types
@@ -161,125 +161,6 @@ class CacheMultiGetResponse:
         for r in self._success_responses:
             r_values.append(r.value_as_bytes())
         return r_values
-
-
-# Dictionary related responses
-DictionaryKey = Union[str, bytes]
-DictionaryValue = Union[str, bytes]
-Dictionary = Dict[DictionaryKey, DictionaryValue]
-
-
-class CacheDictionaryGetResponse:
-    def __init__(self, value: Optional[DictionaryValue], result: CacheGetStatus):
-        self._value = value
-        self._result = result
-
-    def value(self) -> Optional[str]:
-        if self.status() == CacheGetStatus.MISS:
-            return None
-        return cast(bytes, self._value).decode("utf-8")
-
-    def value_as_bytes(self) -> Optional[bytes]:
-        if self.status() == CacheGetStatus.MISS:
-            return None
-        return cast(bytes, self._value)
-
-    def status(self) -> CacheGetStatus:
-        return self._result
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
-        value = self._value
-        try:
-            value = self.value()
-        except UnicodeDecodeError:
-            value = str(value)
-
-        return f"CacheDictionaryGetResponse(value={value}, result={self._result})"
-
-
-class CacheDictionaryValue:
-    def __init__(self, value: DictionaryValue) -> None:
-        self._value = value
-
-    def value(self) -> str:
-        return cast(bytes, self._value).decode("utf-8")
-
-    def value_as_bytes(self) -> bytes:
-        return cast(bytes, self._value)
-
-    def __eq__(self, other: object) -> bool:
-        return type(other) == type(self) and self._value == other._value  # type: ignore
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
-        value = self._value
-        try:
-            value = self.value()
-        except UnicodeDecodeError:
-            pass
-
-        return f"CacheDictionaryValue(value={value})"  # type: ignore
-
-
-# Represents the type of a dictionary as stored in the cache.
-# This is the type returned by dictionary_get_all and
-# dictionary_set.
-StoredDictionary = Dict[DictionaryKey, CacheDictionaryValue]
-
-
-class CacheDictionarySetResponse:
-    def __init__(self, key: bytes, value: StoredDictionary):
-        self._key = key
-        self._value = value
-
-    def value(self) -> StoredDictionary:
-        return self._value
-
-    def key(self) -> str:
-        """Decodes key of item set in cache to a utf-8 string."""
-        return self._key.decode("utf-8")
-
-    def key_as_bytes(self) -> bytes:
-        """Returns key of item stored in cache as bytes."""
-        return self._key
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
-        try:
-            key = self.key()
-        except UnicodeDecodeError:
-            key = self.key_as_bytes()  # type: ignore
-
-        return f"CacheDictionarySetResponse(key={key}, value={self._value})"
-
-
-class CacheDictionaryGetAllResponse:
-    def __init__(self, value: Optional[StoredDictionary], result: CacheGetStatus):
-        self._value = value
-        self._result = result
-
-    def value(self) -> Optional[StoredDictionary]:
-        if self.status() != CacheGetStatus.HIT:
-            return None
-        return self._value
-
-    def status(self) -> CacheGetStatus:
-        return self._result
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
-        return (
-            f"CacheDictionaryGetAllResponse(value={self._value}, result={self._result})"
-        )
 
 
 class CreateCacheResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -276,7 +276,9 @@ class CacheDictionaryGetAllResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionaryGetAllResponse(value={self._value}, result={self._result})"
+        return (
+            f"CacheDictionaryGetAllResponse(value={self._value}, result={self._result})"
+        )
 
 
 class CreateCacheResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -163,12 +163,12 @@ class CacheMultiGetResponse:
         return r_values
 
 
-# Hash related respnses
-HashKeyValueType = Union[str, bytes]
-HashType = Dict[HashKeyValueType, HashKeyValueType]
+# Dictionary related respnses
+DictionaryKeyValueType = Union[str, bytes]
+DictionaryType = Dict[DictionaryKeyValueType, DictionaryKeyValueType]
 
 
-class CacheHashGetStatus(Enum):
+class CacheDictionaryGetStatus(Enum):
     # The key exists for a particular hash
     HIT = 1
     # The hash is missing from the cache
@@ -180,8 +180,8 @@ class CacheHashGetStatus(Enum):
         return self.value == self.HIT.value  # type: ignore
 
 
-class CacheHashGetResponse:
-    def __init__(self, value: Optional[HashKeyValueType], result: CacheHashGetStatus):
+class CacheDictionaryGetResponse:
+    def __init__(self, value: Optional[DictionaryKeyValueType], result: CacheDictionaryGetStatus):
         self._value = value
         self._result = result
 
@@ -195,7 +195,7 @@ class CacheHashGetResponse:
             return None
         return cast(bytes, self._value)
 
-    def status(self) -> CacheHashGetStatus:
+    def status(self) -> CacheDictionaryGetStatus:
         return self._result
 
     def __str__(self) -> str:
@@ -208,11 +208,11 @@ class CacheHashGetResponse:
         except UnicodeDecodeError:
             value = str(value)
 
-        return f"CacheHashGetResponse(value={value}, result={self._result})"
+        return f"CacheDictionaryGetResponse(value={value}, result={self._result})"
 
 
-class CacheHashValue:
-    def __init__(self, value: HashKeyValueType) -> None:
+class CacheDictionaryValue:
+    def __init__(self, value: DictionaryKeyValueType) -> None:
         self._value = value
 
     def value(self) -> str:
@@ -234,20 +234,20 @@ class CacheHashValue:
         except UnicodeDecodeError:
             pass
 
-        return f"CacheHashValue(value={value})"  # type: ignore
+        return f"CacheDictionaryValue(value={value})"  # type: ignore
 
 
 # Represents the type of a hash as stored in the cache.
 # This is the type returned by hgetall and hset.
-StoredHashType = Dict[HashKeyValueType, CacheHashValue]
+StoredDictionaryType = Dict[DictionaryKeyValueType, CacheDictionaryValue]
 
 
-class CacheHashSetResponse:
-    def __init__(self, key: bytes, value: StoredHashType):
+class CacheDictionarySetResponse:
+    def __init__(self, key: bytes, value: StoredDictionaryType):
         self._key = key
         self._value = value
 
-    def value(self) -> StoredHashType:
+    def value(self) -> StoredDictionaryType:
         return self._value
 
     def key(self) -> str:
@@ -267,15 +267,15 @@ class CacheHashSetResponse:
         except UnicodeDecodeError:
             key = self.key_as_bytes()  # type: ignore
 
-        return f"CacheHashSetResponse(key={key}, value={self._value})"
+        return f"CacheDictionarySetResponse(key={key}, value={self._value})"
 
 
-class CacheHashGetAllResponse:
-    def __init__(self, value: Optional[StoredHashType], result: CacheGetStatus):
+class CacheDictionaryGetAllResponse:
+    def __init__(self, value: Optional[StoredDictionaryType], result: CacheGetStatus):
         self._value = value
         self._result = result
 
-    def value(self) -> Optional[StoredHashType]:
+    def value(self) -> Optional[StoredDictionaryType]:
         if self.status() != CacheGetStatus.HIT:
             return None
         return self._value
@@ -287,7 +287,7 @@ class CacheHashGetAllResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheHashGetAllResponse(value={self._value}, result={self._result})"
+        return f"CacheDictionaryGetAllResponse(value={self._value}, result={self._result})"
 
 
 class CreateCacheResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional, List, Union
+from typing import cast, Any, Dict, Optional, List, Union
 from dataclasses import dataclass
 
 from momento_wire_types import cacheclient_pb2 as cache_client_types
@@ -161,6 +161,133 @@ class CacheMultiGetResponse:
         for r in self._success_responses:
             r_values.append(r.value_as_bytes())
         return r_values
+
+
+# Hash related respnses
+HashKeyValueType = Union[str, bytes]
+HashType = Dict[HashKeyValueType, HashKeyValueType]
+
+
+class CacheHashGetStatus(Enum):
+    # The key exists for a particular hash
+    HIT = 1
+    # The hash is missing from the cache
+    HASH_MISS = 2
+    # The hash is in the cache but the key is missing from the hash
+    HASH_KEY_MISS = 3
+
+    def is_hit(self) -> bool:
+        return self.value == self.HIT.value  # type: ignore
+
+
+class CacheHashGetResponse:
+    def __init__(self, value: Optional[HashKeyValueType], result: CacheHashGetStatus):
+        self._value = value
+        self._result = result
+
+    def value(self) -> Optional[str]:
+        if not self.status().is_hit():
+            return None
+        return cast(bytes, self._value).decode("utf-8")
+
+    def value_as_bytes(self) -> Optional[bytes]:
+        if not self.status().is_hit():
+            return None
+        return cast(bytes, self._value)
+
+    def status(self) -> CacheHashGetStatus:
+        return self._result
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        value = self._value
+        try:
+            value = self.value()
+        except UnicodeDecodeError:
+            value = str(value)
+
+        return f"CacheHashGetResponse(value={value}, result={self._result})"
+
+
+class CacheHashValue:
+    def __init__(self, value: HashKeyValueType) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return cast(bytes, self._value).decode("utf-8")
+
+    def value_as_bytes(self) -> bytes:
+        return cast(bytes, self._value)
+
+    def __eq__(self, other: object) -> bool:
+        return type(other) == type(self) and self._value == other._value  # type: ignore
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        value = self._value
+        try:
+            value = self.value()
+        except UnicodeDecodeError:
+            pass
+
+        return f"CacheHashValue(value={value})"  # type: ignore
+
+
+# Represents the type of a hash as stored in the cache.
+# This is the type returned by hgetall and hset.
+StoredHashType = Dict[HashKeyValueType, CacheHashValue]
+
+
+class CacheHashSetResponse:
+    def __init__(self, key: bytes, value: StoredHashType):
+        self._key = key
+        self._value = value
+
+    def value(self) -> StoredHashType:
+        return self._value
+
+    def key(self) -> str:
+        """Decodes key of item set in cache to a utf-8 string."""
+        return self._key.decode("utf-8")
+
+    def key_as_bytes(self) -> bytes:
+        """Returns key of item stored in cache as bytes."""
+        return self._key
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        try:
+            key = self.key()
+        except UnicodeDecodeError:
+            key = self.key_as_bytes()  # type: ignore
+
+        return f"CacheHashSetResponse(key={key}, value={self._value})"
+
+
+class CacheHashGetAllResponse:
+    def __init__(self, value: Optional[StoredHashType], result: CacheGetStatus):
+        self._value = value
+        self._result = result
+
+    def value(self) -> Optional[StoredHashType]:
+        if self.status() != CacheGetStatus.HIT:
+            return None
+        return self._value
+
+    def status(self) -> CacheGetStatus:
+        return self._result
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CacheHashGetAllResponse(value={self._value}, result={self._result})"
 
 
 class CreateCacheResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -164,12 +164,12 @@ class CacheMultiGetResponse:
 
 
 # Dictionary related respnses
-DictionaryKeyValueType = Union[str, bytes]
-DictionaryType = Dict[DictionaryKeyValueType, DictionaryKeyValueType]
+DictionaryKeyValue = Union[str, bytes]
+Dictionary = Dict[DictionaryKeyValue, DictionaryKeyValue]
 
 
 class CacheDictionaryGetResponse:
-    def __init__(self, value: Optional[DictionaryKeyValueType], result: CacheGetStatus):
+    def __init__(self, value: Optional[DictionaryKeyValue], result: CacheGetStatus):
         self._value = value
         self._result = result
 
@@ -200,7 +200,7 @@ class CacheDictionaryGetResponse:
 
 
 class CacheDictionaryValue:
-    def __init__(self, value: DictionaryKeyValueType) -> None:
+    def __init__(self, value: DictionaryKeyValue) -> None:
         self._value = value
 
     def value(self) -> str:
@@ -227,15 +227,15 @@ class CacheDictionaryValue:
 
 # Represents the type of a hash as stored in the cache.
 # This is the type returned by hgetall and hset.
-StoredDictionaryType = Dict[DictionaryKeyValueType, CacheDictionaryValue]
+StoredDictionary = Dict[DictionaryKeyValue, CacheDictionaryValue]
 
 
 class CacheDictionarySetResponse:
-    def __init__(self, key: bytes, value: StoredDictionaryType):
+    def __init__(self, key: bytes, value: StoredDictionary):
         self._key = key
         self._value = value
 
-    def value(self) -> StoredDictionaryType:
+    def value(self) -> StoredDictionary:
         return self._value
 
     def key(self) -> str:
@@ -259,11 +259,11 @@ class CacheDictionarySetResponse:
 
 
 class CacheDictionaryGetAllResponse:
-    def __init__(self, value: Optional[StoredDictionaryType], result: CacheGetStatus):
+    def __init__(self, value: Optional[StoredDictionary], result: CacheGetStatus):
         self._value = value
         self._result = result
 
-    def value(self) -> Optional[StoredDictionaryType]:
+    def value(self) -> Optional[StoredDictionary]:
         if self.status() != CacheGetStatus.HIT:
             return None
         return self._value

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -163,7 +163,7 @@ class CacheMultiGetResponse:
         return r_values
 
 
-# Dictionary related respnses
+# Dictionary related responses
 DictionaryKey = Union[str, bytes]
 DictionaryValue = Union[str, bytes]
 Dictionary = Dict[DictionaryKey, DictionaryValue]
@@ -226,8 +226,9 @@ class CacheDictionaryValue:
         return f"CacheDictionaryValue(value={value})"  # type: ignore
 
 
-# Represents the type of a hash as stored in the cache.
-# This is the type returned by hgetall and hset.
+# Represents the type of a dictionary as stored in the cache.
+# This is the type returned by dictionary_get_all and
+# dictionary_set.
 StoredDictionary = Dict[DictionaryKey, CacheDictionaryValue]
 
 

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -164,12 +164,13 @@ class CacheMultiGetResponse:
 
 
 # Dictionary related respnses
-DictionaryKeyValue = Union[str, bytes]
-Dictionary = Dict[DictionaryKeyValue, DictionaryKeyValue]
+DictionaryKey = Union[str, bytes]
+DictionaryValue = Union[str, bytes]
+Dictionary = Dict[DictionaryKey, DictionaryValue]
 
 
 class CacheDictionaryGetResponse:
-    def __init__(self, value: Optional[DictionaryKeyValue], result: CacheGetStatus):
+    def __init__(self, value: Optional[DictionaryValue], result: CacheGetStatus):
         self._value = value
         self._result = result
 
@@ -200,7 +201,7 @@ class CacheDictionaryGetResponse:
 
 
 class CacheDictionaryValue:
-    def __init__(self, value: DictionaryKeyValue) -> None:
+    def __init__(self, value: DictionaryValue) -> None:
         self._value = value
 
     def value(self) -> str:
@@ -227,7 +228,7 @@ class CacheDictionaryValue:
 
 # Represents the type of a hash as stored in the cache.
 # This is the type returned by hgetall and hset.
-StoredDictionary = Dict[DictionaryKeyValue, CacheDictionaryValue]
+StoredDictionary = Dict[DictionaryKey, CacheDictionaryValue]
 
 
 class CacheDictionarySetResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -168,34 +168,22 @@ DictionaryKeyValueType = Union[str, bytes]
 DictionaryType = Dict[DictionaryKeyValueType, DictionaryKeyValueType]
 
 
-class CacheDictionaryGetStatus(Enum):
-    # The key exists for a particular hash
-    HIT = 1
-    # The hash is missing from the cache
-    HASH_MISS = 2
-    # The hash is in the cache but the key is missing from the hash
-    HASH_KEY_MISS = 3
-
-    def is_hit(self) -> bool:
-        return self.value == self.HIT.value  # type: ignore
-
-
 class CacheDictionaryGetResponse:
-    def __init__(self, value: Optional[DictionaryKeyValueType], result: CacheDictionaryGetStatus):
+    def __init__(self, value: Optional[DictionaryKeyValueType], result: CacheGetStatus):
         self._value = value
         self._result = result
 
     def value(self) -> Optional[str]:
-        if not self.status().is_hit():
+        if self.status() == CacheGetStatus.MISS:
             return None
         return cast(bytes, self._value).decode("utf-8")
 
     def value_as_bytes(self) -> Optional[bytes]:
-        if not self.status().is_hit():
+        if self.status() == CacheGetStatus.MISS:
             return None
         return cast(bytes, self._value)
 
-    def status(self) -> CacheDictionaryGetStatus:
+    def status(self) -> CacheGetStatus:
         return self._result
 
     def __str__(self) -> str:

--- a/src/momento/incubating/__init__.py
+++ b/src/momento/incubating/__init__.py
@@ -1,0 +1,1 @@
+INCUBATING_WARNING_MSG = "Using the incubating client: functionality and features are experimental and subject to change or deletion!"

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -1,0 +1,141 @@
+import pickle
+from typing import cast, Optional
+import warnings
+
+from .. import INCUBATING_WARNING_MSG
+from ...aio.simple_cache_client import SimpleCacheClient
+from ..cache_operation_types import (
+    CacheGetStatus,
+    CacheDictionaryGetResponse,
+    CacheDictionarySetResponse,
+    CacheDictionaryGetAllResponse,
+    DictionaryKey,
+    Dictionary,
+)
+from ..._utilities._data_validation import _validate_request_timeout
+from .utils import convert_dict_values_to_bytes, deserialize_stored_hash
+
+
+class SimpleCacheClientIncubating(SimpleCacheClient):
+    def __init__(
+        self,
+        auth_token: str,
+        default_ttl_seconds: int,
+        data_client_operation_timeout_ms: Optional[int],
+    ):
+        warnings.warn(INCUBATING_WARNING_MSG)
+        super().__init__(
+            auth_token, default_ttl_seconds, data_client_operation_timeout_ms
+        )
+
+    async def dictionary_set(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        dictionary: Dictionary,
+    ) -> CacheDictionarySetResponse:
+        """Store dictionary items (key-value pairs) in the cache.
+
+        Inserts items from `dictionary` into a dictionary `dictionary_name`.
+        Updates (overwrites) values if the key already exists.
+
+        Args:
+            cache_name (str): Name of the cache to store the dictionary in.
+            dictionary_name (str): The name of the dictionary in the cache.
+            dictionary (Dictionary): The items (key-value pairs) to be stored.
+
+        Returns:
+            CacheDictionarySetResponse: data stored in the cache
+        """
+        dictionary_get_response = await self.get(cache_name, dictionary_name)
+        cached_dictionary = {}
+        if dictionary_get_response.status() == CacheGetStatus.HIT:
+            cached_dictionary = cast(
+                Dictionary,
+                pickle.loads(cast(bytes, dictionary_get_response.value_as_bytes())),
+            )
+
+        cached_dictionary.update(convert_dict_values_to_bytes(dictionary))
+
+        set_response = await self.set(
+            cache_name, dictionary_name, pickle.dumps(cached_dictionary)
+        )
+        return CacheDictionarySetResponse(
+            key=set_response._key, value=deserialize_stored_hash(set_response._value)
+        )
+
+    async def dictionary_get(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        key: DictionaryKey,
+    ) -> CacheDictionaryGetResponse:
+        """Retrieve a dictionary value from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to query.
+            key (DictionaryKey): The item to index in the dictionary.
+
+        Returns:
+            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
+        """
+        dictionary_get_response = await self.get(cache_name, dictionary_name)
+        if dictionary_get_response.status() == CacheGetStatus.MISS:
+            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
+
+        dictionary: Dictionary = pickle.loads(
+            cast(bytes, dictionary_get_response.value_as_bytes())
+        )
+
+        try:
+            value = dictionary[key]
+        except KeyError:
+            return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
+
+        return CacheDictionaryGetResponse(value=value, result=CacheGetStatus.HIT)
+
+    async def dictionary_get_all(
+        self, cache_name: str, dictionary_name: str
+    ) -> CacheDictionaryGetAllResponse:
+        """Retrieve the entire dictionary from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to retrieve.
+
+        Returns:
+            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
+        """
+        get_response = await self.get(cache_name, dictionary_name)
+        if get_response.status() == CacheGetStatus.MISS:
+            return CacheDictionaryGetAllResponse(value=None, result=CacheGetStatus.MISS)
+
+        value = deserialize_stored_hash(cast(bytes, get_response.value_as_bytes()))
+        return CacheDictionaryGetAllResponse(value=value, result=CacheGetStatus.HIT)
+
+
+def init(
+    auth_token: str,
+    item_default_ttl_seconds: int,
+    request_timeout_ms: Optional[int] = None,
+) -> SimpleCacheClientIncubating:
+    """Creates a SimpleCacheClientIncubating.
+    !! Includes non-final, experimental features and APIs subject to change  !!
+
+    Args:
+        auth_token: Momento Token to authenticate the requests with Simple Cache Service
+        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
+            possible to override this setting when calling the set method.
+        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
+            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
+            in TimeoutError.
+    Returns:
+        SimpleCacheClientIncubating
+    Raises:
+        IllegalArgumentError: If method arguments fail validations
+    """
+    _validate_request_timeout(request_timeout_ms)
+    return SimpleCacheClientIncubating(
+        auth_token, item_default_ttl_seconds, request_timeout_ms
+    )

--- a/src/momento/incubating/aio/utils.py
+++ b/src/momento/incubating/aio/utils.py
@@ -1,0 +1,17 @@
+import pickle
+from typing import cast
+
+from ..cache_operation_types import CacheDictionaryValue, Dictionary, StoredDictionary
+
+
+def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
+    return {k: v if isinstance(v, bytes) else v.encode() for k, v in dict_.items()}
+
+
+def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:
+    return {k: CacheDictionaryValue(v) for k, v in dict_.items()}
+
+
+def deserialize_stored_hash(pickled_dict: bytes) -> StoredDictionary:
+    d = cast(Dictionary, pickle.loads(pickled_dict))
+    return dict_to_stored_hash(d)

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -1,0 +1,122 @@
+from typing import cast, Dict, Optional, Union
+
+from ..cache_operation_types import CacheGetStatus
+
+
+# Dictionary related responses
+DictionaryKey = Union[str, bytes]
+DictionaryValue = Union[str, bytes]
+Dictionary = Dict[DictionaryKey, DictionaryValue]
+
+
+class CacheDictionaryGetResponse:
+    def __init__(self, value: Optional[DictionaryValue], result: CacheGetStatus):
+        self._value = value
+        self._result = result
+
+    def value(self) -> Optional[str]:
+        if self.status() == CacheGetStatus.MISS:
+            return None
+        return cast(bytes, self._value).decode("utf-8")
+
+    def value_as_bytes(self) -> Optional[bytes]:
+        if self.status() == CacheGetStatus.MISS:
+            return None
+        return cast(bytes, self._value)
+
+    def status(self) -> CacheGetStatus:
+        return self._result
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        value = self._value
+        try:
+            value = self.value()
+        except UnicodeDecodeError:
+            value = str(value)
+
+        return f"CacheDictionaryGetResponse(value={value}, result={self._result})"
+
+
+class CacheDictionaryValue:
+    def __init__(self, value: DictionaryValue) -> None:
+        self._value = value
+
+    def value(self) -> str:
+        return cast(bytes, self._value).decode("utf-8")
+
+    def value_as_bytes(self) -> bytes:
+        return cast(bytes, self._value)
+
+    def __eq__(self, other: object) -> bool:
+        return type(other) == type(self) and self._value == other._value  # type: ignore
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        value = self._value
+        try:
+            value = self.value()
+        except UnicodeDecodeError:
+            pass
+
+        return f"CacheDictionaryValue(value={value})"  # type: ignore
+
+
+# Represents the type of a dictionary as stored in the cache.
+# This is the type returned by dictionary_get_all and
+# dictionary_set.
+StoredDictionary = Dict[DictionaryKey, CacheDictionaryValue]
+
+
+class CacheDictionarySetResponse:
+    def __init__(self, key: bytes, value: StoredDictionary):
+        self._key = key
+        self._value = value
+
+    def value(self) -> StoredDictionary:
+        return self._value
+
+    def key(self) -> str:
+        """Decodes key of item set in cache to a utf-8 string."""
+        return self._key.decode("utf-8")
+
+    def key_as_bytes(self) -> bytes:
+        """Returns key of item stored in cache as bytes."""
+        return self._key
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        try:
+            key = self.key()
+        except UnicodeDecodeError:
+            key = self.key_as_bytes()  # type: ignore
+
+        return f"CacheDictionarySetResponse(key={key}, value={self._value})"
+
+
+class CacheDictionaryGetAllResponse:
+    def __init__(self, value: Optional[StoredDictionary], result: CacheGetStatus):
+        self._value = value
+        self._result = result
+
+    def value(self) -> Optional[StoredDictionary]:
+        if self.status() != CacheGetStatus.HIT:
+            return None
+        return self._value
+
+    def status(self) -> CacheGetStatus:
+        return self._result
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return (
+            f"CacheDictionaryGetAllResponse(value={self._value}, result={self._result})"
+        )

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -1,0 +1,121 @@
+from typing import Optional
+import warnings
+
+from . import INCUBATING_WARNING_MSG
+from .aio import simple_cache_client as aio
+from .._async_utils import wait_for_coroutine
+from .cache_operation_types import (
+    CacheDictionaryGetResponse,
+    CacheDictionarySetResponse,
+    CacheDictionaryGetAllResponse,
+    DictionaryKey,
+    Dictionary,
+)
+from ..simple_cache_client import SimpleCacheClient
+from .._utilities._data_validation import _validate_request_timeout
+
+
+class SimpleCacheClientIncubating(SimpleCacheClient):
+    def __init__(
+        self,
+        auth_token: str,
+        default_ttl_seconds: int,
+        data_client_operation_timeout_ms: Optional[int],
+    ):
+        warnings.warn(INCUBATING_WARNING_MSG)
+        self._init_loop()
+        self._momento_async_client: aio.SimpleCacheClientIncubating = (
+            aio.SimpleCacheClientIncubating(
+                auth_token=auth_token,
+                default_ttl_seconds=default_ttl_seconds,
+                data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+            )
+        )
+
+    def dictionary_set(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        dictionary: Dictionary,
+    ) -> CacheDictionarySetResponse:
+        """Store dictionary items (key-value pairs) in the cache.
+
+        Inserts items from `dictionary` into a dictionary `dictionary_name`.
+        Updates (overwrites) values if the key already exists.
+
+        Args:
+            cache_name (str): Name of the cache to store the dictionary in.
+            dictionary_name (str): The name of the dictionary in the cache.
+            dictionary (Dictionary): The items (key-value pairs) to be stored.
+
+        Returns:
+            CacheDictionarySetResponse: data stored in the cache
+        """
+        coroutine = self._momento_async_client.dictionary_set(
+            cache_name, dictionary_name, dictionary
+        )
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def dictionary_get(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        key: DictionaryKey,
+    ) -> CacheDictionaryGetResponse:
+        """Retrieve a dictionary value from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to query.
+            key (DictionaryKey): The item to index in the dictionary.
+
+        Returns:
+            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
+        """
+        coroutine = self._momento_async_client.dictionary_get(
+            cache_name, dictionary_name, key
+        )
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def dictionary_get_all(
+        self, cache_name: str, dictionary_name: str
+    ) -> CacheDictionaryGetAllResponse:
+        """Retrieve the entire dictionary from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to retrieve.
+
+        Returns:
+            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
+        """
+        coroutine = self._momento_async_client.dictionary_get_all(
+            cache_name, dictionary_name
+        )
+        return wait_for_coroutine(self._loop, coroutine)
+
+
+def init(
+    auth_token: str,
+    item_default_ttl_seconds: int,
+    request_timeout_ms: Optional[int] = None,
+) -> SimpleCacheClientIncubating:
+    """Creates a SimpleCacheClientIncubating.
+    !! Includes non-final, experimental features and APIs subject to change  !!
+
+    Args:
+        auth_token: Momento Token to authenticate the requests with Simple Cache Service
+        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
+            possible to override this setting when calling the set method.
+        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
+            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
+            in TimeoutError.
+    Returns:
+        SimpleCacheClientIncubating
+    Raises:
+        IllegalArgumentError: If method arguments fail validations
+    """
+    _validate_request_timeout(request_timeout_ms)
+    return SimpleCacheClientIncubating(
+        auth_token, item_default_ttl_seconds, request_timeout_ms
+    )

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -380,5 +380,7 @@ def init(
     """
     _validate_request_timeout(request_timeout_ms)
     if incubating:
-        return SimpleCacheClientIncubating(auth_token, item_default_ttl_seconds, request_timeout_ms)
+        return SimpleCacheClientIncubating(
+            auth_token, item_default_ttl_seconds, request_timeout_ms
+        )
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -364,8 +364,6 @@ def init(
     auth_token: str,
     item_default_ttl_seconds: int,
     request_timeout_ms: Optional[int] = None,
-    *,
-    incubating: bool = False
 ) -> SimpleCacheClient:
     """Creates a SimpleCacheClient
 
@@ -383,8 +381,30 @@ def init(
         IllegalArgumentError: If method arguments fail validations
     """
     _validate_request_timeout(request_timeout_ms)
-    if incubating:
-        return SimpleCacheClientIncubating(
-            auth_token, item_default_ttl_seconds, request_timeout_ms
-        )
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)
+
+
+def init_incubating(
+    auth_token: str,
+    item_default_ttl_seconds: int,
+    request_timeout_ms: Optional[int] = None,
+) -> SimpleCacheClientIncubating:
+    """Creates a SimpleCacheClientIncubating.
+    !! Includes non-final, experimental features and APIs subject to change  !!
+
+    Args:
+        auth_token: Momento Token to authenticate the requests with Simple Cache Service
+        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
+            possible to override this setting when calling the set method.
+        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
+            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
+            in TimeoutError.
+    Returns:
+        SimpleCacheClientIncubating
+    Raises:
+        IllegalArgumentError: If method arguments fail validations
+    """
+    _validate_request_timeout(request_timeout_ms)
+    return SimpleCacheClientIncubating(
+        auth_token, item_default_ttl_seconds, request_timeout_ms
+    )

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -282,6 +282,16 @@ class SimpleCacheClient:
         dictionary_name: str,
         mapping: Dictionary,
     ) -> CacheDictionarySetResponse:
+        """Store dictionary items (key-value pairs) in the cache.
+
+        Args:
+            cache_name (str): Name of the cache to store the dictionary mapping in.
+            dictionary_name (str): The name of the dictionary to store the mapping.
+            mapping (Dictionary): The items (key-value pairs) to be stored.
+
+        Returns:
+            CacheDictionarySetResponse: data stored in the cache
+        """
         coroutine = self._momento_async_client.dictionary_set(cache_name, dictionary_name, mapping)
         return wait_for_coroutine(self._loop, coroutine)
 
@@ -291,10 +301,29 @@ class SimpleCacheClient:
         dictionary_name: str,
         key: DictionaryKey,
     ) -> CacheDictionaryGetResponse:
+        """Retrieve a dictionary value from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to query.
+            key (DictionaryKey): The item to index in the dictionary.
+
+        Returns:
+            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
+        """
         coroutine = self._momento_async_client.dictionary_get(cache_name, dictionary_name, key)
         return wait_for_coroutine(self._loop, coroutine)
 
     def dictionary_get_all(self, cache_name: str, dictionary_name: str) -> CacheDictionaryGetAllResponse:
+        """Retrieve the entire dictionary from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to retrieve.
+
+        Returns:
+            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
+        """
         coroutine = self._momento_async_client.dictionary_get_all(cache_name, dictionary_name)
         return wait_for_coroutine(self._loop, coroutine)
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -295,7 +295,9 @@ class SimpleCacheClient:
         Returns:
             CacheDictionarySetResponse: data stored in the cache
         """
-        coroutine = self._momento_async_client.dictionary_set(cache_name, dictionary_name, mapping)
+        coroutine = self._momento_async_client.dictionary_set(
+            cache_name, dictionary_name, mapping
+        )
         return wait_for_coroutine(self._loop, coroutine)
 
     def dictionary_get(
@@ -314,10 +316,14 @@ class SimpleCacheClient:
         Returns:
             CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
         """
-        coroutine = self._momento_async_client.dictionary_get(cache_name, dictionary_name, key)
+        coroutine = self._momento_async_client.dictionary_get(
+            cache_name, dictionary_name, key
+        )
         return wait_for_coroutine(self._loop, coroutine)
 
-    def dictionary_get_all(self, cache_name: str, dictionary_name: str) -> CacheDictionaryGetAllResponse:
+    def dictionary_get_all(
+        self, cache_name: str, dictionary_name: str
+    ) -> CacheDictionaryGetAllResponse:
         """Retrieve the entire dictionary from the cache.
 
         Args:
@@ -327,7 +333,9 @@ class SimpleCacheClient:
         Returns:
             CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
         """
-        coroutine = self._momento_async_client.dictionary_get_all(cache_name, dictionary_name)
+        coroutine = self._momento_async_client.dictionary_get_all(
+            cache_name, dictionary_name
+        )
         return wait_for_coroutine(self._loop, coroutine)
 
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -1,10 +1,8 @@
 import asyncio
 from types import TracebackType
 from typing import Optional, Union, Type, List
-import warnings
 
 from .aio import simple_cache_client as aio
-
 from ._async_utils import wait_for_coroutine
 from .cache_operation_types import (
     CacheGetResponse,
@@ -21,15 +19,7 @@ from .cache_operation_types import (
     CacheMultiGetFailureResponse,
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
-    CacheDictionaryGetResponse,
-    CacheDictionarySetResponse,
-    CacheDictionaryValue,
-    CacheDictionaryGetAllResponse,
-    DictionaryKey,
-    Dictionary,
-    StoredDictionary,
 )
-
 from ._utilities._data_validation import _validate_request_timeout
 
 
@@ -280,86 +270,6 @@ class SimpleCacheClient:
         return wait_for_coroutine(self._loop, coroutine)
 
 
-class SimpleCacheClientIncubating(SimpleCacheClient):
-    def __init__(
-        self,
-        auth_token: str,
-        default_ttl_seconds: int,
-        data_client_operation_timeout_ms: Optional[int],
-    ):
-        warnings.warn(aio.INCUBATING_WARNING_MSG)
-        self._init_loop()
-        self._momento_async_client: aio.SimpleCacheClientIncubating = (
-            aio.SimpleCacheClientIncubating(
-                auth_token=auth_token,
-                default_ttl_seconds=default_ttl_seconds,
-                data_client_operation_timeout_ms=data_client_operation_timeout_ms,
-            )
-        )
-
-    def dictionary_set(
-        self,
-        cache_name: str,
-        dictionary_name: str,
-        dictionary: Dictionary,
-    ) -> CacheDictionarySetResponse:
-        """Store dictionary items (key-value pairs) in the cache.
-
-        Inserts items from `dictionary` into a dictionary `dictionary_name`.
-        Updates (overwrites) values if the key already exists.
-
-        Args:
-            cache_name (str): Name of the cache to store the dictionary in.
-            dictionary_name (str): The name of the dictionary in the cache.
-            dictionary (Dictionary): The items (key-value pairs) to be stored.
-
-        Returns:
-            CacheDictionarySetResponse: data stored in the cache
-        """
-        coroutine = self._momento_async_client.dictionary_set(
-            cache_name, dictionary_name, dictionary
-        )
-        return wait_for_coroutine(self._loop, coroutine)
-
-    def dictionary_get(
-        self,
-        cache_name: str,
-        dictionary_name: str,
-        key: DictionaryKey,
-    ) -> CacheDictionaryGetResponse:
-        """Retrieve a dictionary value from the cache.
-
-        Args:
-            cache_name (str): Name of the cache to get the dictionary from.
-            dictionary_name (str): Name of the dictionary to query.
-            key (DictionaryKey): The item to index in the dictionary.
-
-        Returns:
-            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
-        """
-        coroutine = self._momento_async_client.dictionary_get(
-            cache_name, dictionary_name, key
-        )
-        return wait_for_coroutine(self._loop, coroutine)
-
-    def dictionary_get_all(
-        self, cache_name: str, dictionary_name: str
-    ) -> CacheDictionaryGetAllResponse:
-        """Retrieve the entire dictionary from the cache.
-
-        Args:
-            cache_name (str): Name of the cache to get the dictionary from.
-            dictionary_name (str): Name of the dictionary to retrieve.
-
-        Returns:
-            CacheDictionaryGetAllResponse: Value (the mapping, if present) and status (HIT or MISS).
-        """
-        coroutine = self._momento_async_client.dictionary_get_all(
-            cache_name, dictionary_name
-        )
-        return wait_for_coroutine(self._loop, coroutine)
-
-
 def init(
     auth_token: str,
     item_default_ttl_seconds: int,
@@ -381,29 +291,3 @@ def init(
     """
     _validate_request_timeout(request_timeout_ms)
     return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)
-
-
-def init_incubating(
-    auth_token: str,
-    item_default_ttl_seconds: int,
-    request_timeout_ms: Optional[int] = None,
-) -> SimpleCacheClientIncubating:
-    """Creates a SimpleCacheClientIncubating.
-    !! Includes non-final, experimental features and APIs subject to change  !!
-
-    Args:
-        auth_token: Momento Token to authenticate the requests with Simple Cache Service
-        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
-            possible to override this setting when calling the set method.
-        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
-            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
-            in TimeoutError.
-    Returns:
-        SimpleCacheClientIncubating
-    Raises:
-        IllegalArgumentError: If method arguments fail validations
-    """
-    _validate_request_timeout(request_timeout_ms)
-    return SimpleCacheClientIncubating(
-        auth_token, item_default_ttl_seconds, request_timeout_ms
-    )

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -24,9 +24,9 @@ from .cache_operation_types import (
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,
-    DictionaryKeyValueType,
-    DictionaryType,
-    StoredDictionaryType,
+    DictionaryKeyValue,
+    Dictionary,
+    StoredDictionary,
 )
 
 from ._utilities._data_validation import _validate_request_timeout
@@ -280,7 +280,7 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        mapping: DictionaryType,
+        mapping: Dictionary,
     ) -> CacheDictionarySetResponse:
         coroutine = self._momento_async_client.dictionary_set(cache_name, dictionary_name, mapping)
         return wait_for_coroutine(self._loop, coroutine)
@@ -289,7 +289,7 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        key: DictionaryKeyValueType,
+        key: DictionaryKeyValue,
     ) -> CacheDictionaryGetResponse:
         coroutine = self._momento_async_client.dictionary_get(cache_name, dictionary_name, key)
         return wait_for_coroutine(self._loop, coroutine)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -301,23 +301,23 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        mapping: Dictionary,
+        dictionary: Dictionary,
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
-        Inserts items from `mapping` into a dictionary `dictionary_name`.
+        Inserts items from `dictionary` into a dictionary `dictionary_name`.
         Updates (overwrites) values if the key already exists.
 
         Args:
-            cache_name (str): Name of the cache to store the dictionary mapping in.
-            dictionary_name (str): The name of the dictionary to store the mapping.
-            mapping (Dictionary): The items (key-value pairs) to be stored.
+            cache_name (str): Name of the cache to store the dictionary in.
+            dictionary_name (str): The name of the dictionary in the cache.
+            dictionary (Dictionary): The items (key-value pairs) to be stored.
 
         Returns:
             CacheDictionarySetResponse: data stored in the cache
         """
         coroutine = self._momento_async_client.dictionary_set(
-            cache_name, dictionary_name, mapping
+            cache_name, dictionary_name, dictionary
         )
         return wait_for_coroutine(self._loop, coroutine)
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -21,7 +21,6 @@ from .cache_operation_types import (
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
     CacheDictionaryGetResponse,
-    CacheDictionaryGetStatus,
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -40,6 +40,14 @@ class SimpleCacheClient:
         default_ttl_seconds: int,
         data_client_operation_timeout_ms: Optional[int],
     ):
+        self._init_loop()
+        self._momento_async_client = aio.SimpleCacheClient(
+            auth_token=auth_token,
+            default_ttl_seconds=default_ttl_seconds,
+            data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+        )
+
+    def _init_loop(self):
         try:
             # If the synchronous client is used inside an async application,
             # use the event loop it's running within.
@@ -52,12 +60,6 @@ class SimpleCacheClient:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
         self._loop = loop
-
-        self._momento_async_client = aio.SimpleCacheClient(
-            auth_token=auth_token,
-            default_ttl_seconds=default_ttl_seconds,
-            data_client_operation_timeout_ms=data_client_operation_timeout_ms,
-        )
 
     def __enter__(self) -> "SimpleCacheClient":
         wait_for_coroutine(self._loop, self._momento_async_client.__aenter__())
@@ -286,7 +288,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         data_client_operation_timeout_ms: Optional[int],
     ):
         warnings.warn(aio.INCUBATING_WARNING_MSG)
-        super().__init__(auth_token, default_ttl_seconds, data_client_operation_timeout_ms)
+        self._init_loop()
         self._momento_async_client = aio.SimpleCacheClientIncubating(
             auth_token=auth_token,
             default_ttl_seconds=default_ttl_seconds,

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -20,14 +20,14 @@ from .cache_operation_types import (
     CacheMultiGetFailureResponse,
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
-    CacheHashGetResponse,
-    CacheHashGetStatus,
-    CacheHashSetResponse,
-    CacheHashValue,
-    CacheHashGetAllResponse,
-    HashKeyValueType,
-    HashType,
-    StoredHashType,
+    CacheDictionaryGetResponse,
+    CacheDictionaryGetStatus,
+    CacheDictionarySetResponse,
+    CacheDictionaryValue,
+    CacheDictionaryGetAllResponse,
+    DictionaryKeyValueType,
+    DictionaryType,
+    StoredDictionaryType,
 )
 
 from ._utilities._data_validation import _validate_request_timeout
@@ -277,26 +277,26 @@ class SimpleCacheClient:
         coroutine = self._momento_async_client.multi_get(cache_name, ops)
         return wait_for_coroutine(self._loop, coroutine)
 
-    def hash_set(
+    def dictionary_set(
         self,
         cache_name: str,
-        hash_name: str,
-        mapping: HashType,
-    ) -> CacheHashSetResponse:
-        coroutine = self._momento_async_client.hash_set(cache_name, hash_name, mapping)
+        dictionary_name: str,
+        mapping: DictionaryType,
+    ) -> CacheDictionarySetResponse:
+        coroutine = self._momento_async_client.dictionary_set(cache_name, dictionary_name, mapping)
         return wait_for_coroutine(self._loop, coroutine)
 
-    def hash_get(
+    def dictionary_get(
         self,
         cache_name: str,
-        hash_name: str,
-        key: HashKeyValueType,
-    ) -> CacheHashGetResponse:
-        coroutine = self._momento_async_client.hash_get(cache_name, hash_name, key)
+        dictionary_name: str,
+        key: DictionaryKeyValueType,
+    ) -> CacheDictionaryGetResponse:
+        coroutine = self._momento_async_client.dictionary_get(cache_name, dictionary_name, key)
         return wait_for_coroutine(self._loop, coroutine)
 
-    def hash_get_all(self, cache_name: str, hash_name: str) -> CacheHashGetAllResponse:
-        coroutine = self._momento_async_client.hash_get_all(cache_name, hash_name)
+    def dictionary_get_all(self, cache_name: str, dictionary_name: str) -> CacheDictionaryGetAllResponse:
+        coroutine = self._momento_async_client.dictionary_get_all(cache_name, dictionary_name)
         return wait_for_coroutine(self._loop, coroutine)
 
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -20,6 +20,14 @@ from .cache_operation_types import (
     CacheMultiGetFailureResponse,
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
+    CacheHashGetResponse,
+    CacheHashGetStatus,
+    CacheHashSetResponse,
+    CacheHashValue,
+    CacheHashGetAllResponse,
+    HashKeyValueType,
+    HashType,
+    StoredHashType,
 )
 
 from ._utilities._data_validation import _validate_request_timeout
@@ -267,6 +275,28 @@ class SimpleCacheClient:
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
         coroutine = self._momento_async_client.multi_get(cache_name, ops)
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def hash_set(
+        self,
+        cache_name: str,
+        hash_name: str,
+        mapping: HashType,
+    ) -> CacheHashSetResponse:
+        coroutine = self._momento_async_client.hash_set(cache_name, hash_name, mapping)
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def hash_get(
+        self,
+        cache_name: str,
+        hash_name: str,
+        key: HashKeyValueType,
+    ) -> CacheHashGetResponse:
+        coroutine = self._momento_async_client.hash_get(cache_name, hash_name, key)
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def hash_get_all(self, cache_name: str, hash_name: str) -> CacheHashGetAllResponse:
+        coroutine = self._momento_async_client.hash_get_all(cache_name, hash_name)
         return wait_for_coroutine(self._loop, coroutine)
 
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -47,7 +47,7 @@ class SimpleCacheClient:
             data_client_operation_timeout_ms=data_client_operation_timeout_ms,
         )
 
-    def _init_loop(self):
+    def _init_loop(self) -> None:
         try:
             # If the synchronous client is used inside an async application,
             # use the event loop it's running within.
@@ -289,10 +289,12 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
     ):
         warnings.warn(aio.INCUBATING_WARNING_MSG)
         self._init_loop()
-        self._momento_async_client = aio.SimpleCacheClientIncubating(
-            auth_token=auth_token,
-            default_ttl_seconds=default_ttl_seconds,
-            data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+        self._momento_async_client: aio.SimpleCacheClientIncubating = (
+            aio.SimpleCacheClientIncubating(
+                auth_token=auth_token,
+                default_ttl_seconds=default_ttl_seconds,
+                data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+            )
         )
 
     def dictionary_set(

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -284,6 +284,9 @@ class SimpleCacheClient:
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
+        Inserts items from `mapping` into a dictionary `dictionary_name`.
+        Updates (overwrites) values if the key already exists.
+
         Args:
             cache_name (str): Name of the cache to store the dictionary mapping in.
             dictionary_name (str): The name of the dictionary to store the mapping.

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -374,7 +374,6 @@ def init(
         request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
             Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
             in TimeoutError.
-        incubating (bool): Use the incubating client. Includes non-final, experimental features and APIs.
     Returns:
         SimpleCacheClient
     Raises:

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -24,7 +24,7 @@ from .cache_operation_types import (
     CacheDictionarySetResponse,
     CacheDictionaryValue,
     CacheDictionaryGetAllResponse,
-    DictionaryKeyValue,
+    DictionaryKey,
     Dictionary,
     StoredDictionary,
 )
@@ -289,7 +289,7 @@ class SimpleCacheClient:
         self,
         cache_name: str,
         dictionary_name: str,
-        key: DictionaryKeyValue,
+        key: DictionaryKey,
     ) -> CacheDictionaryGetResponse:
         coroutine = self._momento_async_client.dictionary_get(cache_name, dictionary_name, key)
         return wait_for_coroutine(self._loop, coroutine)

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -1,0 +1,96 @@
+import itertools
+import unittest
+import os
+import warnings
+
+from momento.incubating.aio.utils import (
+    convert_dict_values_to_bytes,
+    dict_to_stored_hash)
+import momento.incubating.simple_cache_client as simple_cache_client
+
+from momento.cache_operation_types import CacheGetStatus
+from momento.incubating.cache_operation_types import CacheDictionaryValue
+
+_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
+_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_DEFAULT_TTL_SECONDS = 60
+
+
+class TestMomento(unittest.TestCase):
+    def test_incubating_warning(self):
+        with self.assertWarns(UserWarning):
+            warnings.simplefilter("always")
+            with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
+                pass
+
+    def test_get_dictionary_miss(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    def test_dictionary_set_response(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test with key as string
+            set_response = simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
+            self.assertEqual("myhash", set_response.key())
+            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+
+            # Test key as bytes
+            set_response = simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
+            self.assertEqual("myhash2", set_response.key())
+            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+
+    def test_dictionary_set_and_dictionary_get_missing_key(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
+            get_response = simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    def test_dictionary_get_hit(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
+            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+                key, value = "key1", "value1"
+                if not key_is_str:
+                    key = key.encode()
+                if not value_is_str:
+                    value = value.encode()
+                dictionary = {key: value}
+                # Use distinct hash names to avoid collisions with already finished tests
+                dictionary_name = f"myhash4-{i}"
+
+                simple_cache.dictionary_set(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
+                get_response = simple_cache.dictionary_get(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
+                self.assertEqual(CacheGetStatus.HIT, get_response.status())
+                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+
+    def test_dictionary_get_all_miss(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    def test_dictionary_get_all_hit(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            dictionary = {"key1": "value1", "key2": "value2"}
+            simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
+            )
+            get_all_response = simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
+            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
+
+            expected = dict_to_stored_hash(
+                convert_dict_values_to_bytes(dictionary))
+            self.assertEqual(expected, get_all_response.value())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -1,0 +1,96 @@
+import itertools
+import os
+import unittest
+import warnings
+
+from momento.cache_operation_types import CacheGetStatus
+import momento.incubating.aio.simple_cache_client as simple_cache_client
+from momento.incubating.cache_operation_types import CacheDictionaryValue
+from momento.incubating.aio.utils import (
+    convert_dict_values_to_bytes,
+    dict_to_stored_hash)
+from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
+
+_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
+_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_DEFAULT_TTL_SECONDS = 60
+
+
+class TestMomentoAsync(IsolatedAsyncioTestCase):
+    async def test_incubating_warning(self):
+        with self.assertWarns(UserWarning):
+            warnings.simplefilter("always")
+            async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
+                pass
+
+    async def test_get_dictionary_miss(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = await simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_dictionary_set_response(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test with key as string
+            set_response = await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
+            self.assertEqual("myhash", set_response.key())
+            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+
+            # Test key as bytes
+            set_response = await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
+            self.assertEqual("myhash2", set_response.key())
+            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+
+    async def test_dictionary_set_and_dictionary_get_missing_key(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
+            get_response = await simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_dictionary_get_hit(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
+            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+                key, value = "key1", "value1"
+                if not key_is_str:
+                    key = key.encode()
+                if not value_is_str:
+                    value = value.encode()
+                dictionary = {key: value}
+                # Use distinct hash names to avoid collisions with already finished tests
+                dictionary_name = f"myhash4-{i}"
+
+                await simple_cache.dictionary_set(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
+                get_response = await simple_cache.dictionary_get(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
+                self.assertEqual(CacheGetStatus.HIT, get_response.status())
+                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+
+    async def test_dictionary_get_all_miss(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = await simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_dictionary_get_all_hit(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            dictionary = {"key1": "value1", "key2": "value2"}
+            await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
+            )
+            get_all_response = await simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
+            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
+
+            expected = dict_to_stored_hash(
+                convert_dict_values_to_bytes(dictionary))
+            self.assertEqual(expected, get_all_response.value())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -14,8 +14,8 @@ from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
     CacheMultiGetOperation,
-    CacheHashGetStatus,
-    CacheHashValue)
+    CacheDictionaryGetStatus,
+    CacheDictionaryValue)
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
 _TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
@@ -370,35 +370,35 @@ class TestMomento(unittest.TestCase):
         self.assertEqual("bar1", get_resp.values()[0])
         self.assertEqual("bar2", get_resp.values()[1])
 
-    def test_get_hash_miss(self):
+    def test_get_dictionary_miss(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = simple_cache.hash_get(
-                cache_name=_TEST_CACHE_NAME, hash_name="hello world", key="key")
-            self.assertEqual(CacheHashGetStatus.HASH_MISS, get_response.status())
+            get_response = simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
+            self.assertEqual(CacheDictionaryGetStatus.HASH_MISS, get_response.status())
 
-    def test_hash_set_response(self):
+    def test_dictionary_set_response(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
-            set_response = simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash", mapping={"key1": "value1"})
+            set_response = simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
             self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheHashValue(value=b"value1")}, set_response.value())
+            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
             # Test key as bytes
-            set_response = simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash2", mapping={b"key1": "value1"})
+            set_response = simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", mapping={b"key1": "value1"})
             self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheHashValue(value=b"value1")}, set_response.value())
+            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
-    def test_hash_set_and_hash_get_missing_key(self):
+    def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", mapping={"key1": "value1"})
-            get_response = simple_cache.hash_get(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", key="key2")
-            self.assertEqual(CacheHashGetStatus.HASH_KEY_MISS, get_response.status())
+            simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
+            get_response = simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
+            self.assertEqual(CacheDictionaryGetStatus.HASH_KEY_MISS, get_response.status())
 
-    def test_hash_get_hit(self):
+    def test_dictionary_get_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
@@ -409,29 +409,29 @@ class TestMomento(unittest.TestCase):
                     value = value.encode()
                 mapping = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
-                hash_name = f"myhash4-{i}"
+                dictionary_name = f"myhash4-{i}"
 
-                simple_cache.hash_set(
-                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, mapping=mapping)
-                get_response = simple_cache.hash_get(
-                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, key=key)
-                self.assertEqual(CacheHashGetStatus.HIT, get_response.status())
+                simple_cache.dictionary_set(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
+                get_response = simple_cache.dictionary_get(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
+                self.assertEqual(CacheDictionaryGetStatus.HIT, get_response.status())
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
-    def test_hash_get_all_miss(self):
+    def test_dictionary_get_all_miss(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = simple_cache.hash_get_all(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash5")
+            get_response = simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
-    def test_hash_get_all_hit(self):
+    def test_dictionary_get_all_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             mapping = {"key1": "value1", "key2": "value2"}
-            simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash6", mapping=mapping
+            simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping
             )
-            get_all_response = simple_cache.hash_get_all(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash6")
+            get_all_response = simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = dict_to_stored_hash(

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -386,20 +386,20 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test with key as string
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
             self.assertEqual("myhash", set_response.key())
             self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
             # Test key as bytes
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", mapping={b"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
             self.assertEqual("myhash2", set_response.key())
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
@@ -413,12 +413,12 @@ class TestMomento(unittest.TestCase):
                     key = key.encode()
                 if not value_is_str:
                     value = value.encode()
-                mapping = {key: value}
+                dictionary = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"myhash4-{i}"
 
                 simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
                 get_response = simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
@@ -432,16 +432,16 @@ class TestMomento(unittest.TestCase):
 
     def test_dictionary_get_all_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
-            mapping = {"key1": "value1", "key2": "value2"}
+            dictionary = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
             )
             get_all_response = simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = dict_to_stored_hash(
-                convert_dict_values_to_bytes(mapping))
+                convert_dict_values_to_bytes(dictionary))
             self.assertEqual(expected, get_all_response.value())
 
 

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -1,21 +1,15 @@
-import itertools
 import unittest
 import os
 import uuid
 import time
-import warnings
 
 import momento.simple_cache_client as simple_cache_client
-from momento.aio.simple_cache_client import (
-    convert_dict_values_to_bytes,
-    dict_to_stored_hash)
 import momento.errors as errors
-
 from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
-    CacheMultiGetOperation,
-    CacheDictionaryValue)
+    CacheMultiGetOperation)
+
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
 _TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
@@ -369,81 +363,6 @@ class TestMomento(unittest.TestCase):
         )
         self.assertEqual("bar1", get_resp.values()[0])
         self.assertEqual("bar2", get_resp.values()[1])
-
-    def test_incubating_warning(self):
-        with self.assertWarns(UserWarning):
-            warnings.simplefilter("always")
-            with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
-                pass
-
-    def test_get_dictionary_miss(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    def test_dictionary_set_response(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            # Test with key as string
-            set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
-            self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
-
-            # Test key as bytes
-            set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
-            self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
-
-    def test_dictionary_set_and_dictionary_get_missing_key(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
-            get_response = simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    def test_dictionary_get_hit(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
-            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
-                key, value = "key1", "value1"
-                if not key_is_str:
-                    key = key.encode()
-                if not value_is_str:
-                    value = value.encode()
-                dictionary = {key: value}
-                # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"myhash4-{i}"
-
-                simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
-                get_response = simple_cache.dictionary_get(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
-                self.assertEqual(CacheGetStatus.HIT, get_response.status())
-                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
-
-    def test_dictionary_get_all_miss(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    def test_dictionary_get_all_hit(self):
-        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            dictionary = {"key1": "value1", "key2": "value2"}
-            simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
-            )
-            get_all_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
-            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
-
-            expected = dict_to_stored_hash(
-                convert_dict_values_to_bytes(dictionary))
-            self.assertEqual(expected, get_all_response.value())
-
 
 
 if __name__ == '__main__':

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -373,17 +373,17 @@ class TestMomento(unittest.TestCase):
     def test_incubating_warning(self):
         with self.assertWarns(UserWarning):
             warnings.simplefilter("always")
-            with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True):
+            with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
                 pass
 
     def test_get_dictionary_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_set_response(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
             set_response = simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
@@ -397,7 +397,7 @@ class TestMomento(unittest.TestCase):
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
             get_response = simple_cache.dictionary_get(
@@ -405,7 +405,7 @@ class TestMomento(unittest.TestCase):
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
                 key, value = "key1", "value1"
@@ -425,13 +425,13 @@ class TestMomento(unittest.TestCase):
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     def test_dictionary_get_all_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_all_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -1,12 +1,21 @@
+import itertools
 import unittest
 import os
 import uuid
 import time
 
 import momento.simple_cache_client as simple_cache_client
+from momento.aio.simple_cache_client import (
+    convert_dict_values_to_bytes,
+    dict_to_stored_hash)
 import momento.errors as errors
 
-from momento.cache_operation_types import CacheMultiSetOperation, CacheMultiGetOperation, CacheGetStatus
+from momento.cache_operation_types import (
+    CacheGetStatus,
+    CacheMultiSetOperation,
+    CacheMultiGetOperation,
+    CacheHashGetStatus,
+    CacheHashValue)
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
 _TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
@@ -360,6 +369,75 @@ class TestMomento(unittest.TestCase):
         )
         self.assertEqual("bar1", get_resp.values()[0])
         self.assertEqual("bar2", get_resp.values()[1])
+
+    def test_get_hash_miss(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = simple_cache.hash_get(
+                cache_name=_TEST_CACHE_NAME, hash_name="hello world", key="key")
+            self.assertEqual(CacheHashGetStatus.HASH_MISS, get_response.status())
+
+    def test_hash_set_response(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test with key as string
+            set_response = simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash", mapping={"key1": "value1"})
+            self.assertEqual("myhash", set_response.key())
+            self.assertEqual({"key1": CacheHashValue(value=b"value1")}, set_response.value())
+
+            # Test key as bytes
+            set_response = simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash2", mapping={b"key1": "value1"})
+            self.assertEqual("myhash2", set_response.key())
+            self.assertEqual({b"key1": CacheHashValue(value=b"value1")}, set_response.value())
+
+    def test_hash_set_and_hash_get_missing_key(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", mapping={"key1": "value1"})
+            get_response = simple_cache.hash_get(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", key="key2")
+            self.assertEqual(CacheHashGetStatus.HASH_KEY_MISS, get_response.status())
+
+    def test_hash_get_hit(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
+            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+                key, value = "key1", "value1"
+                if not key_is_str:
+                    key = key.encode()
+                if not value_is_str:
+                    value = value.encode()
+                mapping = {key: value}
+                # Use distinct hash names to avoid collisions with already finished tests
+                hash_name = f"myhash4-{i}"
+
+                simple_cache.hash_set(
+                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, mapping=mapping)
+                get_response = simple_cache.hash_get(
+                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, key=key)
+                self.assertEqual(CacheHashGetStatus.HIT, get_response.status())
+                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+
+    def test_hash_get_all_miss(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = simple_cache.hash_get_all(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash5")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    def test_hash_get_all_hit(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            mapping = {"key1": "value1", "key2": "value2"}
+            simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash6", mapping=mapping
+            )
+            get_all_response = simple_cache.hash_get_all(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash6")
+            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
+
+            expected = dict_to_stored_hash(
+                convert_dict_values_to_bytes(mapping))
+            self.assertEqual(expected, get_all_response.value())
+
 
 
 if __name__ == '__main__':

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -14,7 +14,6 @@ from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
     CacheMultiGetOperation,
-    CacheDictionaryGetStatus,
     CacheDictionaryValue)
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
@@ -374,7 +373,7 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
-            self.assertEqual(CacheDictionaryGetStatus.HASH_MISS, get_response.status())
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_set_response(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -396,7 +395,7 @@ class TestMomento(unittest.TestCase):
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
-            self.assertEqual(CacheDictionaryGetStatus.HASH_KEY_MISS, get_response.status())
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -415,7 +414,7 @@ class TestMomento(unittest.TestCase):
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
                 get_response = simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
-                self.assertEqual(CacheDictionaryGetStatus.HIT, get_response.status())
+                self.assertEqual(CacheGetStatus.HIT, get_response.status())
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     def test_dictionary_get_all_miss(self):

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import uuid
 import time
+import warnings
 
 import momento.simple_cache_client as simple_cache_client
 from momento.aio.simple_cache_client import (
@@ -369,14 +370,20 @@ class TestMomento(unittest.TestCase):
         self.assertEqual("bar1", get_resp.values()[0])
         self.assertEqual("bar2", get_resp.values()[1])
 
+    def test_incubating_warning(self):
+        with self.assertWarns(UserWarning):
+            warnings.simplefilter("always")
+            with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True):
+                pass
+
     def test_get_dictionary_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_set_response(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test with key as string
             set_response = simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
@@ -390,7 +397,7 @@ class TestMomento(unittest.TestCase):
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
             get_response = simple_cache.dictionary_get(
@@ -398,7 +405,7 @@ class TestMomento(unittest.TestCase):
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
                 key, value = "key1", "value1"
@@ -418,13 +425,13 @@ class TestMomento(unittest.TestCase):
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     def test_dictionary_get_all_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             get_response = simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_all_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             mapping = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -1,18 +1,14 @@
-import itertools
 import os
 import time
 import unittest
 import uuid
-import warnings
 
 import momento.aio.simple_cache_client as simple_cache_client
 import momento.errors as errors
 from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
-    CacheMultiGetOperation,
-    CacheGetStatus,
-    CacheDictionaryValue)
+    CacheMultiGetOperation)
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
@@ -419,80 +415,6 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
             # Make sure were getting values we expect back
             self.assertEqual("buzz5", get_resp.values()[1])
-
-    async def test_incubating_warning(self):
-        with self.assertWarns(UserWarning):
-            warnings.simplefilter("always")
-            async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
-                pass
-
-    async def test_get_dictionary_miss(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    async def test_dictionary_set_response(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            # Test with key as string
-            set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
-            self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
-
-            # Test key as bytes
-            set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
-            self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
-
-    async def test_dictionary_set_and_dictionary_get_missing_key(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
-            get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    async def test_dictionary_get_hit(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
-            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
-                key, value = "key1", "value1"
-                if not key_is_str:
-                    key = key.encode()
-                if not value_is_str:
-                    value = value.encode()
-                dictionary = {key: value}
-                # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"myhash4-{i}"
-
-                await simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
-                get_response = await simple_cache.dictionary_get(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
-                self.assertEqual(CacheGetStatus.HIT, get_response.status())
-                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
-
-    async def test_dictionary_get_all_miss(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
-            self.assertEqual(CacheGetStatus.MISS, get_response.status())
-
-    async def test_dictionary_get_all_hit(self):
-        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            dictionary = {"key1": "value1", "key2": "value2"}
-            await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
-            )
-            get_all_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
-            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
-
-            expected = simple_cache_client.dict_to_stored_hash(
-                simple_cache_client.convert_dict_values_to_bytes(dictionary))
-            self.assertEqual(expected, get_all_response.value())
 
 
 if __name__ == '__main__':

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -436,20 +436,20 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test with key as string
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
             self.assertEqual("myhash", set_response.key())
             self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
             # Test key as bytes
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", mapping={b"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
             self.assertEqual("myhash2", set_response.key())
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
@@ -463,12 +463,12 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                     key = key.encode()
                 if not value_is_str:
                     value = value.encode()
-                mapping = {key: value}
+                dictionary = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"myhash4-{i}"
 
                 await simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
                 get_response = await simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
@@ -482,16 +482,16 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
     async def test_dictionary_get_all_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
-            mapping = {"key1": "value1", "key2": "value2"}
+            dictionary = {"key1": "value1", "key2": "value2"}
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
             )
             get_all_response = await simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = simple_cache_client.dict_to_stored_hash(
-                simple_cache_client.convert_dict_values_to_bytes(mapping))
+                simple_cache_client.convert_dict_values_to_bytes(dictionary))
             self.assertEqual(expected, get_all_response.value())
 
 

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -3,6 +3,7 @@ import os
 import time
 import unittest
 import uuid
+import warnings
 
 import momento.aio.simple_cache_client as simple_cache_client
 import momento.errors as errors
@@ -419,14 +420,20 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             # Make sure were getting values we expect back
             self.assertEqual("buzz5", get_resp.values()[1])
 
+    async def test_incubating_warning(self):
+        with self.assertWarns(UserWarning):
+            warnings.simplefilter("always")
+            async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True):
+                pass
+
     async def test_get_dictionary_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_set_response(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test with key as string
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
@@ -440,7 +447,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
             get_response = await simple_cache.dictionary_get(
@@ -448,7 +455,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
                 key, value = "key1", "value1"
@@ -468,13 +475,13 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     async def test_dictionary_get_all_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             get_response = await simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_all_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
             mapping = {"key1": "value1", "key2": "value2"}
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -423,17 +423,17 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_incubating_warning(self):
         with self.assertWarns(UserWarning):
             warnings.simplefilter("always")
-            async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True):
+            async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
                 pass
 
     async def test_get_dictionary_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_set_response(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
@@ -447,7 +447,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
             get_response = await simple_cache.dictionary_get(
@@ -455,7 +455,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
                 key, value = "key1", "value1"
@@ -475,13 +475,13 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     async def test_dictionary_get_all_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = await simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_all_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, incubating=True) as simple_cache:
+        async with simple_cache_client.init_incubating(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -10,7 +10,7 @@ from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
     CacheMultiGetOperation,
-    CacheDictionaryGetStatus,
+    CacheGetStatus,
     CacheDictionaryValue)
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
@@ -423,7 +423,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
-            self.assertEqual(CacheDictionaryGetStatus.HASH_MISS, get_response.status())
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_set_response(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -445,7 +445,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
-            self.assertEqual(CacheDictionaryGetStatus.HASH_KEY_MISS, get_response.status())
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -464,7 +464,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
                 get_response = await simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
-                self.assertEqual(CacheDictionaryGetStatus.HIT, get_response.status())
+                self.assertEqual(CacheGetStatus.HIT, get_response.status())
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
     async def test_dictionary_get_all_miss(self):

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import time
 import unittest
@@ -5,10 +6,12 @@ import uuid
 
 import momento.aio.simple_cache_client as simple_cache_client
 import momento.errors as errors
-from momento.cache_operation_types import \
-    CacheGetStatus, \
-    CacheMultiSetOperation, \
-    CacheMultiGetOperation
+from momento.cache_operation_types import (
+    CacheGetStatus,
+    CacheMultiSetOperation,
+    CacheMultiGetOperation,
+    CacheHashGetStatus,
+    CacheHashValue)
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
@@ -415,6 +418,74 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
             # Make sure were getting values we expect back
             self.assertEqual("buzz5", get_resp.values()[1])
+
+    async def test_get_hash_miss(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = await simple_cache.hash_get(
+                cache_name=_TEST_CACHE_NAME, hash_name="hello world", key="key")
+            self.assertEqual(CacheHashGetStatus.HASH_MISS, get_response.status())
+
+    async def test_hash_set_response(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test with key as string
+            set_response = await simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash", mapping={"key1": "value1"})
+            self.assertEqual("myhash", set_response.key())
+            self.assertEqual({"key1": CacheHashValue(value=b"value1")}, set_response.value())
+
+            # Test key as bytes
+            set_response = await simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash2", mapping={b"key1": "value1"})
+            self.assertEqual("myhash2", set_response.key())
+            self.assertEqual({b"key1": CacheHashValue(value=b"value1")}, set_response.value())
+
+    async def test_hash_set_and_hash_get_missing_key(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            await simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", mapping={"key1": "value1"})
+            get_response = await simple_cache.hash_get(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", key="key2")
+            self.assertEqual(CacheHashGetStatus.HASH_KEY_MISS, get_response.status())
+
+    async def test_hash_get_hit(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
+            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+                key, value = "key1", "value1"
+                if not key_is_str:
+                    key = key.encode()
+                if not value_is_str:
+                    value = value.encode()
+                mapping = {key: value}
+                # Use distinct hash names to avoid collisions with already finished tests
+                hash_name = f"myhash4-{i}"
+
+                await simple_cache.hash_set(
+                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, mapping=mapping)
+                get_response = await simple_cache.hash_get(
+                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, key=key)
+                self.assertEqual(CacheHashGetStatus.HIT, get_response.status())
+                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+
+    async def test_hash_get_all_miss(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = await simple_cache.hash_get_all(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash5")
+            self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_hash_get_all_hit(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            mapping = {"key1": "value1", "key2": "value2"}
+            await simple_cache.hash_set(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash6", mapping=mapping
+            )
+            get_all_response = await simple_cache.hash_get_all(
+                cache_name=_TEST_CACHE_NAME, hash_name="myhash6")
+            self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
+
+            expected = simple_cache_client.dict_to_stored_hash(
+                simple_cache_client.convert_dict_values_to_bytes(mapping))
+            self.assertEqual(expected, get_all_response.value())
 
 
 if __name__ == '__main__':

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -10,8 +10,8 @@ from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
     CacheMultiGetOperation,
-    CacheHashGetStatus,
-    CacheHashValue)
+    CacheDictionaryGetStatus,
+    CacheDictionaryValue)
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
@@ -419,35 +419,35 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             # Make sure were getting values we expect back
             self.assertEqual("buzz5", get_resp.values()[1])
 
-    async def test_get_hash_miss(self):
+    async def test_get_dictionary_miss(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = await simple_cache.hash_get(
-                cache_name=_TEST_CACHE_NAME, hash_name="hello world", key="key")
-            self.assertEqual(CacheHashGetStatus.HASH_MISS, get_response.status())
+            get_response = await simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
+            self.assertEqual(CacheDictionaryGetStatus.HASH_MISS, get_response.status())
 
-    async def test_hash_set_response(self):
+    async def test_dictionary_set_response(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
-            set_response = await simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash", mapping={"key1": "value1"})
+            set_response = await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", mapping={"key1": "value1"})
             self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheHashValue(value=b"value1")}, set_response.value())
+            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
             # Test key as bytes
-            set_response = await simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash2", mapping={b"key1": "value1"})
+            set_response = await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", mapping={b"key1": "value1"})
             self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheHashValue(value=b"value1")}, set_response.value())
+            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
 
-    async def test_hash_set_and_hash_get_missing_key(self):
+    async def test_dictionary_set_and_dictionary_get_missing_key(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            await simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", mapping={"key1": "value1"})
-            get_response = await simple_cache.hash_get(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash3", key="key2")
-            self.assertEqual(CacheHashGetStatus.HASH_KEY_MISS, get_response.status())
+            await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", mapping={"key1": "value1"})
+            get_response = await simple_cache.dictionary_get(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
+            self.assertEqual(CacheDictionaryGetStatus.HASH_KEY_MISS, get_response.status())
 
-    async def test_hash_get_hit(self):
+    async def test_dictionary_get_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
             for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
@@ -458,29 +458,29 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                     value = value.encode()
                 mapping = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
-                hash_name = f"myhash4-{i}"
+                dictionary_name = f"myhash4-{i}"
 
-                await simple_cache.hash_set(
-                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, mapping=mapping)
-                get_response = await simple_cache.hash_get(
-                    cache_name=_TEST_CACHE_NAME, hash_name=hash_name, key=key)
-                self.assertEqual(CacheHashGetStatus.HIT, get_response.status())
+                await simple_cache.dictionary_set(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, mapping=mapping)
+                get_response = await simple_cache.dictionary_get(
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
+                self.assertEqual(CacheDictionaryGetStatus.HIT, get_response.status())
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
 
-    async def test_hash_get_all_miss(self):
+    async def test_dictionary_get_all_miss(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            get_response = await simple_cache.hash_get_all(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash5")
+            get_response = await simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
-    async def test_hash_get_all_hit(self):
+    async def test_dictionary_get_all_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             mapping = {"key1": "value1", "key2": "value2"}
-            await simple_cache.hash_set(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash6", mapping=mapping
+            await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", mapping=mapping
             )
-            get_all_response = await simple_cache.hash_get_all(
-                cache_name=_TEST_CACHE_NAME, hash_name="myhash6")
+            get_all_response = await simple_cache.dictionary_get_all(
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = simple_cache_client.dict_to_stored_hash(


### PR DESCRIPTION
Closes #85 

Adds a dictionary data type API with a non-production client side implementation. The methods added to the client are:

1. `dictionary_get`: retrieve a value from a dictionary in the cache
2. `dictionary_get_all`: retrieve the whole dictionary from the cache
3.  `dictionary_set`: store key-value pairs in a dictionary (upsert)



