### PR TITLE
chore: Refactor multi-get and multi-set

### DIFF
--- a/src/momento/_utilities/_data_validation.py
+++ b/src/momento/_utilities/_data_validation.py
@@ -1,14 +1,8 @@
-from typing import Optional, Union, List
+from typing import Optional, Union
 
 from grpc.aio import Metadata
 
 from .. import errors
-from ..cache_operation_types import (
-    CacheMultiSetOperation,
-    CacheMultiGetOperation,
-    CacheMultiSetFailureResponse,
-    CacheMultiGetFailureResponse,
-)
 
 
 DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
@@ -16,18 +10,6 @@ DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
 
 def _make_metadata(cache_name: str) -> Metadata:
     return Metadata(("cache", cache_name))  # type: ignore[misc]
-
-
-def _validate_multi_op_list(
-    values: Union[
-        List[CacheMultiSetOperation],
-        List[CacheMultiGetOperation],
-        List[CacheMultiSetFailureResponse],
-        List[CacheMultiGetFailureResponse],
-    ]
-) -> None:
-    if len(values) < 1:
-        raise errors.InvalidArgumentError("empty op list passed to multi operation")
 
 
 def _validate_cache_name(cache_name: str) -> None:

--- a/src/momento/aio/_add_header_client_interceptor.py
+++ b/src/momento/aio/_add_header_client_interceptor.py
@@ -36,7 +36,7 @@ class AddHeaderClientInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
             client_call_details.metadata = Metadata()
         for header in self.headers_to_add_every_time:
             client_call_details.metadata.add(header.name, header.value)
-        if AddHeaderClientInterceptor.are_only_once_headers_sent == False:
+        if not AddHeaderClientInterceptor.are_only_once_headers_sent:
             for header in self._headers_to_add_once:
                 client_call_details.metadata.add(header.name, header.value)
             AddHeaderClientInterceptor.are_only_once_headers_sent = True

--- a/src/momento/aio/_scs_control_client.py
+++ b/src/momento/aio/_scs_control_client.py
@@ -1,4 +1,3 @@
-from time import time
 from typing import Optional
 
 from momento_wire_types.controlclient_pb2 import _CreateCacheRequest

--- a/src/momento/aio/_scs_data_client.py
+++ b/src/momento/aio/_scs_data_client.py
@@ -1,6 +1,6 @@
 import asyncio
 import functools
-from typing import Union, Optional, List, Any
+from typing import Union, Optional, List, Mapping
 from momento_wire_types.cacheclient_pb2 import _GetRequest, _SetRequest, _DeleteRequest
 
 from .. import cache_operation_types as cache_sdk_ops
@@ -75,82 +75,32 @@ class _ScsDataClient:
     async def multi_set(
         self,
         cache_name: str,
-        set_operations: Union[
-            List[cache_sdk_ops.CacheMultiSetOperation],
-            List[cache_sdk_ops.CacheMultiSetFailureResponse],
-        ],
+        items: Union[Mapping[str, str], Mapping[bytes, bytes]],
+        ttl_seconds: Optional[int] = None,
     ) -> cache_sdk_ops.CacheMultiSetResponse:
-
-        _validate_multi_op_list(set_operations)
         _validate_cache_name(cache_name)
 
-        # Will hold which tasks have succeeded or failed to return to caller
-        failed_ops: List[cache_sdk_ops.CacheMultiSetFailureResponse] = []
-        successful_ops: List[cache_sdk_ops.CacheSetResponse] = []
-
         try:
-            requests: List[_SetRequest] = list()
-            request_promises = list()
-            for op in set_operations:
-                item_ttl_seconds = (
-                    self._default_ttlSeconds
-                    if op.ttl_seconds is None
-                    else op.ttl_seconds
-                )
-                _validate_ttl(item_ttl_seconds)
-                set_request = _SetRequest()
-                set_request.cache_key = _as_bytes(op.key, "Unsupported type for key: ")
-                set_request.cache_body = _as_bytes(
-                    op.value, "Unsupported type for value: "
-                )
-                set_request.ttl_milliseconds = item_ttl_seconds * 1000
+            request_promises = [
+                self.set(cache_name, key, value, ttl_seconds)
+                for key, value in items.items()
+            ]
 
-                requests.append(set_request)
-                request_promises.append(
-                    self._grpc_manager.async_stub().Set(
-                        set_request,
-                        metadata=_make_metadata(cache_name),
-                        timeout=self._default_deadline_seconds,
-                    )
-                )
-
+            # A note on `return_exceptions=True`: because we're gathering the results,
+            # if an individual promise raises an exception, we want the others to finish gracefully.
             results = await asyncio.gather(
                 *request_promises,
                 return_exceptions=True,
-                # When set to True exceptions are treated the same as successful results, and aggregated in the
-                # result list. We want to try and make sure all requests have chance to finish.
             )
 
-            for request, result in zip(requests, results):
+            for result in results:
                 if isinstance(result, Exception):
-                    _momento_logger.debug(
-                        f"multi-set sub command failed with "
-                        f"error: {result} "
-                        f"key: {str(request.cache_key)}"
-                    )
-                    failed_ops.append(
-                        cache_sdk_ops.CacheMultiSetFailureResponse(
-                            key=request.cache_key,
-                            value=request.cache_body,
-                            ttl_seconds=int(request.ttl_milliseconds / 1000),
-                            failure=_cache_service_errors_converter.convert(result),
-                        )
-                    )
-                else:
-                    successful_ops.append(
-                        cache_sdk_ops.CacheSetResponse(
-                            result, request.cache_key, request.cache_body
-                        )
-                    )
-            _momento_logger.debug(
-                f"multi-set succeeded "
-                f"successful_op_count={len(successful_ops)} "
-                f"failed_op_count={len(failed_ops)}"
-            )
-            return cache_sdk_ops.CacheMultiSetResponse(
-                successful_responses=successful_ops,
-                failed_responses=failed_ops,
-            )
+                    raise result
+
+            items_as_bytes = {
+                item.key_as_bytes(): item.value_as_bytes() for item in results
+            }
+            return cache_sdk_ops.CacheMultiSetResponse(items=items_as_bytes)
         except Exception as e:
             _momento_logger.debug(f"multi-set failed with error: {e}")
             # re-raise any error caught here is fatal error with overall handling of request objects

--- a/src/momento/aio/_scs_data_client.py
+++ b/src/momento/aio/_scs_data_client.py
@@ -1,6 +1,5 @@
 import asyncio
-import functools
-from typing import Union, Optional, List, Mapping
+from typing import Union, Optional, Mapping
 from momento_wire_types.cacheclient_pb2 import _GetRequest, _SetRequest, _DeleteRequest
 
 from .. import cache_operation_types as cache_sdk_ops
@@ -12,7 +11,6 @@ from .._utilities._data_validation import (
     _validate_ttl,
     _make_metadata,
     _validate_cache_name,
-    _validate_multi_op_list,
 )
 
 _DEFAULT_DEADLINE_SECONDS = 5.0  # 5 seconds

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Optional, Union, Type, List
+from typing import Optional, Mapping, Type, Union, Type
 
 try:
     from ._scs_control_client import _ScsControlClient
@@ -181,17 +181,18 @@ class SimpleCacheClient:
     async def multi_set(
         self,
         cache_name: str,
-        ops: Union[List[CacheMultiSetOperation], List[CacheMultiSetFailureResponse]],
+        items: Union[Mapping[str, str], Mapping[bytes, bytes]],
+        ttl_seconds: Optional[int] = None,
     ) -> CacheMultiSetResponse:
-        """Executes a list of passed Set operations in parallel.
+        """Store items in the cache.
 
         Args:
             cache_name: Name of the cache to store the item in.
-            ops: (Union[List[CacheMultiSetOperation], List[CacheMultiSetFailureResponse]]): List of set operations to
-                execute.
+            items: (Union[Mapping[str, str], Mapping[bytes, bytes]]): The items to store.
+            ttl_seconds: (Optional[int]): The TTL to apply to each item. Defaults to None.
 
         Returns:
-            CacheMultiGetResponse
+            CacheMultiSetResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -200,7 +201,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        return await self._data_client.multi_set(cache_name, ops)
+        return await self._data_client.multi_set(cache_name, items, ttl_seconds)
 
     async def set(
         self,

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -1,5 +1,5 @@
 from types import TracebackType
-from typing import Optional, Mapping, Type, Union, Type
+from typing import Optional, Mapping, Type, Union
 
 try:
     from ._scs_control_client import _ScsControlClient
@@ -36,12 +36,8 @@ from ..cache_operation_types import (
     CacheSetResponse,
     CacheGetResponse,
     CacheDeleteResponse,
-    CacheMultiSetOperation,
-    CacheMultiGetOperation,
-    CacheMultiSetFailureResponse,
     CacheMultiSetResponse,
     CacheMultiGetResponse,
-    CacheMultiGetFailureResponse,
 )
 
 

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -231,16 +231,13 @@ class SimpleCacheClient:
         return await self._data_client.set(cache_name, key, value, ttl_seconds)
 
     async def multi_get(
-        self,
-        cache_name: str,
-        ops: Union[List[CacheMultiGetOperation], List[CacheMultiGetFailureResponse]],
+        self, cache_name: str, *keys: Union[str, bytes]
     ) -> CacheMultiGetResponse:
-        """Executes a list of passed Get operations in parallel.
+        """Retrieve multiple items from the cache.
 
         Args:
-            cache_name: Name of the cache to get the item from.
-            ops: (Union[List[CacheMultiGetOperation], List[CacheMultiGetFailureResponse]]): List of get operations to
-                execute.
+            cache_name (str): Name of the cache to get the item from.
+            keys: (Union[str, bytes]): The keys used to retrieve the items.
 
         Returns:
             CacheMultiGetResponse
@@ -252,7 +249,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        return await self._data_client.multi_get(cache_name, ops)
+        return await self._data_client.multi_get(cache_name, *keys)
 
     async def get(self, cache_name: str, key: str) -> CacheGetResponse:
         """Retrieve an item from the cache

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -132,35 +132,19 @@ class CacheGetResponse:
 
 
 class CacheMultiGetResponse:
-    def __init__(
-        self,
-        successful_responses: List[CacheGetResponse],
-        failed_responses: List[CacheMultiGetFailureResponse],
-    ):
-        self._success_responses = successful_responses
-        self._failed_responses = failed_responses
-
-    def get_successful_responses(self) -> List[CacheGetResponse]:
-        """Returns list of responses of items successfully fetched from cache"""
-        return self._success_responses
-
-    def get_failed_responses(self) -> List[CacheMultiGetFailureResponse]:
-        """Returns list of set responses of items that an error occurred while trying to store in cache"""
-        return self._failed_responses
+    def __init__(self, results: List[CacheGetResponse]):
+        self._results = results
 
     def values(self) -> List[Optional[str]]:
         """Returns list of values as utf-8 string for each Hit. Each item in list is None if was a Miss."""
-        r_values = []
-        for r in self._success_responses:
-            r_values.append(r.value())
-        return r_values
+        return [result.value() for result in self._results]
 
     def values_as_bytes(self) -> List[Optional[bytes]]:
         """Returns list of values as bytes for each Hit. Each item in list is None if was a Miss."""
-        r_values = []
-        for r in self._success_responses:
-            r_values.append(r.value_as_bytes())
-        return r_values
+        return [result.value_as_bytes() for result in self._results]
+
+    def results(self) -> List[CacheGetResponse]:
+        return self._results
 
 
 class CacheDeleteResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -1,8 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import cast, Any, Optional, List, Mapping, Union
-from dataclasses import dataclass
+from typing import Any, Optional, List, Mapping
 
 from momento_wire_types import cacheclient_pb2 as cache_client_types
 from . import _cache_service_errors_converter as error_converter
@@ -46,20 +45,6 @@ class CacheSetResponse:
         return self._key
 
 
-@dataclass
-class CacheMultiSetFailureResponse:
-    key: bytes
-    value: bytes
-    ttl_seconds: int
-    failure: Exception
-
-
-@dataclass
-class CacheMultiGetFailureResponse:
-    key: bytes
-    failure: Exception
-
-
 class CacheMultiSetResponse:
     def __init__(self, items: Mapping[bytes, bytes]):
         self._items = items
@@ -72,18 +57,6 @@ class CacheMultiSetResponse:
 
     def items_as_bytes(self) -> Mapping[bytes, bytes]:
         return self._items
-
-
-@dataclass
-class CacheMultiSetOperation:
-    key: Union[str, bytes]
-    value: Union[str, bytes]
-    ttl_seconds: Optional[int] = None
-
-
-@dataclass
-class CacheMultiGetOperation:
-    key: Union[str, bytes]
 
 
 class CacheGetResponse:

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -112,7 +112,7 @@ class CacheMultiGetResponse:
         """Returns list of values as bytes for each Hit. Each item in list is None if was a Miss."""
         return [result.value_as_bytes() for result in self._results]
 
-    def results(self) -> List[CacheGetResponse]:
+    def to_list(self) -> List[CacheGetResponse]:
         return self._results
 
 

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import cast, Any, Optional, List, Union
+from typing import cast, Any, Optional, List, Mapping, Union
 from dataclasses import dataclass
 
 from momento_wire_types import cacheclient_pb2 as cache_client_types
@@ -61,21 +61,17 @@ class CacheMultiGetFailureResponse:
 
 
 class CacheMultiSetResponse:
-    def __init__(
-        self,
-        successful_responses: List[CacheSetResponse],
-        failed_responses: List[CacheMultiSetFailureResponse],
-    ):
-        self._success_responses = successful_responses
-        self._failed_responses = failed_responses
+    def __init__(self, items: Mapping[bytes, bytes]):
+        self._items = items
 
-    def get_successful_responses(self) -> List[CacheSetResponse]:
-        """Returns list of responses of items successfully stored in cache"""
-        return self._success_responses
+    def items(self) -> Mapping[str, str]:
+        return {
+            key.decode("utf-8"): value.decode("utf-8")
+            for key, value in self._items.items()
+        }
 
-    def get_failed_responses(self) -> List[CacheMultiSetFailureResponse]:
-        """Returns list of set responses of items that an error occurred while trying to store in cache"""
-        return self._failed_responses
+    def items_as_bytes(self) -> Mapping[bytes, bytes]:
+        return self._items
 
 
 @dataclass

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 import warnings
 
 from . import INCUBATING_WARNING_MSG

--- a/src/momento/momento_signer.py
+++ b/src/momento/momento_signer.py
@@ -1,5 +1,4 @@
 import json
-import urllib
 from enum import Enum
 from typing import Optional, Dict
 from jwt.api_jwk import PyJWK

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import TracebackType
-from typing import Optional, Union, Type, List
+from typing import Optional, Mapping, Union, Type, List
 
 from .aio import simple_cache_client as aio
 from ._async_utils import wait_for_coroutine
@@ -204,16 +204,18 @@ class SimpleCacheClient:
     def multi_set(
         self,
         cache_name: str,
-        ops: Union[List[CacheMultiSetOperation], List[CacheMultiSetFailureResponse]],
+        items: Union[Mapping[str, str], Mapping[bytes, bytes]],
+        ttl_seconds: Optional[int] = None,
     ) -> CacheMultiSetResponse:
-        """Executes a list of passed Set operations in parallel.
+        """Store items in the cache.
 
         Args:
             cache_name: Name of the cache to store the item in.
-            ops: (List[CacheMultiSetOperation]): List of set operations to execute.
+            items: (Union[Mapping[str, str], Mapping[bytes, bytes]]): The items to store.
+            ttl_seconds: (Optional[int]): The TTL to apply to each item. Defaults to None.
 
         Returns:
-            CacheMultiGetResponse
+            CacheMultiSetResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -222,7 +224,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        coroutine = self._momento_async_client.multi_set(cache_name, ops)
+        coroutine = self._momento_async_client.multi_set(cache_name, items, ttl_seconds)
         return wait_for_coroutine(self._loop, coroutine)
 
     def get(self, cache_name: str, key: str) -> CacheGetResponse:

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import TracebackType
-from typing import Optional, Mapping, Union, Type, List
+from typing import Optional, Mapping, Union, Type
 
 from .aio import simple_cache_client as aio
 from ._async_utils import wait_for_coroutine
@@ -13,11 +13,7 @@ from .cache_operation_types import (
     DeleteCacheResponse,
     ListCachesResponse,
     CacheMultiGetResponse,
-    CacheMultiGetOperation,
-    CacheMultiSetOperation,
     CacheMultiSetResponse,
-    CacheMultiSetFailureResponse,
-    CacheMultiGetFailureResponse,
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -246,16 +246,13 @@ class SimpleCacheClient:
         return wait_for_coroutine(self._loop, coroutine)
 
     def multi_get(
-        self,
-        cache_name: str,
-        ops: Union[List[CacheMultiGetOperation], List[CacheMultiGetFailureResponse]],
+        self, cache_name: str, *keys: Union[str, bytes]
     ) -> CacheMultiGetResponse:
-        """Executes a list of passed Get operations in parallel.
+        """Retrieve multiple items from the cache.
 
         Args:
-            cache_name: Name of the cache to get the item from.
-            ops: (Union[List[CacheMultiGetOperation], List[CacheMultiGetFailureResponse]]): List of get operations to
-                execute.
+            cache_name (str): Name of the cache to get the item from.
+            keys: (Union[str, bytes]): The keys used to retrieve the items.
 
         Returns:
             CacheMultiGetResponse
@@ -267,7 +264,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        coroutine = self._momento_async_client.multi_get(cache_name, ops)
+        coroutine = self._momento_async_client.multi_get(cache_name, *keys)
         return wait_for_coroutine(self._loop, coroutine)
 
     def delete(self, cache_name: str, key: str) -> CacheDeleteResponse:

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -8,11 +8,12 @@ import momento.errors as errors
 from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
-    CacheMultiGetOperation)
+    CacheMultiGetOperation,
+)
 
 
-_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
-_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
+_TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
 _BAD_AUTH_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoiY29udHJvbC5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSIsImMiOiJjYWNoZS5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSJ9.gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy"
 _DEFAULT_TTL_SECONDS = 60
 
@@ -71,22 +72,28 @@ class TestMomento(unittest.TestCase):
     def test_init_throws_exception_when_client_uses_negative_default_ttl(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, -1)
-        self.assertEqual('{}'.format(cm.exception), "TTL Seconds must be a non-negative integer")
+        self.assertEqual(
+            "{}".format(cm.exception), "TTL Seconds must be a non-negative integer"
+        )
 
     def test_init_throws_exception_for_non_jwt_token(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init("notanauthtoken", _DEFAULT_TTL_SECONDS)
-        self.assertEqual('{}'.format(cm.exception), "Invalid Auth token.")
+        self.assertEqual("{}".format(cm.exception), "Invalid Auth token.")
 
     def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, -1)
-        self.assertEqual('{}'.format(cm.exception), "Request timeout must be greater than zero.")
+        self.assertEqual(
+            "{}".format(cm.exception), "Request timeout must be greater than zero."
+        )
 
     def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, 0)
-        self.assertEqual('{}'.format(cm.exception), "Request timeout must be greater than zero.")
+        self.assertEqual(
+            "{}".format(cm.exception), "Request timeout must be greater than zero."
+        )
 
     # create_cache
 
@@ -101,16 +108,21 @@ class TestMomento(unittest.TestCase):
     def test_create_cache_throws_validation_exception_for_null_cache_name(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.create_cache(None)
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_create_cache_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.create_cache(1)
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_create_cache_throws_authentication_exception_for_bad_token(self):
-        with simple_cache_client.init(_BAD_AUTH_TOKEN,
-                                      _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 simple_cache.create_cache(str(uuid.uuid4()))
 
@@ -141,11 +153,14 @@ class TestMomento(unittest.TestCase):
     def test_delete_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.delete_cache(1)
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_delete_cache_throws_authentication_exception_for_bad_token(self):
-        with simple_cache_client.init(_BAD_AUTH_TOKEN,
-                                      _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 simple_cache.create_cache(str(uuid.uuid4()))
 
@@ -170,8 +185,9 @@ class TestMomento(unittest.TestCase):
             self.client.delete_cache(cache_name)
 
     def test_list_caches_throws_authentication_exception_for_bad_token(self):
-        with simple_cache_client.init(_BAD_AUTH_TOKEN,
-                                      _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 simple_cache.list_caches()
 
@@ -188,12 +204,12 @@ class TestMomento(unittest.TestCase):
 
         set_resp = self.client.set(_TEST_CACHE_NAME, key, value)
         self.assertEqual(set_resp.value(), value)
-        self.assertEqual(set_resp.value_as_bytes(), bytes(value, 'utf-8'))
+        self.assertEqual(set_resp.value_as_bytes(), bytes(value, "utf-8"))
 
         get_resp = self.client.get(_TEST_CACHE_NAME, key)
         self.assertEqual(get_resp.status(), CacheGetStatus.HIT)
         self.assertEqual(get_resp.value(), value)
-        self.assertEqual(get_resp.value_as_bytes(), bytes(value, 'utf-8'))
+        self.assertEqual(get_resp.value_as_bytes(), bytes(value, "utf-8"))
 
     def test_set_and_get_with_byte_key_values(self):
         key = uuid.uuid4().bytes
@@ -217,14 +233,17 @@ class TestMomento(unittest.TestCase):
     def test_expires_items_after_ttl(self):
         key = str(uuid.uuid4())
         val = str(uuid.uuid4())
-        with simple_cache_client.init(_AUTH_TOKEN,
-                                      2) as simple_cache:
+        with simple_cache_client.init(_AUTH_TOKEN, 2) as simple_cache:
             simple_cache.set(_TEST_CACHE_NAME, key, val)
 
-            self.assertEqual(simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.HIT)
+            self.assertEqual(
+                simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.HIT
+            )
 
             time.sleep(4)
-            self.assertEqual(simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.MISS)
+            self.assertEqual(
+                simple_cache.get(_TEST_CACHE_NAME, key).status(), CacheGetStatus.MISS
+            )
 
     def test_set_with_different_ttl(self):
         key1 = str(uuid.uuid4())
@@ -233,12 +252,20 @@ class TestMomento(unittest.TestCase):
         self.client.set(_TEST_CACHE_NAME, key1, "1", 2)
         self.client.set(_TEST_CACHE_NAME, key2, "2")
 
-        self.assertEqual(self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.HIT)
-        self.assertEqual(self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT)
+        self.assertEqual(
+            self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.HIT
+        )
+        self.assertEqual(
+            self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT
+        )
 
         time.sleep(4)
-        self.assertEqual(self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.MISS)
-        self.assertEqual(self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT)
+        self.assertEqual(
+            self.client.get(_TEST_CACHE_NAME, key1).status(), CacheGetStatus.MISS
+        )
+        self.assertEqual(
+            self.client.get(_TEST_CACHE_NAME, key2).status(), CacheGetStatus.HIT
+        )
 
     # set
 
@@ -251,13 +278,15 @@ class TestMomento(unittest.TestCase):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(None, "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_set_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             self.client.set("", "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
+        self.assertEqual("{}".format(cm.exception), "Cache header is empty")
 
     def test_set_with_null_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError):
@@ -270,34 +299,44 @@ class TestMomento(unittest.TestCase):
     def test_set_negative_ttl_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(_TEST_CACHE_NAME, "foo", "bar", -1)
-        self.assertEqual('{}'.format(cm.exception), "TTL Seconds must be a non-negative integer")
+        self.assertEqual(
+            "{}".format(cm.exception), "TTL Seconds must be a non-negative integer"
+        )
 
     def test_set_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(1, "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_set_with_bad_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(_TEST_CACHE_NAME, 1, "bar")
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for key: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for key: <class 'int'>"
+        )
 
     def test_set_with_bad_value_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(_TEST_CACHE_NAME, "foo", 1)
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for value: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for value: <class 'int'>"
+        )
 
     def test_set_throws_authentication_exception_for_bad_token(self):
-        with simple_cache_client.init(_BAD_AUTH_TOKEN,
-                                      _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 simple_cache.set(_TEST_CACHE_NAME, "foo", "bar")
 
     def test_set_throws_timeout_error_for_short_request_timeout(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 simple_cache.set(_TEST_CACHE_NAME, "foo", "bar")
-
 
     # get
 
@@ -310,13 +349,15 @@ class TestMomento(unittest.TestCase):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.get(None, "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_get_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             self.client.get("", "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
+        self.assertEqual("{}".format(cm.exception), "Cache header is empty")
 
     def test_get_with_null_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError):
@@ -325,40 +366,45 @@ class TestMomento(unittest.TestCase):
     def test_get_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.get(1, "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     def test_get_with_bad_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.get(_TEST_CACHE_NAME, 1)
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for key: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for key: <class 'int'>"
+        )
 
     def test_get_throws_authentication_exception_for_bad_token(self):
-        with simple_cache_client.init(_BAD_AUTH_TOKEN,
-                                      _DEFAULT_TTL_SECONDS) as simple_cache:
+        with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 simple_cache.get(_TEST_CACHE_NAME, "foo")
 
     def test_get_throws_timeout_error_for_short_request_timeout(self):
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 simple_cache.get(_TEST_CACHE_NAME, "foo")
 
     def test_multi_get_and_set(self):
-        set_resp = self.client.multi_set(
-            cache_name=_TEST_CACHE_NAME,
-            ops=[
-                CacheMultiSetOperation(key="foo1", value="bar1"),
-                CacheMultiSetOperation(key="foo2", value="bar2"),
-                CacheMultiSetOperation(key="foo3", value="bar3"),
-                CacheMultiSetOperation(key="foo4", value="bar4"),
-                CacheMultiSetOperation(key="foo5", value="bar5"),
-            ]
-        )
-        self.assertEqual(0, len(set_resp.get_failed_responses()))
-        self.assertEqual(5, len(set_resp.get_successful_responses()))
+        items = {
+            "foo1": "bar1",
+            "foo2": "bar2",
+            "foo3": "bar3",
+            "foo4": "bar4",
+            "foo5": "bar5",
+        }
+        set_resp = self.client.multi_set(cache_name=_TEST_CACHE_NAME, items=items)
+        self.assertEqual(items, set_resp.items())
+
         get_resp = self.client.multi_get(
-            _TEST_CACHE_NAME,
-            "foo5", "foo1", "foo2", "foo3")
+            _TEST_CACHE_NAME, "foo5", "foo1", "foo2", "foo3"
+        )
         values = get_resp.values()
         self.assertEqual("bar5", values[0])
         self.assertEqual("bar1", values[1])
@@ -367,48 +413,62 @@ class TestMomento(unittest.TestCase):
 
     def test_multi_get_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 simple_cache.multi_get(
-                    _TEST_CACHE_NAME,
-                    "key1", "key2", "key3", "key4", "key5", "key6"
+                    _TEST_CACHE_NAME, "key1", "key2", "key3", "key4", "key5", "key6"
                 )
 
     def test_multi_set_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
-        with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
-            set_resp = simple_cache.multi_set(
-                cache_name=_TEST_CACHE_NAME,
-                ops=[
-                    CacheMultiSetOperation(key="fizz1", value="buzz1"),
-                    CacheMultiSetOperation(key="fizz2", value="buzz2"),
-                    CacheMultiSetOperation(key="fizz3", value="buzz3"),
-                    CacheMultiSetOperation(key="fizz4", value="buzz4"),
-                    CacheMultiSetOperation(key="fizz5", value="buzz5"),
-                ]
-            )
+        with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
+            with self.assertRaises(errors.TimeoutError):
+                simple_cache.multi_set(
+                    cache_name=_TEST_CACHE_NAME,
+                    items={
+                        "fizz1": "buzz1",
+                        "fizz2": "buzz2",
+                        "fizz3": "buzz3",
+                        "fizz4": "buzz4",
+                        "fizz5": "buzz5",
+                    },
+                )
 
     # Test delete for key that doesn't exist
     def test_delete_key_doesnt_exist(self):
         key = "a key that isnt there"
-        self.assertEqual(CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
         self.client.delete(_TEST_CACHE_NAME, key)
-        self.assertEqual(CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
     # Test delete
     def test_delete(self):
         # Set an item to then delete...
         key = "key1"
-        self.assertEqual(CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
         self.client.set(_TEST_CACHE_NAME, key, "value1")
-        self.assertEqual(CacheGetStatus.HIT, (self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.HIT, (self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
         # Delete
         self.client.delete(_TEST_CACHE_NAME, key)
 
         # Verify deleted
-        self.assertEqual(CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -271,7 +271,6 @@ class TestMomento(unittest.TestCase):
             self.client.set(cache_name, "foo", "bar")
 
     def test_set_with_null_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.set(None, "foo", "bar")
         self.assertEqual(
@@ -279,7 +278,6 @@ class TestMomento(unittest.TestCase):
         )
 
     def test_set_with_empty_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             self.client.set("", "foo", "bar")
         self.assertEqual("{}".format(cm.exception), "Cache header is empty")
@@ -342,7 +340,6 @@ class TestMomento(unittest.TestCase):
             self.client.get(cache_name, "foo")
 
     def test_get_with_null_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             self.client.get(None, "foo")
         self.assertEqual(
@@ -350,7 +347,6 @@ class TestMomento(unittest.TestCase):
         )
 
     def test_get_with_empty_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             self.client.get("", "foo")
         self.assertEqual("{}".format(cm.exception), "Cache header is empty")

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -5,11 +5,7 @@ import time
 
 import momento.simple_cache_client as simple_cache_client
 import momento.errors as errors
-from momento.cache_operation_types import (
-    CacheGetStatus,
-    CacheMultiSetOperation,
-    CacheMultiGetOperation,
-)
+from momento.cache_operation_types import CacheGetStatus
 
 
 _AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -294,7 +294,6 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             await self.client.set(cache_name, "foo", "bar")
 
     async def test_set_with_null_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(None, "foo", "bar")
         self.assertEqual(
@@ -302,7 +301,6 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         )
 
     async def test_set_with_empty_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             await self.client.set("", "foo", "bar")
         self.assertEqual("{}".format(cm.exception), "Cache header is empty")
@@ -365,7 +363,6 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             await self.client.get(cache_name, "foo")
 
     async def test_get_with_null_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.get(None, "foo")
         self.assertEqual(
@@ -373,7 +370,6 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         )
 
     async def test_get_with_empty_cache_name_throws_exception(self):
-        cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             await self.client.get("", "foo")
         self.assertEqual("{}".format(cm.exception), "Cache header is empty")

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -8,11 +8,12 @@ import momento.errors as errors
 from momento.cache_operation_types import (
     CacheGetStatus,
     CacheMultiSetOperation,
-    CacheMultiGetOperation)
+    CacheMultiGetOperation,
+)
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
-_AUTH_TOKEN = os.getenv('TEST_AUTH_TOKEN')
-_TEST_CACHE_NAME = os.getenv('TEST_CACHE_NAME')
+_AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
+_TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
 _BAD_AUTH_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoiY29udHJvbC5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSIsImMiOiJjYWNoZS5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSJ9.gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy"
 _DEFAULT_TTL_SECONDS = 60
 
@@ -72,26 +73,36 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_init_throws_exception_when_client_uses_negative_default_ttl(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, -1)
-        self.assertEqual('{}'.format(cm.exception), "TTL Seconds must be a non-negative integer")
+        self.assertEqual(
+            "{}".format(cm.exception), "TTL Seconds must be a non-negative integer"
+        )
 
     async def test_init_throws_exception_for_non_jwt_token(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init("notanauthtoken", _DEFAULT_TTL_SECONDS)
-        self.assertEqual('{}'.format(cm.exception), "Invalid Auth token.")
+        self.assertEqual("{}".format(cm.exception), "Invalid Auth token.")
 
-    async def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(self):
+    async def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(
+        self,
+    ):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, -1)
-        self.assertEqual('{}'.format(cm.exception), "Request timeout must be greater than zero.")
+        self.assertEqual(
+            "{}".format(cm.exception), "Request timeout must be greater than zero."
+        )
 
     async def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, 0)
-        self.assertEqual('{}'.format(cm.exception), "Request timeout must be greater than zero.")
+        self.assertEqual(
+            "{}".format(cm.exception), "Request timeout must be greater than zero."
+        )
 
     # create_cache
 
-    async def test_create_cache_throws_already_exists_when_creating_existing_cache(self):
+    async def test_create_cache_throws_already_exists_when_creating_existing_cache(
+        self,
+    ):
         with self.assertRaises(errors.AlreadyExistsError):
             await self.client.create_cache(_TEST_CACHE_NAME)
 
@@ -102,16 +113,21 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_create_cache_throws_validation_exception_for_null_cache_name(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.create_cache(None)
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_create_cache_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.create_cache(1)
-        self.assertEqual('{}'.format(cm.exception),
-                         "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_create_cache_throws_authentication_exception_for_bad_token(self):
-        async with simple_cache_client.init(_BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 await simple_cache.create_cache(str(uuid.uuid4()))
 
@@ -142,10 +158,14 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_delete_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.delete_cache(1)
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_delete_cache_throws_authentication_exception_for_bad_token(self):
-        async with simple_cache_client.init(_BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 await simple_cache.create_cache(str(uuid.uuid4()))
 
@@ -170,7 +190,9 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             await self.client.delete_cache(cache_name)
 
     async def test_list_caches_throws_authentication_exception_for_bad_token(self):
-        async with simple_cache_client.init(_BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 await simple_cache.list_caches()
 
@@ -178,15 +200,21 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         # skip until pagination is actually implemented, see
         # https://github.com/momentohq/control-plane-service/issues/83
         self.skipTest("pagination not yet implemented")
-    
+
     # signing keys
     async def test_create_list_revoke_signing_keys(self):
         create_resp = await self.client.create_signing_key(30)
         list_resp = await self.client.list_signing_keys()
-        self.assertTrue(create_resp.key_id() in [signing_key.key_id() for signing_key in list_resp.signing_keys()])
+        self.assertTrue(
+            create_resp.key_id()
+            in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+        )
         await self.client.revoke_signing_key(create_resp.key_id())
         list_resp = await self.client.list_signing_keys()
-        self.assertFalse(create_resp.key_id() in [signing_key.key_id() for signing_key in list_resp.signing_keys()])
+        self.assertFalse(
+            create_resp.key_id()
+            in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+        )
 
     # setting and getting
 
@@ -196,12 +224,12 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
         set_resp = await self.client.set(_TEST_CACHE_NAME, key, value)
         self.assertEqual(set_resp.value(), value)
-        self.assertEqual(set_resp.value_as_bytes(), bytes(value, 'utf-8'))
+        self.assertEqual(set_resp.value_as_bytes(), bytes(value, "utf-8"))
 
         get_resp = await self.client.get(_TEST_CACHE_NAME, key)
         self.assertEqual(get_resp.status(), CacheGetStatus.HIT)
         self.assertEqual(get_resp.value(), value)
-        self.assertEqual(get_resp.value_as_bytes(), bytes(value, 'utf-8'))
+        self.assertEqual(get_resp.value_as_bytes(), bytes(value, "utf-8"))
 
     async def test_set_and_get_with_byte_key_values(self):
         key = uuid.uuid4().bytes
@@ -228,10 +256,16 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(_AUTH_TOKEN, 2) as simple_cache:
             await simple_cache.set(_TEST_CACHE_NAME, key, val)
 
-            self.assertEqual((await simple_cache.get(_TEST_CACHE_NAME, key)).status(), CacheGetStatus.HIT)
+            self.assertEqual(
+                (await simple_cache.get(_TEST_CACHE_NAME, key)).status(),
+                CacheGetStatus.HIT,
+            )
 
             time.sleep(4)
-            self.assertEqual((await simple_cache.get(_TEST_CACHE_NAME, key)).status(), CacheGetStatus.MISS)
+            self.assertEqual(
+                (await simple_cache.get(_TEST_CACHE_NAME, key)).status(),
+                CacheGetStatus.MISS,
+            )
 
     async def test_set_with_different_ttl(self):
         key1 = str(uuid.uuid4())
@@ -240,12 +274,21 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         await self.client.set(_TEST_CACHE_NAME, key1, "1", 2)
         await self.client.set(_TEST_CACHE_NAME, key2, "2")
 
-        self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key1)).status(), CacheGetStatus.HIT)
-        self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT)
+        self.assertEqual(
+            (await self.client.get(_TEST_CACHE_NAME, key1)).status(), CacheGetStatus.HIT
+        )
+        self.assertEqual(
+            (await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT
+        )
 
         time.sleep(4)
-        self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key1)).status(), CacheGetStatus.MISS)
-        self.assertEqual((await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT)
+        self.assertEqual(
+            (await self.client.get(_TEST_CACHE_NAME, key1)).status(),
+            CacheGetStatus.MISS,
+        )
+        self.assertEqual(
+            (await self.client.get(_TEST_CACHE_NAME, key2)).status(), CacheGetStatus.HIT
+        )
 
     # set
 
@@ -258,13 +301,15 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(None, "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_set_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             await self.client.set("", "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
+        self.assertEqual("{}".format(cm.exception), "Cache header is empty")
 
     async def test_set_with_null_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError):
@@ -277,30 +322,42 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_set_negative_ttl_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(_TEST_CACHE_NAME, "foo", "bar", -1)
-        self.assertEqual('{}'.format(cm.exception), "TTL Seconds must be a non-negative integer")
+        self.assertEqual(
+            "{}".format(cm.exception), "TTL Seconds must be a non-negative integer"
+        )
 
     async def test_set_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(1, "foo", "bar")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_set_with_bad_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(_TEST_CACHE_NAME, 1, "bar")
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for key: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for key: <class 'int'>"
+        )
 
     async def test_set_with_bad_value_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.set(_TEST_CACHE_NAME, "foo", 1)
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for value: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for value: <class 'int'>"
+        )
 
     async def test_set_throws_authentication_exception_for_bad_token(self):
-        async with simple_cache_client.init(_BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 await simple_cache.set(_TEST_CACHE_NAME, "foo", "bar")
 
     async def test_set_throws_timeout_error_for_short_request_timeout(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 await simple_cache.set(_TEST_CACHE_NAME, "foo", "bar")
 
@@ -315,13 +372,15 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.get(None, "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_get_with_empty_cache_name_throws_exception(self):
         cache_name = str(uuid.uuid4())
         with self.assertRaises(errors.BadRequestError) as cm:
             await self.client.get("", "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache header is empty")
+        self.assertEqual("{}".format(cm.exception), "Cache header is empty")
 
     async def test_get_with_null_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError):
@@ -330,40 +389,46 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
     async def test_get_with_bad_cache_name_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.get(1, "foo")
-        self.assertEqual('{}'.format(cm.exception), "Cache name must be a non-empty string")
+        self.assertEqual(
+            "{}".format(cm.exception), "Cache name must be a non-empty string"
+        )
 
     async def test_get_with_bad_key_throws_exception(self):
         with self.assertRaises(errors.InvalidArgumentError) as cm:
             await self.client.get(_TEST_CACHE_NAME, 1)
-        self.assertEqual('{}'.format(cm.exception), "Unsupported type for key: <class 'int'>")
+        self.assertEqual(
+            "{}".format(cm.exception), "Unsupported type for key: <class 'int'>"
+        )
 
     async def test_get_throws_authentication_exception_for_bad_token(self):
-        async with simple_cache_client.init(_BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS) as simple_cache:
+        async with simple_cache_client.init(
+            _BAD_AUTH_TOKEN, _DEFAULT_TTL_SECONDS
+        ) as simple_cache:
             with self.assertRaises(errors.AuthenticationError):
                 await simple_cache.get(_TEST_CACHE_NAME, "foo")
 
     async def test_get_throws_timeout_error_for_short_request_timeout(self):
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 await simple_cache.get(_TEST_CACHE_NAME, "foo")
 
     # Multi op tests
     async def test_multi_get_and_set(self):
-        set_resp = await self.client.multi_set(
-            cache_name=_TEST_CACHE_NAME,
-            ops=[
-                CacheMultiSetOperation(key="foo1", value="bar1"),
-                CacheMultiSetOperation(key="foo2", value="bar2"),
-                CacheMultiSetOperation(key="foo3", value="bar3"),
-                CacheMultiSetOperation(key="foo4", value="bar4"),
-                CacheMultiSetOperation(key="foo5", value="bar5"),
-            ]
-        )
-        self.assertEqual(0, len(set_resp.get_failed_responses()))
-        self.assertEqual(5, len(set_resp.get_successful_responses()))
+        items = {
+            "foo1": "bar1",
+            "foo2": "bar2",
+            "foo3": "bar3",
+            "foo4": "bar4",
+            "foo5": "bar5",
+        }
+        set_resp = await self.client.multi_set(cache_name=_TEST_CACHE_NAME, items=items)
+        self.assertEqual(items, set_resp.items())
+
         get_resp = await self.client.multi_get(
-            _TEST_CACHE_NAME,
-            "foo5", "foo1", "foo2", "foo3")
+            _TEST_CACHE_NAME, "foo5", "foo1", "foo2", "foo3"
+        )
         values = get_resp.values()
         self.assertEqual("bar5", values[0])
         self.assertEqual("bar1", values[1])
@@ -372,48 +437,62 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
     async def test_multi_get_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
                 await simple_cache.multi_get(
-                    _TEST_CACHE_NAME,
-                    "key1", "key2", "key3", "key4", "key5", "key6"
+                    _TEST_CACHE_NAME, "key1", "key2", "key3", "key4", "key5", "key6"
                 )
 
     async def test_multi_set_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
-        async with simple_cache_client.init(_AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1) as simple_cache:
-            set_resp = await simple_cache.multi_set(
-                cache_name=_TEST_CACHE_NAME,
-                ops=[
-                    CacheMultiSetOperation(key="fizz1", value="buzz1"),
-                    CacheMultiSetOperation(key="fizz2", value="buzz2"),
-                    CacheMultiSetOperation(key="fizz3", value="buzz3"),
-                    CacheMultiSetOperation(key="fizz4", value="buzz4"),
-                    CacheMultiSetOperation(key="fizz5", value="buzz5"),
-                ]
-            )
+        async with simple_cache_client.init(
+            _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
+        ) as simple_cache:
+            with self.assertRaises(errors.TimeoutError):
+                await simple_cache.multi_set(
+                    cache_name=_TEST_CACHE_NAME,
+                    items={
+                        "fizz1": "buzz1",
+                        "fizz2": "buzz2",
+                        "fizz3": "buzz3",
+                        "fizz4": "buzz4",
+                        "fizz5": "buzz5",
+                    },
+                )
 
     # Test delete for key that doesn't exist
     async def test_delete_key_doesnt_exist(self):
         key = "a key that isnt there"
-        self.assertEqual(CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
         await self.client.delete(_TEST_CACHE_NAME, key)
-        self.assertEqual(CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
     # Test delete
     async def test_delete(self):
         # Set an item to then delete...
         key = "key1"
-        self.assertEqual(CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
         await self.client.set(_TEST_CACHE_NAME, key, "value1")
-        self.assertEqual(CacheGetStatus.HIT, (await self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.HIT, (await self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
         # Delete
         await self.client.delete(_TEST_CACHE_NAME, key)
 
         # Verify deleted
-        self.assertEqual(CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status())
+        self.assertEqual(
+            CacheGetStatus.MISS, (await self.client.get(_TEST_CACHE_NAME, key)).status()
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -5,11 +5,7 @@ import uuid
 
 import momento.aio.simple_cache_client as simple_cache_client
 import momento.errors as errors
-from momento.cache_operation_types import (
-    CacheGetStatus,
-    CacheMultiSetOperation,
-    CacheMultiGetOperation,
-)
+from momento.cache_operation_types import CacheGetStatus
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
 
 _AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")

--- a/tests/test_momento_signer.py
+++ b/tests/test_momento_signer.py
@@ -16,97 +16,146 @@ _ES_256_JWK_PUB = '{"kty":"EC","crv":"P-256","kid":"testKeyId","x":"xtu5hUhexZV7
 _ES_NO_ALG_JWK = '{"kty":"EC","d":"ZhrhvO1Zk8ENkqlDXpHrEJ2TWgZhPSyjgX0j-8jUWig","crv":"P-256","kid":"testKeyId","x":"5BU5xuaUvasp9gUfSS3HGtqd1oHdGoHH3KtrzoQLd0Q","y":"WUjUeDikRXRHa-AWyNdH5Ye1Nyifd3P26F52Uv4eTVo"}'
 _ES_NO_ALG_JWK_PUB = '{"kty":"EC","crv":"P-256","kid":"testKeyId","x":"5BU5xuaUvasp9gUfSS3HGtqd1oHdGoHH3KtrzoQLd0Q","y":"WUjUeDikRXRHa-AWyNdH5Ye1Nyifd3P26F52Uv4eTVo"}'
 
+
 class TestMomentoSigner(unittest.TestCase):
     def test_rsa256(self):
-        token = MomentoSigner(_RSA_256_JWK).sign_access_token(SigningRequest(
-            cache_name="foo",
-            cache_key="bar",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
-        verified_claims = jwt.decode(token, PyJWK.from_json(_RSA_256_JWK_PUB).key, algorithms=["RS256"])
-        self.assertEqual(verified_claims, {'exp': 4079276098, 'cache': 'foo', 'key': 'bar', 'method': ['get']})
+        token = MomentoSigner(_RSA_256_JWK).sign_access_token(
+            SigningRequest(
+                cache_name="foo",
+                cache_key="bar",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            )
+        )
+        verified_claims = jwt.decode(
+            token, PyJWK.from_json(_RSA_256_JWK_PUB).key, algorithms=["RS256"]
+        )
+        self.assertEqual(
+            verified_claims,
+            {"exp": 4079276098, "cache": "foo", "key": "bar", "method": ["get"]},
+        )
 
     def test_rsa_no_alg(self):
-        token = MomentoSigner(_RSA_NO_ALG_JWK).sign_access_token(SigningRequest(
-            cache_name="foo",
-            cache_key="bar",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
-        verified_claims = jwt.decode(token, PyJWK.from_json(_RSA_NO_ALG_JWK_PUB).key, algorithms=["RS256"])
-        self.assertEqual(verified_claims, {'exp': 4079276098, 'cache': 'foo', 'key': 'bar', 'method': ['get']})
+        token = MomentoSigner(_RSA_NO_ALG_JWK).sign_access_token(
+            SigningRequest(
+                cache_name="foo",
+                cache_key="bar",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            )
+        )
+        verified_claims = jwt.decode(
+            token, PyJWK.from_json(_RSA_NO_ALG_JWK_PUB).key, algorithms=["RS256"]
+        )
+        self.assertEqual(
+            verified_claims,
+            {"exp": 4079276098, "cache": "foo", "key": "bar", "method": ["get"]},
+        )
 
     def test_rsa384(self):
-        token = MomentoSigner(_RSA_384_JWK).sign_access_token(SigningRequest(
-            cache_name="foo",
-            cache_key="bar",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
-        verified_claims = jwt.decode(token, PyJWK.from_json(_RSA_384_JWK_PUB).key, algorithms=["RS384"])
-        self.assertEqual(verified_claims, {'exp': 4079276098, 'cache': 'foo', 'key': 'bar', 'method': ['get']})
-
+        token = MomentoSigner(_RSA_384_JWK).sign_access_token(
+            SigningRequest(
+                cache_name="foo",
+                cache_key="bar",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            )
+        )
+        verified_claims = jwt.decode(
+            token, PyJWK.from_json(_RSA_384_JWK_PUB).key, algorithms=["RS384"]
+        )
+        self.assertEqual(
+            verified_claims,
+            {"exp": 4079276098, "cache": "foo", "key": "bar", "method": ["get"]},
+        )
 
     def test_es256(self):
-        token = MomentoSigner(_ES_256_JWK).sign_access_token(SigningRequest(
-            cache_name="foo",
-            cache_key="bar",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
-        verified_claims = jwt.decode(token, PyJWK.from_json(_ES_256_JWK_PUB).key, algorithms=["ES256"])
-        self.assertEqual(verified_claims, {'exp': 4079276098, 'cache': 'foo', 'key': 'bar', 'method': ['get']})
+        token = MomentoSigner(_ES_256_JWK).sign_access_token(
+            SigningRequest(
+                cache_name="foo",
+                cache_key="bar",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            )
+        )
+        verified_claims = jwt.decode(
+            token, PyJWK.from_json(_ES_256_JWK_PUB).key, algorithms=["ES256"]
+        )
+        self.assertEqual(
+            verified_claims,
+            {"exp": 4079276098, "cache": "foo", "key": "bar", "method": ["get"]},
+        )
 
     def test_es_no_alg(self):
-        token = MomentoSigner(_ES_NO_ALG_JWK).sign_access_token(SigningRequest(
-            cache_name="foo",
-            cache_key="bar",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
-        verified_claims = jwt.decode(token, PyJWK.from_json(_ES_NO_ALG_JWK_PUB).key, algorithms=["ES256"])
-        self.assertEqual(verified_claims, {'exp': 4079276098, 'cache': 'foo', 'key': 'bar', 'method': ['get']})
+        token = MomentoSigner(_ES_NO_ALG_JWK).sign_access_token(
+            SigningRequest(
+                cache_name="foo",
+                cache_key="bar",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            )
+        )
+        verified_claims = jwt.decode(
+            token, PyJWK.from_json(_ES_NO_ALG_JWK_PUB).key, algorithms=["ES256"]
+        )
+        self.assertEqual(
+            verified_claims,
+            {"exp": 4079276098, "cache": "foo", "key": "bar", "method": ["get"]},
+        )
 
     def test_empty_jwk_json_string(self):
         with self.assertRaises(InvalidArgumentError):
-            MomentoSigner('')
+            MomentoSigner("")
 
     def test_nothing_jwk_json_string(self):
         with self.assertRaises(InvalidArgumentError):
-            MomentoSigner('{}')
+            MomentoSigner("{}")
 
     def test_incomplete_jwk_json_string(self):
         with self.assertRaises(InvalidArgumentError):
             MomentoSigner('{"alg":"foo","kid":"bar","kty":"RSA"}')
 
-
     def test_create_presigned_url_for_get(self):
-        result = MomentoSigner(_RSA_256_JWK).create_presigned_url("example.com", SigningRequest(
-            cache_name='!#$&\'()*+,/:;=?@[]',
-            cache_key="!#$&\'()*+,/:;=?@[]",
-            cache_operation=CacheOperation.GET,
-            expiry_epoch_seconds=4079276098
-        ))
+        result = MomentoSigner(_RSA_256_JWK).create_presigned_url(
+            "example.com",
+            SigningRequest(
+                cache_name="!#$&'()*+,/:;=?@[]",
+                cache_key="!#$&'()*+,/:;=?@[]",
+                cache_operation=CacheOperation.GET,
+                expiry_epoch_seconds=4079276098,
+            ),
+        )
 
-        self.assertEqual(result, 'https://rest.example.com/cache/get/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RLZXlJZCJ9.eyJleHAiOjQwNzkyNzYwOTgsImNhY2hlIjoiISMkJicoKSorLC86Oz0_QFtdIiwia2V5IjoiISMkJicoKSorLC86Oz0_QFtdIiwibWV0aG9kIjpbImdldCJdfQ.TpM6MLCnEWKJfwy0Mp5n9c9ygS5KwklpHqNTTCCncICTgENblbz3BGMUXUw4ljrTCt0uwxebX2iIROMGP32SevMlcygxsnXweHHVvkONAeok5ASvhiQtJcClb_4BMCkxPL7OlmaDlJVrcWdIqNa5E_HG6IWA6TXDJDzRrNPvknD7TVMRYDxaUMagdF3kPMBXZeO6CdlhLGb6Kfhmyc2mkdt8o-aCK3-n2vIXqiEwRNkSVr2iGBlP1l6nlVQ_dXfb0I56fLTncF1xWI1zDf2pbiQn9S3Z4n45_0C2yZy_FI8csWM2gYNqKK5VqsxkpbhlFJWyINxnyNA-FMBDhdJUZQ')
+        self.assertEqual(
+            result,
+            "https://rest.example.com/cache/get/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RLZXlJZCJ9.eyJleHAiOjQwNzkyNzYwOTgsImNhY2hlIjoiISMkJicoKSorLC86Oz0_QFtdIiwia2V5IjoiISMkJicoKSorLC86Oz0_QFtdIiwibWV0aG9kIjpbImdldCJdfQ.TpM6MLCnEWKJfwy0Mp5n9c9ygS5KwklpHqNTTCCncICTgENblbz3BGMUXUw4ljrTCt0uwxebX2iIROMGP32SevMlcygxsnXweHHVvkONAeok5ASvhiQtJcClb_4BMCkxPL7OlmaDlJVrcWdIqNa5E_HG6IWA6TXDJDzRrNPvknD7TVMRYDxaUMagdF3kPMBXZeO6CdlhLGb6Kfhmyc2mkdt8o-aCK3-n2vIXqiEwRNkSVr2iGBlP1l6nlVQ_dXfb0I56fLTncF1xWI1zDf2pbiQn9S3Z4n45_0C2yZy_FI8csWM2gYNqKK5VqsxkpbhlFJWyINxnyNA-FMBDhdJUZQ",
+        )
 
     def test_create_presigned_url_for_set(self):
-        result = MomentoSigner(_RSA_256_JWK).create_presigned_url("example.com", SigningRequest(
-            cache_name="!#$&\'()*+,/:;=?@[]",
-            cache_key="!#$&\'()*+,/:;=?@[]",
-            cache_operation=CacheOperation.SET,
-            expiry_epoch_seconds=4079276098,
-            ttl_seconds=5
-        ))
+        result = MomentoSigner(_RSA_256_JWK).create_presigned_url(
+            "example.com",
+            SigningRequest(
+                cache_name="!#$&'()*+,/:;=?@[]",
+                cache_key="!#$&'()*+,/:;=?@[]",
+                cache_operation=CacheOperation.SET,
+                expiry_epoch_seconds=4079276098,
+                ttl_seconds=5,
+            ),
+        )
 
-        self.assertEqual(result, 'https://rest.example.com/cache/set/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RLZXlJZCJ9.eyJleHAiOjQwNzkyNzYwOTgsImNhY2hlIjoiISMkJicoKSorLC86Oz0_QFtdIiwia2V5IjoiISMkJicoKSorLC86Oz0_QFtdIiwibWV0aG9kIjpbInNldCJdLCJ0dGwiOjV9.GlsGrxuoMMvwyr-SHBxfAK_CEk55P218jcsBTW9PiXoYgd85BNuDaHcQJaE_31CRdJ5emXj_qIQZjFLz3LDb3zHSAHCSYzg_pDZyVB-yLaW4nOCiztaxlr_FsihgghHUziO2lFyPgNpx2iZUQ5RnUvaCkhwN8R-FbKhBQ4Oh8hG4xBuILEIA5fJ8PAhbvmqzgmgbzplbhPMVvNPVXbdEn5YCdqIuoo6oQTB8ksgm788d7zRBgJmcyF07lDviGFaXt7OYshBWxKZ8f8Iv9PTaDtIFWPJDdaYCTcaYoaOqA2VXFEFmqcuDwcRIaNGkaYd8emqnlKc4ItdASLWV5k1Wjg&ttl_milliseconds=5000')
+        self.assertEqual(
+            result,
+            "https://rest.example.com/cache/set/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RLZXlJZCJ9.eyJleHAiOjQwNzkyNzYwOTgsImNhY2hlIjoiISMkJicoKSorLC86Oz0_QFtdIiwia2V5IjoiISMkJicoKSorLC86Oz0_QFtdIiwibWV0aG9kIjpbInNldCJdLCJ0dGwiOjV9.GlsGrxuoMMvwyr-SHBxfAK_CEk55P218jcsBTW9PiXoYgd85BNuDaHcQJaE_31CRdJ5emXj_qIQZjFLz3LDb3zHSAHCSYzg_pDZyVB-yLaW4nOCiztaxlr_FsihgghHUziO2lFyPgNpx2iZUQ5RnUvaCkhwN8R-FbKhBQ4Oh8hG4xBuILEIA5fJ8PAhbvmqzgmgbzplbhPMVvNPVXbdEn5YCdqIuoo6oQTB8ksgm788d7zRBgJmcyF07lDviGFaXt7OYshBWxKZ8f8Iv9PTaDtIFWPJDdaYCTcaYoaOqA2VXFEFmqcuDwcRIaNGkaYd8emqnlKc4ItdASLWV5k1Wjg&ttl_milliseconds=5000",
+        )
 
     def test_create_presigned_url_for_set_missing_ttl(self):
         with self.assertRaises(InvalidArgumentError):
-            MomentoSigner(_RSA_256_JWK).create_presigned_url("example.com", SigningRequest(
-                cache_name="!#$&\'()*+,/:;=?@[]",
-                cache_key="!#$&\'()*+,/:;=?@[]",
-                cache_operation=CacheOperation.SET,
-                expiry_epoch_seconds=4079276098,
-            ))
+            MomentoSigner(_RSA_256_JWK).create_presigned_url(
+                "example.com",
+                SigningRequest(
+                    cache_name="!#$&'()*+,/:;=?@[]",
+                    cache_key="!#$&'()*+,/:;=?@[]",
+                    cache_operation=CacheOperation.SET,
+                    expiry_epoch_seconds=4079276098,
+                ),
+            )


### PR DESCRIPTION
Closes #111 

I refactored `multi_get` and `multi_set` to use method signatures and responses like those we approved for the dictionary type. In short:

```python
client.multi_set(cache_name="my-cache", items={"key1": "value1", "key2": "value2"}, ttl_seconds=60)

response = client.multi_get("my-cache", "key1", "key2", "key3")
response.status() # [<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>]
response.values() # ["value1", "value2", None]
response.to_list() # CacheMultiGetResponse(responses=[CacheGetResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>), CacheGetResponse(value=b'value2', result=<CacheGetStatus.HIT: 1>), CacheGetResponse(value=None, result=<CacheGetStatus:MISS 2>)])

```