### PR TITLE
fix: momento logger function definitions

### DIFF
--- a/src/momento/_momento_logger.py
+++ b/src/momento/_momento_logger.py
@@ -3,9 +3,9 @@ import logging
 logger = logging.getLogger("momentosdk")
 
 
-def info(msg: str) -> None:
-    logger.info(msg)
+""" info('some %s stuff', 'information') """
+info = logger.info
 
 
-def debug(msg: str) -> None:
-    logger.debug(msg)
+""" debug('some %s stuff', 'debug') """
+debug = logger.debug


### PR DESCRIPTION
quit stripping `*args` from the logging functions.

Relates to https://github.com/momentohq/client-sdk-python/issues/101