### PR TITLE
chore: Align dictionary interface with latest spec

### DIFF
--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -27,27 +27,18 @@ CacheDictionaryGetResponse(value='value1', result=<CacheGetStatus.HIT: 1>)
 ```
 >>> dictionary_get_all_response = client.dictionary_get_all(cache_name="my-example-cache", dictionary_name="my-dictionary")
 >>> dictionary_get_all_response
-CacheDictionaryGetAllResponse(value={b'key1': CacheDictionaryValue(value='value1'), b'key2': CacheDictionaryValue(value='value2')}, result=<CacheGetStatus.HIT: 1>)
+CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, result=<CacheGetStatus.HIT: 1>)
 
->>> stored_dictionary = dictionary_get_all_response.value()
->>> stored_dictionary
-{'key1': CacheDictionaryValue(value='value1'), 'key2': CacheDictionaryValue(value='value2')}
+>>> dictionary_get_all_response.value()
+{'key1': 'value1', 'key2': 'value2'}
 
->>> stored_dictionary["key1"].value()
+>>> dictionary_get_all_response.value_as_bytes()
+{b'key1': b'value1', b'key2': b'value2'}
+```
+
+5. Interact with a returned dictionary
+```
+>>> my_dictionary = dictionary_get_all_response.value()
+>>> my_dictionary["key1"]
 'value1'
->>> stored_dictionary["key1"].value_as_bytes()
-b'value1'
-```
-
-5. Lastly we may store and index the keys as bytes
-```
->>> client.dictionary_set("my-example-cache", "my-dictionary", {b"key1": b"value1", b"key2": b"value2"})
-CacheDictionarySetResponse(key=my-dictionary, value={b'key1': b'value1', b'key2': b'value2'})
-
->>> stored_dictionary = client.dictionary_get_all("my-example-cache", "my-dictionary").value(keys_as_bytes=True)
->>> stored_dictionary
-{b'key1': CacheDictionaryValue(value='value1'), b'key2': CacheDictionaryValue(value='value2')}
-
->>> stored_dictionary[b"key1"].value_as_bytes()
-b'value1'
 ```

--- a/src/momento/incubating/aio/utils.py
+++ b/src/momento/incubating/aio/utils.py
@@ -1,23 +1,22 @@
 import pickle
 from typing import cast
 
-from ..cache_operation_types import CacheDictionaryValue, Dictionary, StoredDictionary
+from ..cache_operation_types import BytesDictionary, Dictionary
 from ..._utilities._data_validation import _as_bytes
 
 
-def convert_dict_values_to_bytes(dict_: Dictionary) -> Dictionary:
+def convert_dict_items_to_bytes(dictionary: Dictionary) -> BytesDictionary:
     return {
         _as_bytes(k, "Unsupported type for key: "): _as_bytes(
             v, "Unsupported type for value: "
         )
-        for k, v in dict_.items()
+        for k, v in dictionary.items()
     }
 
 
-def dict_to_stored_hash(dict_: Dictionary) -> StoredDictionary:
-    return {k: CacheDictionaryValue(v) for k, v in dict_.items()}
+def deserialize_dictionary(pickled_dictionary: bytes) -> BytesDictionary:
+    return cast(BytesDictionary, pickle.loads(pickled_dictionary))
 
 
-def deserialize_stored_hash(pickled_dict: bytes) -> StoredDictionary:
-    d = cast(Dictionary, pickle.loads(pickled_dict))
-    return dict_to_stored_hash(d)
+def serialize_dictionary(dictionary: BytesDictionary) -> bytes:
+    return pickle.dumps(dictionary)

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -3,13 +3,10 @@ import unittest
 import os
 import warnings
 
-from momento.incubating.aio.utils import (
-    convert_dict_values_to_bytes,
-    dict_to_stored_hash)
+from momento.incubating.aio.utils import convert_dict_items_to_bytes
 import momento.incubating.simple_cache_client as simple_cache_client
 
 from momento.cache_operation_types import CacheGetStatus
-from momento.incubating.cache_operation_types import CacheDictionaryValue
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
 _TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
@@ -89,11 +86,10 @@ class TestMomento(unittest.TestCase):
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
-            expected = dict_to_stored_hash(
-                convert_dict_values_to_bytes(dictionary))
-            self.assertEqual(expected, get_all_response.value(keys_as_bytes=True))
+            expected = convert_dict_items_to_bytes(dictionary)
+            self.assertEqual(expected, get_all_response.value_as_bytes())
 
-            expected = {k.decode("utf-8"): v for k, v in expected.items()}
+            expected = dictionary
             self.assertEqual(expected, get_all_response.value())
 
 

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -5,10 +5,7 @@ import warnings
 
 from momento.cache_operation_types import CacheGetStatus
 import momento.incubating.aio.simple_cache_client as simple_cache_client
-from momento.incubating.cache_operation_types import CacheDictionaryValue
-from momento.incubating.aio.utils import (
-    convert_dict_values_to_bytes,
-    dict_to_stored_hash)
+from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
 _AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
@@ -89,11 +86,10 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
-            expected = dict_to_stored_hash(
-                convert_dict_values_to_bytes(dictionary))
-            self.assertEqual(expected, get_all_response.value(keys_as_bytes=True))
+            expected = convert_dict_items_to_bytes(dictionary)
+            self.assertEqual(expected, get_all_response.value_as_bytes())
 
-            expected = {k.decode("utf-8"): v for k, v in expected.items()}
+            expected = dictionary
             self.assertEqual(expected, get_all_response.value())
 
 


### PR DESCRIPTION
Align CacheDictionaryGetAll with latest spec.

For the incubating dictionary type, we are limiting the convenience functions to returning either string->string or bytes->bytes. This simplifies the API to returned dictionaries for the most common use cases. See the latest incubating README for changes in user experience.
