### PR TITLE
feat: dictionary multi-get, unary set, and TTL.

### DIFF
--- a/src/momento/_utilities/_data_validation.py
+++ b/src/momento/_utilities/_data_validation.py
@@ -11,6 +11,9 @@ from ..cache_operation_types import (
 )
 
 
+DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
+
+
 def _make_metadata(cache_name: str) -> Metadata:
     return Metadata(("cache", cache_name))  # type: ignore[misc]
 
@@ -32,7 +35,10 @@ def _validate_cache_name(cache_name: str) -> None:
         raise errors.InvalidArgumentError("Cache name must be a non-empty string")
 
 
-def _as_bytes(data: Union[str, bytes], error_message: str) -> bytes:
+def _as_bytes(
+    data: Union[str, bytes],
+    error_message: Optional[str] = DEFAULT_STRING_CONVERSION_ERROR,
+) -> bytes:
     if isinstance(data, str):
         return data.encode("utf-8")
     if isinstance(data, bytes):

--- a/src/momento/_utilities/_serialization.py
+++ b/src/momento/_utilities/_serialization.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+
+def _bytes_to_string(value: bytes) -> str:
+    """Decode bytes to a UTF-8 string.
+
+    Args:
+        value (bytes): The bytes to decode
+
+    Returns:
+        str: UTF-8 representation of bytes
+
+    Raises:
+        UnicodeDecodeError
+    """
+    return value.decode(encoding="utf-8")
+
+
+def _bytes_dict_to_string_dict(dictionary: Dict[bytes, bytes]) -> Dict[str, str]:
+    return {_bytes_to_string(k): _bytes_to_string(v) for k, v in dictionary.items()}

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -16,21 +16,21 @@ This demonstrates the methods and response types for a dictionary data type in t
 2. Set one item in a dictionary
 
 ```python
->>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", key="key1", value="value1", refresh_ttl=False)
+>>> client.dictionary_set(cache_name="my-cache", dictionary_name="my-dictionary", key="key1", value="value1", refresh_ttl=False)
 CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key=b'key1', value=b'value1')
 ```
 
 3. Set multiple items in a dictionary
 
 ```python
->>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
+>>> client.dictionary_set(cache_name="my-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
 CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2': b'value2', b'key3': b'value3'})
 ```
 
 4. Get one value from a dictionary
 
 ```python
->>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1")
+>>> get_response = client.dictionary_get("my-cache", "my-dictionary", "key1")
 >>> get_response
 CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 
@@ -44,7 +44,7 @@ CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 5. Get multiple values from a dictionary
 
 ```python
->>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1", "key2", "key7")
+>>> get_response = client.dictionary_get("my-cache", "my-dictionary", "key1", "key2", "key7")
 >>> get_response
 CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
 
@@ -63,7 +63,7 @@ CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<C
 6. Get the entire dictionary
 
 ```python
->>> dictionary_get_all_response = client.dictionary_get_all(cache_name="my-example-cache", dictionary_name="my-dictionary")
+>>> dictionary_get_all_response = client.dictionary_get_all(cache_name="my-cache", dictionary_name="my-dictionary")
 >>> dictionary_get_all_response
 CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, result=<CacheGetStatus.HIT: 1>)
 

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -1,4 +1,5 @@
 # Incubating
+
 The `momento.incubating` package has work-in-progress features that may or may be be in the final version.
 
 ## Dictionary Methods
@@ -6,25 +7,62 @@ The `momento.incubating` package has work-in-progress features that may or may b
 This demonstrates the methods and response types for a dictionary data type in the cache.
 
 1. Initialize the cache
-```
+
+```python
 >>> import momento.incubating.simple_cache_client as scc
 >>> client = scc.init(auth_token=AUTH_TOKEN, item_default_ttl_seconds=DEFAULT_TTL)
 ```
 
-2. Set a dictionary
-```
->>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", dictionary={"key1": "value1", "key2": "value2"})
-CacheDictionarySetResponse(key='my-dictionary', value={'key1': 'value1', 'key2': 'value2'})
+2. Set one item in a dictionary
+
+```python
+>>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", key="key1", value="value1", refresh_ttl=False)
+CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key='key1', value='value1')
 ```
 
-3. Get a value from a dictionary
-```
->>> client.dictionary_get(cache_name="my-example-cache", dictionary_name="my-dictionary", key="key1")
-CacheDictionaryGetResponse(value='value1', result=<CacheGetStatus.HIT: 1>)
+3. Set multiple items in a dictionary
+
+```python
+>>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
+CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={'key2': 'value2', 'key3': 'value3'})
 ```
 
-4. Get the entire dictionary
+4. Get one value from a dictionary
+
+```python
+>>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1")
+>>> get_response
+CacheDictionaryGetUnaryResponse(value='value1', result=<CacheGetStatus.HIT: 1>)
+
+>>> get_response.status()
+<CacheGetStatus.HIT: 1>
+
+>>> get_response.value()
+'value2'
 ```
+
+5. Get multiple values from a dictionary
+
+```python
+>>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1", "key2", "key7")
+>>> get_response
+CacheDictionaryGetMultiResponse(values=['value1', 'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
+
+>>> get_response.to_list()
+[CacheDictionaryGetUnaryResponse(value='value1', result=<CacheGetStatus.HIT: 1>),
+ CacheDictionaryGetUnaryResponse(value='value2', result=<CacheGetStatus.HIT: 1>),
+ CacheDictionaryGetUnaryResponse(value=None, result=<CacheGetStatus.MISS: 2>)]
+
+ >>> get_response.status()
+ [<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>]
+
+ >>> get_response.values()
+['value1', 'value2', None]
+```
+
+6. Get the entire dictionary
+
+```python
 >>> dictionary_get_all_response = client.dictionary_get_all(cache_name="my-example-cache", dictionary_name="my-dictionary")
 >>> dictionary_get_all_response
 CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, result=<CacheGetStatus.HIT: 1>)
@@ -36,8 +74,9 @@ CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, re
 {b'key1': b'value1', b'key2': b'value2'}
 ```
 
-5. Interact with a returned dictionary
-```
+7. Interact with a returned dictionary
+
+```python
 >>> my_dictionary = dictionary_get_all_response.value()
 >>> my_dictionary["key1"]
 'value1'

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -23,7 +23,7 @@ CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key=b'key1', va
 3. Set multiple items in a dictionary
 
 ```python
->>> client.dictionary_set(cache_name="my-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
+>>> client.dictionary_multi_set(cache_name="my-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
 CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2': b'value2', b'key3': b'value3'})
 ```
 

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -17,14 +17,14 @@ This demonstrates the methods and response types for a dictionary data type in t
 
 ```python
 >>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", key="key1", value="value1", refresh_ttl=False)
-CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key='key1', value='value1')
+CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key=b'key1', value=b'value1')
 ```
 
 3. Set multiple items in a dictionary
 
 ```python
 >>> client.dictionary_set(cache_name="my-example-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
-CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={'key2': 'value2', 'key3': 'value3'})
+CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2': b'value2', b'key3': b'value3'})
 ```
 
 4. Get one value from a dictionary
@@ -32,7 +32,7 @@ CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={'key2': 
 ```python
 >>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1")
 >>> get_response
-CacheDictionaryGetUnaryResponse(value='value1', result=<CacheGetStatus.HIT: 1>)
+CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 
 >>> get_response.status()
 <CacheGetStatus.HIT: 1>
@@ -46,11 +46,11 @@ CacheDictionaryGetUnaryResponse(value='value1', result=<CacheGetStatus.HIT: 1>)
 ```python
 >>> get_response = client.dictionary_get("my-example-cache", "my-dictionary", "key1", "key2", "key7")
 >>> get_response
-CacheDictionaryGetMultiResponse(values=['value1', 'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
+CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
 
 >>> get_response.to_list()
-[CacheDictionaryGetUnaryResponse(value='value1', result=<CacheGetStatus.HIT: 1>),
- CacheDictionaryGetUnaryResponse(value='value2', result=<CacheGetStatus.HIT: 1>),
+[CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>),
+ CacheDictionaryGetUnaryResponse(value=b'value2', result=<CacheGetStatus.HIT: 1>),
  CacheDictionaryGetUnaryResponse(value=None, result=<CacheGetStatus.MISS: 2>)]
 
  >>> get_response.status()

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -30,7 +30,7 @@ CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2':
 4. Get one value from a dictionary
 
 ```python
->>> get_response = client.dictionary_get("my-cache", "my-dictionary", "key1")
+>>> get_response = client.dictionary_get(cache_name="my-cache", dictionary_name="my-dictionary", key="key1")
 >>> get_response
 CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 
@@ -44,7 +44,7 @@ CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 5. Get multiple values from a dictionary
 
 ```python
->>> get_response = client.dictionary_get("my-cache", "my-dictionary", "key1", "key2", "key7")
+>>> get_response = client.dictionary_multi_get("my-cache", "my-dictionary", "key1", "key2", "key7")
 >>> get_response
 CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
 

--- a/src/momento/incubating/_utilities/_serialization.py
+++ b/src/momento/incubating/_utilities/_serialization.py
@@ -17,4 +17,12 @@ def _bytes_to_string(value: bytes) -> str:
 
 
 def _bytes_dict_to_string_dict(dictionary: Dict[bytes, bytes]) -> Dict[str, str]:
+    """Convert byte-byte dictionary to string-string dictionary.
+
+    Args:
+        dictionary (Dict[bytes, bytes]): The dictionary to convert.
+
+    Returns:
+        Dict[str, str]: The dictionary with decoded items.
+    """
     return {_bytes_to_string(k): _bytes_to_string(v) for k, v in dictionary.items()}

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -39,6 +39,9 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         cache_name: str,
         dictionary_name: str,
         dictionary: Dictionary,
+        ttl_seconds: Optional[int] = None,
+        *,
+        refresh_ttl: bool
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
@@ -49,6 +52,9 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             cache_name (str): Name of the cache to store the dictionary in.
             dictionary_name (str): The name of the dictionary in the cache.
             dictionary (Dictionary): The items (key-value pairs) to be stored.
+            refresh_ttl (bool): If, when performing an update, to refresh the ttl.
+            ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
+            as a whole.
 
         Returns:
             CacheDictionarySetResponse: data stored in the cache

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -79,7 +79,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             raise ValueError("One of key or dictionary must be set")
 
         if dictionary is None:
-            dictionary = {key: value}
+            dictionary = {key: value}  # type: ignore
 
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         cached_dictionary: BytesDictionary = {}
@@ -88,12 +88,12 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
                 cast(bytes, dictionary_get_response.value_as_bytes())
             )
 
-        cached_dictionary.update(convert_dict_items_to_bytes(dictionary))
+        cached_dictionary.update(convert_dict_items_to_bytes(dictionary))  # type: ignore
 
         set_response = await self.set(
             cache_name, dictionary_name, serialize_dictionary(cached_dictionary)
         )
-        return CacheDictionarySetResponse(key=set_response._key, value=dictionary)
+        return CacheDictionarySetResponse(key=set_response._key, value=dictionary)  # type: ignore
 
     async def dictionary_get(
         self,

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -64,10 +64,11 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             cache_name (str): Name of the cache to store the dictionary in.
             dictionary_name (str): The name of the dictionary in the cache.
             key (Optional[DictionaryKey], optional): The key to set (unary set). Defaults to None.
-            value (Optional[DictionaryValue], optional): The value to set (unary set). Defaults to None.
-            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set). Defaults to None.
+                value (Optional[DictionaryValue], optional): The value to set (unary set). Defaults to None.
+            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set).
+                Defaults to None.
             ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
-            as a whole.
+                as a whole.
             refresh_ttl (bool): If, when performing an update, to refresh the ttl.
 
         Returns:
@@ -110,10 +111,10 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
 
         Returns:
             Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
-            For a single key, a wrapper for the value (if present) and
-            status (HIT or MISS).
+                For a single key, a wrapper for the value (if present) and
+                status (HIT or MISS).
 
-            For multiple keys, a wrapper over a list of values and statuses.
+                For multiple keys, a wrapper over a list of values and statuses.
         """
         if len(keys) == 0:
             raise ValueError("Argument keys must be non-empty")

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -100,11 +100,13 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         )
         if key is not None:
             return CacheDictionarySetUnaryResponse(
-                dictionary_name=set_response._key,
+                dictionary_name=dictionary_name,
                 key=_as_bytes(key),
                 value=_as_bytes(cast(DictionaryValue, value)),
             )
-        return CacheDictionarySetMultiResponse(dictionary_name=set_response._key, dictionary=bytes_dictionary)  # type: ignore
+        return CacheDictionarySetMultiResponse(
+            dictionary_name=dictionary_name, dictionary=bytes_dictionary
+        )
 
     async def dictionary_get(
         self,

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -41,15 +41,7 @@ class CacheDictionaryGetUnaryResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        value = self._value
-        try:
-            value = self.value()
-        except UnicodeDecodeError:
-            value = str(value)
-
-        return (
-            f"CacheDictionaryGetUnaryResponse(value={value!r}, result={self._result!r})"
-        )
+        return f"CacheDictionaryGetUnaryResponse(value={self._value!r}, result={self._result!r})"
 
 
 class CacheDictionaryGetMultiResponse:
@@ -86,24 +78,17 @@ class CacheDictionaryGetMultiResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        values = self._values
-        try:
-            values = self.values()  # type: ignore
-        except UnicodeDecodeError:
-            values = [str(v) for v in values]
-
-        return f"CacheDictionaryGetMultiResponse(values={values!r}, results={self._results!r})"
+        return f"CacheDictionaryGetMultiResponse(values={self._values!r}, results={self._results!r})"
 
 
 class CacheDictionarySetUnaryResponse:
-    def __init__(self, dictionary_name: bytes, key: bytes, value: bytes):
+    def __init__(self, dictionary_name: str, key: bytes, value: bytes):
         self._dictionary_name = dictionary_name
         self._key = key
         self._value = value
 
     def dictionary_name(self) -> str:
-        """Decodes key of item set in cache to a utf-8 string."""
-        return _bytes_to_string(self._dictionary_name)
+        return self._dictionary_name
 
     def key(self) -> str:
         return _bytes_to_string(self._key)
@@ -121,17 +106,16 @@ class CacheDictionarySetUnaryResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionarySetUnaryResponse(dictionary_name={self.dictionary_name()!r}, key={self._key!r}, value={self._value!r})"
+        return f"CacheDictionarySetUnaryResponse(dictionary_name={self._dictionary_name!r}, key={self._key!r}, value={self._value!r})"
 
 
 class CacheDictionarySetMultiResponse:
-    def __init__(self, dictionary_name: bytes, dictionary: BytesDictionary):
+    def __init__(self, dictionary_name: str, dictionary: BytesDictionary):
         self._dictionary_name = dictionary_name
         self._dictionary = dictionary
 
     def dictionary_name(self) -> str:
-        """Decodes key of item set in cache to a utf-8 string."""
-        return _bytes_to_string(self._dictionary_name)
+        return self._dictionary_name
 
     def dictionary(self) -> StringDictionary:
         return _bytes_dict_to_string_dict(self._dictionary)
@@ -143,7 +127,7 @@ class CacheDictionarySetMultiResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionarySetMultiResponse(dictionary_name={self.dictionary_name()!r}, dictionary={self._dictionary!r})"
+        return f"CacheDictionarySetMultiResponse(dictionary_name={self._dictionary_name!r}, dictionary={self._dictionary!r})"
 
 
 class CacheDictionaryGetAllResponse:

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -1,7 +1,7 @@
 from typing import cast, Dict, List, Optional, Union
 
 from ..cache_operation_types import CacheGetStatus
-from .._utilities._serialization import _bytes_to_string, _bytes_dict_to_string_dict
+from ._utilities._serialization import _bytes_to_string, _bytes_dict_to_string_dict
 
 
 # Dictionary related responses

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Dict, List, Optional, Union
+from typing import cast, Dict, List, Optional, Union
 
 from ..cache_operation_types import CacheGetStatus
 
@@ -29,7 +29,7 @@ class CacheDictionaryGetUnaryResponse:
     def status(self) -> CacheGetStatus:
         return self._result
 
-    def __eq__(self, other: Any):
+    def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, CacheDictionaryGetUnaryResponse)
             and self._value == other._value

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -1,11 +1,12 @@
-from typing import Optional
+from typing import Optional, Union
 import warnings
 
 from . import INCUBATING_WARNING_MSG
 from .aio import simple_cache_client as aio
 from .._async_utils import wait_for_coroutine
 from .cache_operation_types import (
-    CacheDictionaryGetResponse,
+    CacheDictionaryGetUnaryResponse,
+    CacheDictionaryGetMultiResponse,
     CacheDictionarySetResponse,
     CacheDictionaryGetAllResponse,
     DictionaryKey,
@@ -70,8 +71,8 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        key: DictionaryKey,
-    ) -> CacheDictionaryGetResponse:
+        *keys: DictionaryKey,
+    ) -> Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
         """Retrieve a dictionary value from the cache.
 
         Args:
@@ -80,10 +81,14 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             key (DictionaryKey): The item to index in the dictionary.
 
         Returns:
-            CacheDictionaryGetResponse: Value (if present) and status (HIT or MISS).
+            Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
+            For a single key, a wrapper for the value (if present) and
+            status (HIT or MISS).
+
+            For multiple keys, a wrapper over a list of values and statuses.
         """
         coroutine = self._momento_async_client.dictionary_get(
-            cache_name, dictionary_name, key
+            cache_name, dictionary_name, *keys
         )
         return wait_for_coroutine(self._loop, coroutine)
 

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -7,7 +7,8 @@ from .._async_utils import wait_for_coroutine
 from .cache_operation_types import (
     CacheDictionaryGetUnaryResponse,
     CacheDictionaryGetMultiResponse,
-    CacheDictionarySetResponse,
+    CacheDictionarySetUnaryResponse,
+    CacheDictionarySetMultiResponse,
     CacheDictionaryGetAllResponse,
     DictionaryKey,
     DictionaryValue,
@@ -44,7 +45,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         ttl_seconds: Optional[int] = None,
         *,
         refresh_ttl: bool,
-    ) -> CacheDictionarySetResponse:
+    ) -> Union[CacheDictionarySetUnaryResponse, CacheDictionarySetMultiResponse]:
         """Store dictionary items (key-value pairs) in the cache.
 
         Inserts items from `dictionary` into a dictionary `dictionary_name`.
@@ -70,7 +71,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             refresh_ttl (bool): If, when performing an update, to refresh the ttl.
 
         Returns:
-            CacheDictionarySetResponse: data stored in the cache
+            Union[CacheDictionarySetUnaryResponse, CacheDictionarySetMultiResponse]: data stored in the cache
         """
         coroutine = self._momento_async_client.dictionary_set(
             cache_name,

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -37,6 +37,9 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         cache_name: str,
         dictionary_name: str,
         dictionary: Dictionary,
+        ttl_seconds: Optional[int] = None,
+        *,
+        refresh_ttl: bool
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
@@ -47,12 +50,19 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             cache_name (str): Name of the cache to store the dictionary in.
             dictionary_name (str): The name of the dictionary in the cache.
             dictionary (Dictionary): The items (key-value pairs) to be stored.
+            refresh_ttl (bool): If, when performing an update, to refresh the ttl.
+            ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
+            as a whole.
 
         Returns:
             CacheDictionarySetResponse: data stored in the cache
         """
         coroutine = self._momento_async_client.dictionary_set(
-            cache_name, dictionary_name, dictionary
+            cache_name,
+            dictionary_name,
+            dictionary,
+            ttl_seconds,
+            refresh_ttl=refresh_ttl,
         )
         return wait_for_coroutine(self._loop, coroutine)
 

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -10,6 +10,7 @@ from .cache_operation_types import (
     CacheDictionarySetResponse,
     CacheDictionaryGetAllResponse,
     DictionaryKey,
+    DictionaryValue,
     Dictionary,
 )
 from ..simple_cache_client import SimpleCacheClient
@@ -37,23 +38,35 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        dictionary: Dictionary,
+        key: Optional[DictionaryKey] = None,
+        value: Optional[DictionaryValue] = None,
+        dictionary: Optional[Dictionary] = None,
         ttl_seconds: Optional[int] = None,
         *,
-        refresh_ttl: bool
+        refresh_ttl: bool,
     ) -> CacheDictionarySetResponse:
         """Store dictionary items (key-value pairs) in the cache.
 
         Inserts items from `dictionary` into a dictionary `dictionary_name`.
         Updates (overwrites) values if the key already exists.
 
+        Items may be set in one of two ways:
+        - the function may be run with either a single item to set, `key` and `value, or
+        - multiple items with the `dictionary` argument which accepts a `Dictionary`.
+
+        To illustrate:
+        >>> client.dictionary_set(cache_name, dictionary_name, key="key" value="value")
+        >>> client.dictionary_set(cache_name, dictionary_name, dictionary={"key1": "value1", "key2": "value2"})
+
         Args:
             cache_name (str): Name of the cache to store the dictionary in.
             dictionary_name (str): The name of the dictionary in the cache.
-            dictionary (Dictionary): The items (key-value pairs) to be stored.
-            refresh_ttl (bool): If, when performing an update, to refresh the ttl.
+            key (Optional[DictionaryKey], optional): The key to set (unary set). Defaults to None.
+            value (Optional[DictionaryValue], optional): The value to set (unary set). Defaults to None.
+            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set). Defaults to None.
             ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
             as a whole.
+            refresh_ttl (bool): If, when performing an update, to refresh the ttl.
 
         Returns:
             CacheDictionarySetResponse: data stored in the cache
@@ -61,6 +74,8 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         coroutine = self._momento_async_client.dictionary_set(
             cache_name,
             dictionary_name,
+            key,
+            value,
             dictionary,
             ttl_seconds,
             refresh_ttl=refresh_ttl,

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -63,9 +63,10 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             dictionary_name (str): The name of the dictionary in the cache.
             key (Optional[DictionaryKey], optional): The key to set (unary set). Defaults to None.
             value (Optional[DictionaryValue], optional): The value to set (unary set). Defaults to None.
-            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set). Defaults to None.
+            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set).
+                Defaults to None.
             ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
-            as a whole.
+                as a whole.
             refresh_ttl (bool): If, when performing an update, to refresh the ttl.
 
         Returns:
@@ -97,10 +98,10 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
 
         Returns:
             Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
-            For a single key, a wrapper for the value (if present) and
-            status (HIT or MISS).
+                For a single key, a wrapper for the value (if present) and
+                status (HIT or MISS).
 
-            For multiple keys, a wrapper over a list of values and statuses.
+                For multiple keys, a wrapper over a list of values and statuses.
         """
         coroutine = self._momento_async_client.dictionary_get(
             cache_name, dictionary_name, *keys

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -110,23 +110,42 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        *keys: DictionaryKey,
-    ) -> Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
+        key: DictionaryKey,
+    ) -> CacheDictionaryGetUnaryResponse:
         """Retrieve a dictionary value from the cache.
 
         Args:
             cache_name (str): Name of the cache to get the dictionary from.
             dictionary_name (str): Name of the dictionary to query.
-            key (DictionaryKey): The item to index in the dictionary.
+            key (DictionaryKey): The key to index in the dictionary.
 
         Returns:
-            Union[CacheDictionaryGetUnaryResponse, CacheDictionaryGetMultiResponse]:
-                For a single key, a wrapper for the value (if present) and
-                status (HIT or MISS).
-
-                For multiple keys, a wrapper over a list of values and statuses.
+            CacheDictionaryGetUnaryResponse: A wrapper for the value (if present)
+                and status (HIT or MISS).
         """
         coroutine = self._momento_async_client.dictionary_get(
+            cache_name, dictionary_name, key
+        )
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def dictionary_multi_get(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        *keys: DictionaryKey,
+    ) -> CacheDictionaryGetMultiResponse:
+        """Retrieve dictionary values from the cache.
+
+        Args:
+            cache_name (str): Name of the cache to get the dictionary from.
+            dictionary_name (str): Name of the dictionary to query.
+            keys (DictionaryKey): The item(s) to index in the dictionary.
+
+        Returns:
+            CacheDictionaryGetMultiResponse: a wrapper over a list of values
+                and statuses.
+        """
+        coroutine = self._momento_async_client.dictionary_multi_get(
             cache_name, dictionary_name, *keys
         )
         return wait_for_coroutine(self._loop, coroutine)

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -39,45 +39,67 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         cache_name: str,
         dictionary_name: str,
-        key: Optional[DictionaryKey] = None,
-        value: Optional[DictionaryValue] = None,
-        dictionary: Optional[Dictionary] = None,
+        key: DictionaryKey,
+        value: DictionaryValue,
         ttl_seconds: Optional[int] = None,
         *,
         refresh_ttl: bool,
-    ) -> Union[CacheDictionarySetUnaryResponse, CacheDictionarySetMultiResponse]:
-        """Store dictionary items (key-value pairs) in the cache.
+    ) -> CacheDictionarySetUnaryResponse:
+        """Store a dictionary item in the cache.
 
-        Inserts items from `dictionary` into a dictionary `dictionary_name`.
+        Inserts a `value` for `key` in into a dictionary `dictionary_name`.
         Updates (overwrites) values if the key already exists.
-
-        Items may be set in one of two ways:
-        - the function may be run with either a single item to set, `key` and `value, or
-        - multiple items with the `dictionary` argument which accepts a `Dictionary`.
-
-        To illustrate:
-        >>> client.dictionary_set(cache_name, dictionary_name, key="key" value="value")
-        >>> client.dictionary_set(cache_name, dictionary_name, dictionary={"key1": "value1", "key2": "value2"})
 
         Args:
             cache_name (str): Name of the cache to store the dictionary in.
             dictionary_name (str): The name of the dictionary in the cache.
-            key (Optional[DictionaryKey], optional): The key to set (unary set). Defaults to None.
-            value (Optional[DictionaryValue], optional): The value to set (unary set). Defaults to None.
-            dictionary (Optional[Dictionary], optional): The items (key-value pairs) to be stored (multi set).
-                Defaults to None.
+            key (DictionaryKey): The key to set.
+            value (DictionaryValue): The value to store.
             ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
                 as a whole.
             refresh_ttl (bool): If, when performing an update, to refresh the ttl.
 
         Returns:
-            Union[CacheDictionarySetUnaryResponse, CacheDictionarySetMultiResponse]: data stored in the cache
+            CacheDictionarySetUnaryResponse: data stored in the cache
         """
         coroutine = self._momento_async_client.dictionary_set(
             cache_name,
             dictionary_name,
             key,
             value,
+            ttl_seconds,
+            refresh_ttl=refresh_ttl,
+        )
+        return wait_for_coroutine(self._loop, coroutine)
+
+    def dictionary_multi_set(
+        self,
+        cache_name: str,
+        dictionary_name: str,
+        dictionary: Dictionary,
+        ttl_seconds: Optional[int] = None,
+        *,
+        refresh_ttl: bool,
+    ) -> CacheDictionarySetMultiResponse:
+        """Store dictionary items (key-value pairs) in the cache.
+
+        Inserts items from `dictionary` into a dictionary `dictionary_name`.
+        Updates (overwrites) values if the key already exists.
+
+        Args:
+            cache_name (str): Name of the cache to store the dictionary in.
+            dictionary_name (str): The name of the dictionary in the cache.
+            dictionary (Dictionary): The items (key-value pairs) to be stored.
+            ttl_seconds (Optional[int], optional): Time to live in seconds for the dictionary
+                as a whole.
+            refresh_ttl (bool): If, when performing an update, to refresh the ttl.
+
+        Returns:
+            CacheDictionarySetMultiResponse: data stored in the cache
+        """
+        coroutine = self._momento_async_client.dictionary_multi_set(
+            cache_name,
+            dictionary_name,
             dictionary,
             ttl_seconds,
             refresh_ttl=refresh_ttl,

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -54,7 +54,7 @@ class TestMomento(unittest.TestCase):
         ) as simple_cache:
             # Test with key as string
             dictionary = {"key1": "value1"}
-            set_response = simple_cache.dictionary_set(
+            set_response = simple_cache.dictionary_multi_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict",
                 dictionary=dictionary,
@@ -65,7 +65,7 @@ class TestMomento(unittest.TestCase):
 
             # Test as bytes
             dictionary = {b"key1": b"value1"}
-            set_response = simple_cache.dictionary_set(
+            set_response = simple_cache.dictionary_multi_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict2",
                 dictionary=dictionary,
@@ -97,28 +97,11 @@ class TestMomento(unittest.TestCase):
             )
             self.assertEqual(value, get_response.value())
 
-    def test_dictionary_set_invalid(self):
-        with simple_cache_client.init(
-            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
-        ) as simple_cache:
-            with self.assertRaises(ValueError):
-                simple_cache.dictionary_set(_TEST_CACHE_NAME, "blah", refresh_ttl=False)
-
-            with self.assertRaises(ValueError):
-                simple_cache.dictionary_set(
-                    _TEST_CACHE_NAME,
-                    "blah",
-                    key="key",
-                    value="value",
-                    dictionary={"key": "value"},
-                    refresh_ttl=False,
-                )
-
     def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            simple_cache.dictionary_set(
+            simple_cache.dictionary_multi_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict3",
                 dictionary={"key1": "value1"},
@@ -153,7 +136,7 @@ class TestMomento(unittest.TestCase):
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"mydict4-{i}"
 
-                simple_cache.dictionary_set(
+                simple_cache.dictionary_multi_set(
                     cache_name=_TEST_CACHE_NAME,
                     dictionary_name=dictionary_name,
                     dictionary=dictionary,
@@ -177,7 +160,7 @@ class TestMomento(unittest.TestCase):
             dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
-            simple_cache.dictionary_set(
+            simple_cache.dictionary_multi_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name=dictionary_name,
                 dictionary=dictionary,
@@ -228,7 +211,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
-            simple_cache.dictionary_set(
+            simple_cache.dictionary_multi_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict6",
                 dictionary=dictionary,

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -9,8 +9,8 @@ import momento.incubating.simple_cache_client as simple_cache_client
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
 
-_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
-_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
+_TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
 _DEFAULT_TTL_SECONDS = 60
 
 
@@ -22,79 +22,128 @@ class TestMomento(unittest.TestCase):
                 pass
 
     def test_dictionary_get_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key")
+                _TEST_CACHE_NAME, "hello world", "key"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_multi_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3")
+                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
+            )
             self.assertEqual(3, len(get_response.to_list()))
-            self.assertTrue(all(result == CacheGetStatus.MISS for result in get_response.status()))
+            self.assertTrue(
+                all(result == CacheGetStatus.MISS for result in get_response.status())
+            )
             self.assertEqual(3, len(get_response.values()))
             self.assertTrue(all(value is None for value in get_response.values()))
             self.assertEqual(3, len(get_response.values_as_bytes()))
-            self.assertTrue(all(value is None for value in get_response.values_as_bytes()))
+            self.assertTrue(
+                all(value is None for value in get_response.values_as_bytes())
+            )
 
     def test_dictionary_set_response(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             # Test with key as string
             dictionary = {"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("mydict", set_response.key())
-            self.assertEqual(dictionary, set_response.value())
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict",
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
+            self.assertEqual("mydict", set_response.dictionary_name())
+            self.assertEqual(dictionary, set_response.dictionary())
 
-            # Test key as bytes
-            dictionary={b"key1": "value1"}
+            # Test as bytes
+            dictionary = {b"key1": b"value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict2", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("mydict2", set_response.key())
-            self.assertEqual(dictionary, set_response.value())
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict2",
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
+            self.assertEqual("mydict2", set_response.dictionary_name())
+            self.assertEqual(dictionary, set_response.dictionary_as_bytes())
 
     def test_dictionary_set_unary(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary_name = "mydict20"
             key, value = "my-key", "my-value"
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key, value=value, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                key=key,
+                value=value,
+                refresh_ttl=False,
+            )
 
-            self.assertEqual(dictionary_name, set_response.key())
-            self.assertEqual({key: value}, set_response.value())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
+            self.assertEqual(key, set_response.key())
+            self.assertEqual(value, set_response.value())
 
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, key)
+                _TEST_CACHE_NAME, dictionary_name, key
+            )
             self.assertEqual(value, get_response.value())
 
     def test_dictionary_set_invalid(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(ValueError):
-                simple_cache.dictionary_set(
-                    _TEST_CACHE_NAME, "blah", refresh_ttl=False)
+                simple_cache.dictionary_set(_TEST_CACHE_NAME, "blah", refresh_ttl=False)
 
             with self.assertRaises(ValueError):
                 simple_cache.dictionary_set(
-                    _TEST_CACHE_NAME, "blah", key="key", value="value", dictionary={"key": "value"}, refresh_ttl=False)
+                    _TEST_CACHE_NAME,
+                    "blah",
+                    key="key",
+                    value="value",
+                    dictionary={"key": "value"},
+                    refresh_ttl=False,
+                )
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", dictionary={"key1": "value1"}, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict3",
+                dictionary={"key1": "value1"},
+                refresh_ttl=False,
+            )
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "mydict3", "key2")
+                _TEST_CACHE_NAME, "mydict3", "key2"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_zero_length_keys(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(ValueError):
                 simple_cache.dictionary_get(_TEST_CACHE_NAME, "my-dictionary", *[])
 
     def test_dictionary_get_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
-            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+            for i, (key_is_str, value_is_str) in enumerate(
+                itertools.product((True, False), (True, False))
+            ):
                 key, value = "key1", "value1"
                 if not key_is_str:
                     key = key.encode()
@@ -105,52 +154,89 @@ class TestMomento(unittest.TestCase):
                 dictionary_name = f"mydict4-{i}"
 
                 simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
+                    cache_name=_TEST_CACHE_NAME,
+                    dictionary_name=dictionary_name,
+                    dictionary=dictionary,
+                    refresh_ttl=False,
+                )
                 get_response = simple_cache.dictionary_get(
-                    _TEST_CACHE_NAME, dictionary_name, key)
+                    _TEST_CACHE_NAME, dictionary_name, key
+                )
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
-                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+                self.assertEqual(
+                    value,
+                    get_response.value()
+                    if value_is_str
+                    else get_response.value_as_bytes(),
+                )
 
     def test_dictionary_get_multi_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3")
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
+            )
 
             values = ["value1", "value2", "value3"]
-            self.assertEqual(get_response.values(), values) 
-            self.assertEqual(get_response.values_as_bytes(), [b"value1", b"value2", b"value3"])
+            self.assertEqual(get_response.values(), values)
+            self.assertEqual(
+                get_response.values_as_bytes(), [b"value1", b"value2", b"value3"]
+            )
 
-            results = [CacheGetStatus.HIT]*3
+            results = [CacheGetStatus.HIT] * 3
             self.assertTrue(get_response.status(), results)
 
-            individual_responses = [CacheDictionaryGetUnaryResponse(value.encode("utf-8"), result) for value, result in zip(values, results)]
+            individual_responses = [
+                CacheDictionaryGetUnaryResponse(value.encode("utf-8"), result)
+                for value, result in zip(values, results)
+            ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5")
-            self.assertTrue(get_response.status(), [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS])
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
+            )
+            self.assertTrue(
+                get_response.status(),
+                [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS],
+            )
             self.assertTrue(get_response.values(), ["value1", "value2", None])
-            self.assertTrue(get_response.values_as_bytes(), [b"value1", b"value2", None])
+            self.assertTrue(
+                get_response.values_as_bytes(), [b"value1", b"value2", None]
+            )
 
     def test_dictionary_get_all_miss(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_all_hit(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6", dictionary=dictionary, refresh_ttl=False
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict6",
+                dictionary=dictionary,
+                refresh_ttl=False,
             )
             get_all_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6"
+            )
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = convert_dict_items_to_bytes(dictionary)
@@ -160,5 +246,5 @@ class TestMomento(unittest.TestCase):
             self.assertEqual(expected, get_all_response.value())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -26,7 +26,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key"
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key"
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -34,7 +34,7 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            get_response = simple_cache.dictionary_get(
+            get_response = simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
             )
             self.assertEqual(3, len(get_response.to_list()))
@@ -93,7 +93,7 @@ class TestMomento(unittest.TestCase):
             self.assertEqual(value, set_response.value())
 
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, key
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key
             )
             self.assertEqual(value, get_response.value())
 
@@ -108,7 +108,7 @@ class TestMomento(unittest.TestCase):
                 refresh_ttl=False,
             )
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "mydict3", "key2"
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", key="key2"
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -117,7 +117,9 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             with self.assertRaises(ValueError):
-                simple_cache.dictionary_get(_TEST_CACHE_NAME, "my-dictionary", *[])
+                simple_cache.dictionary_multi_get(
+                    _TEST_CACHE_NAME, "my-dictionary", *[]
+                )
 
     def test_dictionary_get_hit(self):
         with simple_cache_client.init(
@@ -143,7 +145,9 @@ class TestMomento(unittest.TestCase):
                     refresh_ttl=False,
                 )
                 get_response = simple_cache.dictionary_get(
-                    _TEST_CACHE_NAME, dictionary_name, key
+                    cache_name=_TEST_CACHE_NAME,
+                    dictionary_name=dictionary_name,
+                    key=key,
                 )
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
                 self.assertEqual(
@@ -166,7 +170,7 @@ class TestMomento(unittest.TestCase):
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            get_response = simple_cache.dictionary_get(
+            get_response = simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
             )
 
@@ -185,7 +189,7 @@ class TestMomento(unittest.TestCase):
             ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
-            get_response = simple_cache.dictionary_get(
+            get_response = simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
             )
             self.assertTrue(

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -31,21 +31,21 @@ class TestMomento(unittest.TestCase):
             # Test with key as string
             dictionary = {"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary, refresh_ttl=False)
             self.assertEqual("myhash", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
             dictionary={b"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary, refresh_ttl=False)
             self.assertEqual("myhash2", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"}, refresh_ttl=False)
             get_response = simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
@@ -64,7 +64,7 @@ class TestMomento(unittest.TestCase):
                 dictionary_name = f"myhash4-{i}"
 
                 simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
                 get_response = simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
@@ -80,7 +80,7 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary, refresh_ttl=False
             )
             get_all_response = simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")

--- a/tests/incubating/test_momento.py
+++ b/tests/incubating/test_momento.py
@@ -43,23 +43,47 @@ class TestMomento(unittest.TestCase):
             # Test with key as string
             dictionary = {"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("myhash", set_response.key())
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict", dictionary=dictionary, refresh_ttl=False)
+            self.assertEqual("mydict", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
             dictionary={b"key1": "value1"}
             set_response = simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("myhash2", set_response.key())
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict2", dictionary=dictionary, refresh_ttl=False)
+            self.assertEqual("mydict2", set_response.key())
             self.assertEqual(dictionary, set_response.value())
+
+    def test_dictionary_set_unary(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            dictionary_name = "mydict20"
+            key, value = "my-key", "my-value"
+            set_response = simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key, value=value, refresh_ttl=False)
+
+            self.assertEqual(dictionary_name, set_response.key())
+            self.assertEqual({key: value}, set_response.value())
+
+            get_response = simple_cache.dictionary_get(
+                _TEST_CACHE_NAME, dictionary_name, key)
+            self.assertEqual(value, get_response.value())
+
+    def test_dictionary_set_invalid(self):
+        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            with self.assertRaises(ValueError):
+                simple_cache.dictionary_set(
+                    _TEST_CACHE_NAME, "blah", refresh_ttl=False)
+
+            with self.assertRaises(ValueError):
+                simple_cache.dictionary_set(
+                    _TEST_CACHE_NAME, "blah", key="key", value="value", dictionary={"key": "value"}, refresh_ttl=False)
 
     def test_dictionary_set_and_dictionary_get_missing_key(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"}, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", dictionary={"key1": "value1"}, refresh_ttl=False)
             get_response = simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "myhash3", "key2")
+                _TEST_CACHE_NAME, "mydict3", "key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_zero_length_keys(self):
@@ -78,7 +102,7 @@ class TestMomento(unittest.TestCase):
                     value = value.encode()
                 dictionary = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"myhash4-{i}"
+                dictionary_name = f"mydict4-{i}"
 
                 simple_cache.dictionary_set(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
@@ -89,7 +113,7 @@ class TestMomento(unittest.TestCase):
 
     def test_dictionary_get_multi_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            dictionary_name = "mydictionary10"
+            dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
             simple_cache.dictionary_set(
@@ -116,17 +140,17 @@ class TestMomento(unittest.TestCase):
     def test_dictionary_get_all_miss(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     def test_dictionary_get_all_hit(self):
         with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary, refresh_ttl=False
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6", dictionary=dictionary, refresh_ttl=False
             )
             get_all_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = convert_dict_items_to_bytes(dictionary)

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -43,23 +43,47 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             # Test with key as string
             dictionary = {"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("myhash", set_response.key())
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict", dictionary=dictionary, refresh_ttl=False)
+            self.assertEqual("mydict", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
             dictionary = dictionary={b"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("myhash2", set_response.key())
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict2", dictionary=dictionary, refresh_ttl=False)
+            self.assertEqual("mydict2", set_response.key())
             self.assertEqual(dictionary, set_response.value())
+
+    async def test_dictionary_set_unary(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            dictionary_name = "mydict20"
+            key, value = "my-key", "my-value"
+            set_response = await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key, value=value, refresh_ttl=False)
+
+            self.assertEqual(dictionary_name, set_response.key())
+            self.assertEqual({key: value}, set_response.value())
+
+            get_response = await simple_cache.dictionary_get(
+                _TEST_CACHE_NAME, dictionary_name, key)
+            self.assertEqual(value, get_response.value())
+
+    async def test_dictionary_set_invalid(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            with self.assertRaises(ValueError):
+                await simple_cache.dictionary_set(
+                    _TEST_CACHE_NAME, "blah", refresh_ttl=False)
+
+            with self.assertRaises(ValueError):
+                await simple_cache.dictionary_set(
+                    _TEST_CACHE_NAME, "blah", key="key", value="value", dictionary={"key": "value"}, refresh_ttl=False)
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"}, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", dictionary={"key1": "value1"}, refresh_ttl=False)
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "myhash3", "key2")
+                _TEST_CACHE_NAME, "mydict3", "key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_zero_length_keys(self):
@@ -78,7 +102,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                     value = value.encode()
                 dictionary = {key: value}
                 # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"myhash4-{i}"
+                dictionary_name = f"mydict4-{i}"
 
                 await simple_cache.dictionary_set(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
@@ -89,7 +113,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
     async def test_dictionary_get_multi_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            dictionary_name = "mydictionary10"
+            dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
             await simple_cache.dictionary_set(
@@ -116,17 +140,17 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_dictionary_get_all_miss(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash5")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_all_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary, refresh_ttl=False
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6", dictionary=dictionary, refresh_ttl=False
             )
             get_all_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6")
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = convert_dict_items_to_bytes(dictionary)

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -44,15 +44,15 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             dictionary = {"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="mydict", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("mydict", set_response.key())
-            self.assertEqual(dictionary, set_response.value())
+            self.assertEqual("mydict", set_response.dictionary_name())
+            self.assertEqual(dictionary, set_response.dictionary())
 
-            # Test key as bytes
-            dictionary = dictionary={b"key1": "value1"}
+            # Test as bytes
+            dictionary = dictionary={b"key1": b"value1"}
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="mydict2", dictionary=dictionary, refresh_ttl=False)
-            self.assertEqual("mydict2", set_response.key())
-            self.assertEqual(dictionary, set_response.value())
+            self.assertEqual("mydict2", set_response.dictionary_name())
+            self.assertEqual(dictionary, set_response.dictionary_as_bytes())
 
     async def test_dictionary_set_unary(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -61,8 +61,9 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key, value=value, refresh_ttl=False)
 
-            self.assertEqual(dictionary_name, set_response.key())
-            self.assertEqual({key: value}, set_response.value())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
+            self.assertEqual(key, set_response.key())
+            self.assertEqual(value, set_response.value())
 
             get_response = await simple_cache.dictionary_get(
                 _TEST_CACHE_NAME, dictionary_name, key)

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -26,7 +26,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key"
+                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key"
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -34,7 +34,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            get_response = await simple_cache.dictionary_get(
+            get_response = await simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
             )
             self.assertEqual(3, len(get_response.to_list()))
@@ -93,7 +93,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual(value, set_response.value())
 
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, key
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key
             )
             self.assertEqual(value, get_response.value())
 
@@ -109,7 +109,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 refresh_ttl=False,
             )
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "mydict3", "key2"
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", key="key2"
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -118,7 +118,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             with self.assertRaises(ValueError):
-                await simple_cache.dictionary_get(
+                await simple_cache.dictionary_multi_get(
                     _TEST_CACHE_NAME, "my-dictionary", *[]
                 )
 
@@ -146,7 +146,9 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                     refresh_ttl=False,
                 )
                 get_response = await simple_cache.dictionary_get(
-                    _TEST_CACHE_NAME, dictionary_name, key
+                    cache_name=_TEST_CACHE_NAME,
+                    dictionary_name=dictionary_name,
+                    key=key,
                 )
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
                 self.assertEqual(
@@ -169,7 +171,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            get_response = await simple_cache.dictionary_get(
+            get_response = await simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
             )
 
@@ -188,7 +190,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
-            get_response = await simple_cache.dictionary_get(
+            get_response = await simple_cache.dictionary_multi_get(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
             )
             self.assertTrue(

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -31,21 +31,21 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             # Test with key as string
             dictionary = {"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash", dictionary=dictionary, refresh_ttl=False)
             self.assertEqual("myhash", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
             # Test key as bytes
             dictionary = dictionary={b"key1": "value1"}
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary)
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash2", dictionary=dictionary, refresh_ttl=False)
             self.assertEqual("myhash2", set_response.key())
             self.assertEqual(dictionary, set_response.value())
 
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"})
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"}, refresh_ttl=False)
             get_response = await simple_cache.dictionary_get(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
@@ -64,7 +64,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 dictionary_name = f"myhash4-{i}"
 
                 await simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary)
+                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
                 get_response = await simple_cache.dictionary_get(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
@@ -80,7 +80,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary
+                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6", dictionary=dictionary, refresh_ttl=False
             )
             get_all_response = await simple_cache.dictionary_get_all(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash6")

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -9,8 +9,8 @@ import momento.incubating.aio.simple_cache_client as simple_cache_client
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
-_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
-_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
+_TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
 _DEFAULT_TTL_SECONDS = 60
 
 
@@ -22,80 +22,114 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 pass
 
     async def test_dictionary_get_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key")
+                _TEST_CACHE_NAME, "hello world", "key"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_multi_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3")
+                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
+            )
             self.assertEqual(3, len(get_response.to_list()))
-            self.assertTrue(all(result == CacheGetStatus.MISS for result in get_response.status()))
+            self.assertTrue(
+                all(result == CacheGetStatus.MISS for result in get_response.status())
+            )
             self.assertEqual(3, len(get_response.values()))
             self.assertTrue(all(value is None for value in get_response.values()))
             self.assertEqual(3, len(get_response.values_as_bytes()))
-            self.assertTrue(all(value is None for value in get_response.values_as_bytes()))
+            self.assertTrue(
+                all(value is None for value in get_response.values_as_bytes())
+            )
 
     async def test_dictionary_set_response(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             # Test with key as string
             dictionary = {"key1": "value1"}
-            set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict", dictionary=dictionary, refresh_ttl=False)
+            set_response = await simple_cache.dictionary_multi_set(
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict",
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
             self.assertEqual("mydict", set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary())
 
             # Test as bytes
-            dictionary = dictionary={b"key1": b"value1"}
-            set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict2", dictionary=dictionary, refresh_ttl=False)
+            dictionary = dictionary = {b"key1": b"value1"}
+            set_response = await simple_cache.dictionary_multi_set(
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict2",
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
             self.assertEqual("mydict2", set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary_as_bytes())
 
     async def test_dictionary_set_unary(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary_name = "mydict20"
             key, value = "my-key", "my-value"
             set_response = await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key, value=value, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                key=key,
+                value=value,
+                refresh_ttl=False,
+            )
 
             self.assertEqual(dictionary_name, set_response.dictionary_name())
             self.assertEqual(key, set_response.key())
             self.assertEqual(value, set_response.value())
 
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, key)
+                _TEST_CACHE_NAME, dictionary_name, key
+            )
             self.assertEqual(value, get_response.value())
 
-    async def test_dictionary_set_invalid(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
-            with self.assertRaises(ValueError):
-                await simple_cache.dictionary_set(
-                    _TEST_CACHE_NAME, "blah", refresh_ttl=False)
-
-            with self.assertRaises(ValueError):
-                await simple_cache.dictionary_set(
-                    _TEST_CACHE_NAME, "blah", key="key", value="value", dictionary={"key": "value"}, refresh_ttl=False)
-
     async def test_dictionary_set_and_dictionary_get_missing_key(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", dictionary={"key1": "value1"}, refresh_ttl=False)
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict3",
+                key="key1",
+                value="value1",
+                refresh_ttl=False,
+            )
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, "mydict3", "key2")
+                _TEST_CACHE_NAME, "mydict3", "key2"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_zero_length_keys(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(ValueError):
-                await simple_cache.dictionary_get(_TEST_CACHE_NAME, "my-dictionary", *[])
+                await simple_cache.dictionary_get(
+                    _TEST_CACHE_NAME, "my-dictionary", *[]
+                )
 
     async def test_dictionary_get_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
-            for i, (key_is_str, value_is_str) in enumerate(itertools.product((True, False), (True, False))):
+            for i, (key_is_str, value_is_str) in enumerate(
+                itertools.product((True, False), (True, False))
+            ):
                 key, value = "key1", "value1"
                 if not key_is_str:
                     key = key.encode()
@@ -105,53 +139,90 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"mydict4-{i}"
 
-                await simple_cache.dictionary_set(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
+                await simple_cache.dictionary_multi_set(
+                    cache_name=_TEST_CACHE_NAME,
+                    dictionary_name=dictionary_name,
+                    dictionary=dictionary,
+                    refresh_ttl=False,
+                )
                 get_response = await simple_cache.dictionary_get(
-                    _TEST_CACHE_NAME, dictionary_name, key)
+                    _TEST_CACHE_NAME, dictionary_name, key
+                )
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
-                self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+                self.assertEqual(
+                    value,
+                    get_response.value()
+                    if value_is_str
+                    else get_response.value_as_bytes(),
+                )
 
     async def test_dictionary_get_multi_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
-            await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
+            await simple_cache.dictionary_multi_set(
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                dictionary=dictionary,
+                refresh_ttl=False,
+            )
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3")
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
+            )
 
             values = ["value1", "value2", "value3"]
-            self.assertEqual(get_response.values(), values) 
-            self.assertEqual(get_response.values_as_bytes(), [b"value1", b"value2", b"value3"])
+            self.assertEqual(get_response.values(), values)
+            self.assertEqual(
+                get_response.values_as_bytes(), [b"value1", b"value2", b"value3"]
+            )
 
-            results = [CacheGetStatus.HIT]*3
+            results = [CacheGetStatus.HIT] * 3
             self.assertTrue(get_response.status(), results)
 
-            individual_responses = [CacheDictionaryGetUnaryResponse(value.encode("utf-8"), result) for value, result in zip(values, results)]
+            individual_responses = [
+                CacheDictionaryGetUnaryResponse(value.encode("utf-8"), result)
+                for value, result in zip(values, results)
+            ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
             get_response = await simple_cache.dictionary_get(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5")
-            self.assertTrue(get_response.status(), [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS])
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
+            )
+            self.assertTrue(
+                get_response.status(),
+                [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS],
+            )
             self.assertTrue(get_response.values(), ["value1", "value2", None])
-            self.assertTrue(get_response.values_as_bytes(), [b"value1", b"value2", None])
+            self.assertTrue(
+                get_response.values_as_bytes(), [b"value1", b"value2", None]
+            )
 
     async def test_dictionary_get_all_miss(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             get_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5"
+            )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
     async def test_dictionary_get_all_hit(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
-            await simple_cache.dictionary_set(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6", dictionary=dictionary, refresh_ttl=False
+            await simple_cache.dictionary_multi_set(
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name="mydict6",
+                dictionary=dictionary,
+                refresh_ttl=False,
             )
             get_all_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6")
+                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6"
+            )
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 
             expected = convert_dict_items_to_bytes(dictionary)
@@ -161,6 +232,5 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual(expected, get_all_response.value())
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/incubating/test_momento_async.py
+++ b/tests/incubating/test_momento_async.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 
 from momento.cache_operation_types import CacheGetStatus
+from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
 import momento.incubating.aio.simple_cache_client as simple_cache_client
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
@@ -20,11 +21,22 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS):
                 pass
 
-    async def test_get_dictionary_miss(self):
+    async def test_dictionary_get_miss(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
             get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key")
+                _TEST_CACHE_NAME, "hello world", "key")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_dictionary_get_multi_miss(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            get_response = await simple_cache.dictionary_get(
+                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3")
+            self.assertEqual(3, len(get_response.to_list()))
+            self.assertTrue(all(result == CacheGetStatus.MISS for result in get_response.status()))
+            self.assertEqual(3, len(get_response.values()))
+            self.assertTrue(all(value is None for value in get_response.values()))
+            self.assertEqual(3, len(get_response.values_as_bytes()))
+            self.assertTrue(all(value is None for value in get_response.values_as_bytes()))
 
     async def test_dictionary_set_response(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -47,8 +59,13 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", dictionary={"key1": "value1"}, refresh_ttl=False)
             get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="myhash3", key="key2")
+                _TEST_CACHE_NAME, "myhash3", "key2")
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
+
+    async def test_dictionary_get_zero_length_keys(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            with self.assertRaises(ValueError):
+                await simple_cache.dictionary_get(_TEST_CACHE_NAME, "my-dictionary", *[])
 
     async def test_dictionary_get_hit(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
@@ -66,9 +83,35 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 await simple_cache.dictionary_set(
                     cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
                 get_response = await simple_cache.dictionary_get(
-                    cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, key=key)
+                    _TEST_CACHE_NAME, dictionary_name, key)
                 self.assertEqual(CacheGetStatus.HIT, get_response.status())
                 self.assertEqual(value, get_response.value() if value_is_str else get_response.value_as_bytes())
+
+    async def test_dictionary_get_multi_hit(self):
+        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+            dictionary_name = "mydictionary10"
+            dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
+
+            await simple_cache.dictionary_set(
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name, dictionary=dictionary, refresh_ttl=False)
+            get_response = await simple_cache.dictionary_get(
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3")
+
+            values = ["value1", "value2", "value3"]
+            self.assertEqual(get_response.values(), values) 
+            self.assertEqual(get_response.values_as_bytes(), [b"value1", b"value2", b"value3"])
+
+            results = [CacheGetStatus.HIT]*3
+            self.assertTrue(get_response.status(), results)
+
+            individual_responses = [CacheDictionaryGetUnaryResponse(value.encode("utf-8"), result) for value, result in zip(values, results)]
+            self.assertEqual(get_response.to_list(), individual_responses)
+
+            get_response = await simple_cache.dictionary_get(
+                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5")
+            self.assertTrue(get_response.status(), [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS])
+            self.assertTrue(get_response.values(), ["value1", "value2", None])
+            self.assertTrue(get_response.values_as_bytes(), [b"value1", b"value2", None])
 
     async def test_dictionary_get_all_miss(self):
         async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:


### PR DESCRIPTION
Closes #109 

Adds to the dictionary incubating methods with:

- multi-get: `dictionary_multi_get("my-cache", "my-dictionary", "key1", "key2", "key3")`
- unary-set: `dictionary_set("my-cache", "my-dictionary", "key", "value", refresh_ttl=False)`, cf `dictionary_multi_set("my-cache", "my-dictionary", dictionary={"key1": "value1", "key2": "value2", "key3": "value3"}, refresh_ttl=False)`
- TTL: `dictionary_set("my-cache", "my-dictionary", "key", "value", ttl_seconds=60, refresh_ttl=False)` per discussions we have had.


See `src/momento/incubating/README.md` for a listing of the dictionary functionality. In particular see the response types:

```python
>>> get_response = client.dictionary_get("my-cache", "my-dictionary", "key1")
>>> get_response
CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)

>>> get_response.status()
<CacheGetStatus.HIT: 1>

>>> get_response.value()
'value2'
```

and 

```python
>>> get_response = client.dictionary_multi_get("my-cache", "my-dictionary", "key1", "key2", "key7")
>>> get_response
CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])

>>> get_response.to_list()
[CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>),
 CacheDictionaryGetUnaryResponse(value=b'value2', result=<CacheGetStatus.HIT: 1>),
 CacheDictionaryGetUnaryResponse(value=None, result=<CacheGetStatus.MISS: 2>)]

 >>> get_response.status()
 [<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>]

 >>> get_response.values()
['value1', 'value2', None]
```