### PR TITLE
fix: incubating dictionary convenience methods

### DIFF
--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -60,9 +60,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         set_response = await self.set(
             cache_name, dictionary_name, pickle.dumps(cached_dictionary)
         )
-        return CacheDictionarySetResponse(
-            key=set_response._key, value=deserialize_stored_hash(set_response._value)
-        )
+        return CacheDictionarySetResponse(key=set_response._key, value=dictionary)
 
     async def dictionary_get(
         self,

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -4,6 +4,8 @@ import warnings
 
 from .. import INCUBATING_WARNING_MSG
 from ...aio.simple_cache_client import SimpleCacheClient
+from ..._utilities._data_validation import _as_bytes
+
 from ..cache_operation_types import (
     CacheGetStatus,
     CacheDictionaryGetResponse,
@@ -87,7 +89,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         )
 
         try:
-            value = dictionary[key]
+            value = dictionary[_as_bytes(key, "Unsupported type for key: ")]
         except KeyError:
             return CacheDictionaryGetResponse(value=None, result=CacheGetStatus.MISS)
 

--- a/src/momento/incubating/aio/utils.py
+++ b/src/momento/incubating/aio/utils.py
@@ -2,10 +2,11 @@ import pickle
 from typing import cast
 
 from ..cache_operation_types import CacheDictionaryValue, Dictionary, StoredDictionary
+from ..._utilities._data_validation import _as_bytes
 
 
 def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
-    return {k: v if isinstance(v, bytes) else v.encode() for k, v in dict_.items()}
+    return {_as_bytes(k, "Unsupported type for key: "): _as_bytes(v, "Unsupported type for value: ") for k, v in dict_.items()}
 
 
 def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:

--- a/src/momento/incubating/aio/utils.py
+++ b/src/momento/incubating/aio/utils.py
@@ -6,7 +6,12 @@ from ..._utilities._data_validation import _as_bytes
 
 
 def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
-    return {_as_bytes(k, "Unsupported type for key: "): _as_bytes(v, "Unsupported type for value: ") for k, v in dict_.items()}
+    return {
+        _as_bytes(k, "Unsupported type for key: "): _as_bytes(
+            v, "Unsupported type for value: "
+        )
+        for k, v in dict_.items()
+    }
 
 
 def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -73,11 +73,11 @@ StoredDictionary = Dict[DictionaryKey, CacheDictionaryValue]
 
 
 class CacheDictionarySetResponse:
-    def __init__(self, key: bytes, value: StoredDictionary):
+    def __init__(self, key: bytes, value: Dictionary):
         self._key = key
         self._value = value
 
-    def value(self) -> StoredDictionary:
+    def value(self) -> Dictionary:
         return self._value
 
     def key(self) -> str:

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -105,10 +105,28 @@ class CacheDictionaryGetAllResponse:
         self._value = value
         self._result = result
 
-    def value(self) -> Optional[StoredDictionary]:
+    def value(self, *, keys_as_bytes: bool = False) -> Optional[StoredDictionary]:
+        """Get the dictionary as stored in the cache.
+
+        By default unmarshals the keys to strings. To override this
+        set `keys_as_bytes` to `True`.
+
+        Values are of type `CacheDictionaryValue`, which implement `value` and
+        `value_as_bytes` methods to unmarshal to string or bytes respectively.
+
+        Args:
+            keys_as_bytes (bool, optional): Leave the keys as uninterpreted bytes. Defaults to False.
+
+        Returns:
+            Optional[StoredDictionary]: The dictionary if the cache get was a hit, else None.
+        """
         if self.status() != CacheGetStatus.HIT:
             return None
-        return self._value
+
+        if keys_as_bytes:
+            return self._value
+
+        return {cast(bytes, k).decode("utf-8"): v for k, v in self._value.items()}
 
     def status(self) -> CacheGetStatus:
         return self._result

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -126,7 +126,7 @@ class CacheDictionaryGetAllResponse:
         if keys_as_bytes:
             return self._value
 
-        return {cast(bytes, k).decode("utf-8"): v for k, v in self._value.items()}
+        return {cast(bytes, k).decode("utf-8"): v for k, v in self._value.items()}  # type: ignore
 
     def status(self) -> CacheGetStatus:
         return self._result

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -91,6 +91,9 @@ class TestMomento(unittest.TestCase):
 
             expected = dict_to_stored_hash(
                 convert_dict_values_to_bytes(dictionary))
+            self.assertEqual(expected, get_all_response.value(keys_as_bytes=True))
+
+            expected = {k.decode("utf-8"): v for k, v in expected.items()}
             self.assertEqual(expected, get_all_response.value())
 
 

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -32,16 +32,18 @@ class TestMomento(unittest.TestCase):
     def test_dictionary_set_response(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
+            dictionary = {"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary)
             self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+            self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
+            dictionary={b"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary)
             self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+            self.assertEqual(dictionary, set_response.value())
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -32,16 +32,18 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_dictionary_set_response(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             # Test with key as string
+            dictionary = {"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary)
             self.assertEqual("myhash", set_response.key())
-            self.assertEqual({"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+            self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
+            dictionary = dictionary={b"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary={b"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary)
             self.assertEqual("myhash2", set_response.key())
-            self.assertEqual({b"key1": CacheDictionaryValue(value=b"value1")}, set_response.value())
+            self.assertEqual(dictionary, set_response.value())
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -91,7 +91,11 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
             expected = dict_to_stored_hash(
                 convert_dict_values_to_bytes(dictionary))
+            self.assertEqual(expected, get_all_response.value(keys_as_bytes=True))
+
+            expected = {k.decode("utf-8"): v for k, v in expected.items()}
             self.assertEqual(expected, get_all_response.value())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes `value` method of `CacheDictionaryGetAllResponse` to support unmarshalling keys to strings or bytes. Intended usage is as follows:

```
client.dictionary_set("my-cache", "my-dictionary", {"key1": "value1", "key2": "value2"})
get_all_response = client.dictionary_get_all("my-cache", "my-dictionary")
stored_dictionary = get_all_response.value()
value = stored_dictionary["key1"].value()) # value = "value1"
```

As well as:
```
client.dictionary_set("my-cache", "my-dictionary", {b"key1": b"key2", b"key3": b"key4"})
get_all_response = client.dictionary_get_all("my-cache", "my-dictionary")
stored_dictionary = get_all_response.value(keys_as_bytes=True)
value = stored_dictionary[b"key1"].value_as_bytes() # value = b"value1"
```

Will refine convenience methods further pending customer feedback
