### PR TITLE
chore: Add repr and str methods to response objects

### DIFF
--- a/src/momento/aio/_scs_control_client.py
+++ b/src/momento/aio/_scs_control_client.py
@@ -37,11 +37,10 @@ class _ScsControlClient:
             _momento_logger.debug(f"Creating cache with name: {cache_name}")
             request = _CreateCacheRequest()
             request.cache_name = cache_name
-            return CreateCacheResponse.from_grpc_response(
-                await self._grpc_manager.async_stub().CreateCache(
-                    request, timeout=_DEADLINE_SECONDS
-                )
+            await self._grpc_manager.async_stub().CreateCache(
+                request, timeout=_DEADLINE_SECONDS
             )
+            return CreateCacheResponse()
         except Exception as e:
             _momento_logger.debug(
                 f"Failed to create cache: {cache_name} with exception:{e}"
@@ -54,11 +53,10 @@ class _ScsControlClient:
             _momento_logger.debug(f"Deleting cache with name: {cache_name}")
             request = _DeleteCacheRequest()
             request.cache_name = cache_name
-            return DeleteCacheResponse.from_grpc_response(
-                await self._grpc_manager.async_stub().DeleteCache(
-                    request, timeout=_DEADLINE_SECONDS
-                )
+            await self._grpc_manager.async_stub().DeleteCache(
+                request, timeout=_DEADLINE_SECONDS
             )
+            return DeleteCacheResponse()
         except Exception as e:
             _momento_logger.debug(
                 f"Failed to delete cache: {cache_name} with exception:{e}"
@@ -104,11 +102,10 @@ class _ScsControlClient:
             _momento_logger.debug(f"Revoking signing key with key_id {key_id}")
             request = _RevokeSigningKeyRequest()
             request.key_id = key_id
-            return RevokeSigningKeyResponse.from_grpc_response(
-                await self._grpc_manager.async_stub().RevokeSigningKey(
-                    request, timeout=_DEADLINE_SECONDS
-                )
+            await self._grpc_manager.async_stub().RevokeSigningKey(
+                request, timeout=_DEADLINE_SECONDS
             )
+            return RevokeSigningKeyResponse()
         except Exception as e:
             _momento_logger.debug(
                 f"Failed to revoke signing key with key_id {key_id} exception: {e}"

--- a/src/momento/aio/_scs_control_client.py
+++ b/src/momento/aio/_scs_control_client.py
@@ -37,7 +37,7 @@ class _ScsControlClient:
             _momento_logger.debug(f"Creating cache with name: {cache_name}")
             request = _CreateCacheRequest()
             request.cache_name = cache_name
-            return CreateCacheResponse(
+            return CreateCacheResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().CreateCache(
                     request, timeout=_DEADLINE_SECONDS
                 )
@@ -54,7 +54,7 @@ class _ScsControlClient:
             _momento_logger.debug(f"Deleting cache with name: {cache_name}")
             request = _DeleteCacheRequest()
             request.cache_name = cache_name
-            return DeleteCacheResponse(
+            return DeleteCacheResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().DeleteCache(
                     request, timeout=_DEADLINE_SECONDS
                 )
@@ -71,7 +71,7 @@ class _ScsControlClient:
             list_caches_request.next_token = (
                 next_token if next_token is not None else ""
             )
-            return ListCachesResponse(
+            return ListCachesResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().ListCaches(
                     list_caches_request, timeout=_DEADLINE_SECONDS
                 )
@@ -89,7 +89,7 @@ class _ScsControlClient:
             )
             create_signing_key_request = _CreateSigningKeyRequest()
             create_signing_key_request.ttl_minutes = ttl_minutes
-            return CreateSigningKeyResponse(
+            return CreateSigningKeyResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().CreateSigningKey(
                     create_signing_key_request, timeout=_DEADLINE_SECONDS
                 ),
@@ -104,7 +104,7 @@ class _ScsControlClient:
             _momento_logger.debug(f"Revoking signing key with key_id {key_id}")
             request = _RevokeSigningKeyRequest()
             request.key_id = key_id
-            return RevokeSigningKeyResponse(
+            return RevokeSigningKeyResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().RevokeSigningKey(
                     request, timeout=_DEADLINE_SECONDS
                 )
@@ -123,7 +123,7 @@ class _ScsControlClient:
             list_signing_keys_request.next_token = (
                 next_token if next_token is not None else ""
             )
-            return ListSigningKeysResponse(
+            return ListSigningKeysResponse.from_grpc_response(
                 await self._grpc_manager.async_stub().ListSigningKeys(
                     list_signing_keys_request, timeout=_DEADLINE_SECONDS
                 ),

--- a/src/momento/aio/_scs_data_client.py
+++ b/src/momento/aio/_scs_data_client.py
@@ -64,7 +64,7 @@ class _ScsDataClient:
             )
             _momento_logger.debug(f"Set succeeded for key: {str(key)}")
             return cache_sdk_ops.CacheSetResponse(
-                response, set_request.cache_key, set_request.cache_body
+                set_request.cache_key, set_request.cache_body
             )
         except Exception as e:
             _momento_logger.debug(f"Set failed for {str(key)} with response: {e}")
@@ -163,7 +163,7 @@ class _ScsDataClient:
                 timeout=self._default_deadline_seconds,
             )
             _momento_logger.debug(f"Received a delete response for {str(key)}")
-            return cache_sdk_ops.CacheDeleteResponse(response)
+            return cache_sdk_ops.CacheDeleteResponse.from_grpc_response(response)
         except Exception as e:
             _momento_logger.debug(f"Delete failed for {str(key)} with response: {e}")
             raise _cache_service_errors_converter.convert(e)

--- a/src/momento/aio/_scs_data_client.py
+++ b/src/momento/aio/_scs_data_client.py
@@ -163,7 +163,7 @@ class _ScsDataClient:
                 timeout=self._default_deadline_seconds,
             )
             _momento_logger.debug(f"Received a delete response for {str(key)}")
-            return cache_sdk_ops.CacheDeleteResponse.from_grpc_response(response)
+            return cache_sdk_ops.CacheDeleteResponse()
         except Exception as e:
             _momento_logger.debug(f"Delete failed for {str(key)} with response: {e}")
             raise _cache_service_errors_converter.convert(e)

--- a/src/momento/aio/_scs_grpc_manager.py
+++ b/src/momento/aio/_scs_grpc_manager.py
@@ -1,5 +1,5 @@
 import grpc
-import pkg_resources
+import pkg_resources  # type: ignore
 
 import momento_wire_types.cacheclient_pb2_grpc as cache_client
 import momento_wire_types.controlclient_pb2_grpc as control_client

--- a/src/momento/aio/_scs_grpc_manager.py
+++ b/src/momento/aio/_scs_grpc_manager.py
@@ -1,5 +1,5 @@
 import grpc
-import pkg_resources  # type: ignore
+import pkg_resources
 
 import momento_wire_types.cacheclient_pb2_grpc as cache_client
 import momento_wire_types.controlclient_pb2_grpc as control_client

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -20,9 +20,6 @@ class CacheSetResponse:
         Args:
             key (bytes): The value of the key of item that was stored in cache..
             value (bytes): The value of item that was stored in the cache.
-
-        Raises:
-            InternalServerError: If server encountered an unknown error while trying to store the item.
         """
         self._value = value
         self._key = key

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -149,10 +149,6 @@ class CacheDeleteResponse:
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def from_grpc_response(grpc_create_cache_response: Any) -> "CacheDeleteResponse":  # type: ignore[misc]
-        return CacheDeleteResponse()
-
     def __str__(self) -> str:
         return self.__repr__()
 
@@ -164,10 +160,6 @@ class CreateCacheResponse:
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def from_grpc_response(grpc_create_cache_response: Any) -> "CreateCacheResponse":  # type: ignore[misc]
-        return CreateCacheResponse()
-
     def __str__(self) -> str:
         return self.__repr__()
 
@@ -178,10 +170,6 @@ class CreateCacheResponse:
 class DeleteCacheResponse:
     def __init__(self) -> None:
         pass
-
-    @staticmethod
-    def from_grpc_response(grpc_create_cache_response: Any) -> "DeleteCacheResponse":  # type: ignore[misc]
-        return DeleteCacheResponse()
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -307,10 +295,6 @@ class CreateSigningKeyResponse:
 class RevokeSigningKeyResponse:
     def __init__(self) -> None:
         pass
-
-    @staticmethod
-    def from_grpc_response(grpc_revoke_signing_key_response: Any) -> "RevokeSigningKeyResponse":  # type: ignore[misc]
-        return RevokeSigningKeyResponse()
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -14,11 +14,10 @@ class CacheGetStatus(Enum):
 
 
 class CacheSetResponse:
-    def __init__(self, grpc_set_response: Any, key: bytes, value: bytes):  # type: ignore[misc]
+    def __init__(self, key: bytes, value: bytes):
         """Initializes CacheSetResponse to handle gRPC set response.
 
         Args:
-            grpc_set_response: Protobuf based response returned by Scs.
             key (bytes): The value of the key of item that was stored in cache..
             value (bytes): The value of item that was stored in the cache.
 
@@ -44,6 +43,12 @@ class CacheSetResponse:
         """Returns key of item stored in cache as bytes."""
         return self._key
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CacheSetResponse(key={self._key!r}, value={self._value!r})"
+
 
 class CacheMultiSetResponse:
     def __init__(self, items: Mapping[bytes, bytes]):
@@ -57,6 +62,9 @@ class CacheMultiSetResponse:
 
     def items_as_bytes(self) -> Mapping[bytes, bytes]:
         return self._items
+
+    def __str__(self) -> str:
+        return self.__repr__()
 
     def __repr__(self) -> str:
         return f"CacheMultiSetResponse(items={self._items!r})"
@@ -108,6 +116,9 @@ class CacheGetResponse:
         """Returns get operation result such as HIT or MISS."""
         return self._status
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
     def __repr__(self) -> str:
         return f"CacheGetResponse(value={self._value!r}, status={self._status!r})"
 
@@ -130,54 +141,97 @@ class CacheMultiGetResponse:
     def to_list(self) -> List[CacheGetResponse]:
         return self._responses
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
     def __repr__(self) -> str:
         return f"CacheMultiGetResponse(responses={self._responses!r})"
 
 
 class CacheDeleteResponse:
-    def __init__(self, grpc_create_cache_response: Any):  # type: ignore[misc]
+    def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def from_grpc_response(grpc_create_cache_response: Any) -> "CacheDeleteResponse":  # type: ignore[misc]
+        return CacheDeleteResponse()
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CacheDeleteResponse()"
 
 
 class CreateCacheResponse:
-    def __init__(self, grpc_create_cache_response: Any):  # type: ignore[misc]
+    def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def from_grpc_response(grpc_create_cache_response: Any) -> "CreateCacheResponse":  # type: ignore[misc]
+        return CreateCacheResponse()
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CreateCacheResponse()"
 
 
 class DeleteCacheResponse:
-    def __init__(self, grpc_delete_cache_response: Any):  # type: ignore[misc]
+    def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def from_grpc_response(grpc_create_cache_response: Any) -> "DeleteCacheResponse":  # type: ignore[misc]
+        return DeleteCacheResponse()
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"DeleteCacheResponse()"
 
 
 class CacheInfo:
-    def __init__(self, grpc_listed_cache: Any):  # type: ignore[misc]
+    def __init__(self, name: str):
+        """Initializes CacheInfo to handle caches returned from list cache operation.
+
+        Args:
+            name (str): Name of the cache.
+        """
+        self._name = name
+
+    def name(self) -> str:
+        """Returns the cache's name."""
+        return self._name
+
+    @staticmethod
+    def from_grpc_response(grpc_listed_cache: Any) -> "CacheInfo":  # type: ignore[misc]
         """Initializes CacheInfo to handle caches returned from list cache operation.
 
         Args:
             grpc_listed_cache: Protobuf based response returned by Scs.
         """
-        self._name: str = grpc_listed_cache.cache_name  # type: ignore[misc]
+        return CacheInfo(name=grpc_listed_cache.cache_name)  # type: ignore[misc]
 
-    def name(self) -> str:
-        """Returns all cache's name."""
-        return self._name
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CacheInfo(name={self._name!r})"
 
 
 class ListCachesResponse:
-    def __init__(self, grpc_list_cache_response: Any):  # type: ignore[misc]
+    def __init__(self, next_token: Optional[str], caches: List[CacheInfo]):
         """Initializes ListCacheResponse to handle list cache response.
 
         Args:
-            grpc_list_cache_response: Protobuf based response returned by Scs.
+            next_token (Optional[str]): Next list caches page token.
+            caches (List[CacheInfo]): Cache info from this page of results.
         """
-        self._next_token: Optional[str] = (
-            grpc_list_cache_response.next_token  # type: ignore[misc]
-            if grpc_list_cache_response.next_token != ""  # type: ignore[misc]
-            else None
-        )
-        self._caches = []
-        for cache in grpc_list_cache_response.cache:  # type: ignore[misc]
-            self._caches.append(CacheInfo(cache))  # type: ignore[misc]
+        self._next_token = next_token
+        self._caches = caches
 
     def next_token(self) -> Optional[str]:
         """Returns next token."""
@@ -187,20 +241,39 @@ class ListCachesResponse:
         """Returns all caches."""
         return self._caches
 
+    @staticmethod
+    def from_grpc_response(grpc_list_cache_response: Any) -> "ListCachesResponse":  # type: ignore[misc]
+        """Initializes ListCacheResponse to handle list cache response.
+
+        Args:
+            grpc_list_cache_response: Protobuf based response returned by Scs.
+        """
+        next_token: Optional[str] = (
+            grpc_list_cache_response.next_token  # type: ignore[misc]
+            if grpc_list_cache_response.next_token != ""  # type: ignore[misc]
+            else None
+        )
+        caches = [CacheInfo.from_grpc_response(cache) for cache in grpc_list_cache_response.cache]  # type: ignore[misc]
+        return ListCachesResponse(next_token=next_token, caches=caches)
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"ListCachesResponse(next_token={self._next_token!r}, caches={self._caches!r})"
+
 
 class CreateSigningKeyResponse:
-    def __init__(self, grpc_create_signing_key_response: Any, endpoint: str):  # type: ignore[misc]
+    def __init__(self, key_id: str, endpoint: str, key: str, expires_at: datetime):
         """Initializes CreateSigningKeyResponse to handle create signing key response.
 
         Args:
             grpc_create_signing_key_response: Protobuf based response returned by Scs.
         """
-        self._key_id: str = json.loads(grpc_create_signing_key_response.key)["kid"]  # type: ignore[misc]
-        self._endpoint: str = endpoint
-        self._key: str = grpc_create_signing_key_response.key  # type: ignore[misc]
-        self._expires_at: datetime = datetime.fromtimestamp(
-            grpc_create_signing_key_response.expires_at  # type: ignore[misc]
-        )
+        self._key_id = key_id
+        self._endpoint = endpoint
+        self._key = key
+        self._expires_at = expires_at
 
     def key_id(self) -> str:
         """Returns the id of the signing key"""
@@ -218,24 +291,47 @@ class CreateSigningKeyResponse:
         """Returns the datetime representation of when the key expires"""
         return self._expires_at
 
+    @staticmethod
+    def from_grpc_response(grpc_create_signing_key_response: Any, endpoint: str) -> "CreateSigningKeyResponse":  # type: ignore[misc]
+        key_id: str = json.loads(grpc_create_signing_key_response.key)["kid"]  # type: ignore[misc]
+        key: str = grpc_create_signing_key_response.key  # type: ignore[misc]
+        expires_at: datetime = datetime.fromtimestamp(
+            grpc_create_signing_key_response.expires_at  # type: ignore[misc]
+        )
+        return CreateSigningKeyResponse(key_id, endpoint, key, expires_at)
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"CreateSigningKeyResponse(key_id={self._key_id!r}, endpoint={self._endpoint!r}, key={self._key!r}, expires_at={self._expires_at!r})"
+
 
 class RevokeSigningKeyResponse:
-    def __init__(self, grpc_revoke_signing_key_response: Any):  # type: ignore[misc]
+    def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def from_grpc_response(grpc_revoke_signing_key_response: Any) -> "RevokeSigningKeyResponse":  # type: ignore[misc]
+        return RevokeSigningKeyResponse()
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"RevokeSigningKeyResponse()"
 
 
 class SigningKey:
-    def __init__(self, grpc_listed_signing_key: Any, endpoint: str):  # type: ignore[misc]
+    def __init__(self, key_id: str, expires_at: datetime, endpoint: str):
         """Initializes SigningKey to handle signing keys returned from list signing keys operation.
 
         Args:
             grpc_listed_signing_key: Protobuf based response returned by Scs.
         """
-        self._key_id: str = grpc_listed_signing_key.key_id  # type: ignore[misc]
-        self._expires_at: datetime = datetime.fromtimestamp(
-            grpc_listed_signing_key.expires_at  # type: ignore[misc]
-        )
-        self._endpoint: str = endpoint
+        self._key_id = key_id
+        self._expires_at = expires_at
+        self._endpoint = endpoint
 
     def key_id(self) -> str:
         """Returns the id of the Momento signing key"""
@@ -249,23 +345,30 @@ class SigningKey:
         """Returns the endpoint of the Momento signing key"""
         return self._endpoint
 
+    @staticmethod
+    def from_grpc_response(grpc_listed_signing_key: Any, endpoint: str) -> "SigningKey":  # type: ignore[misc]
+        key_id: str = grpc_listed_signing_key.key_id  # type: ignore[misc]
+        expires_at: datetime = datetime.fromtimestamp(
+            grpc_listed_signing_key.expires_at  # type: ignore[misc]
+        )
+        return SigningKey(key_id, expires_at, endpoint)
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"SigningKey(key_id={self._key_id!r}, expires_at={self._expires_at!r}, endpoint={self._endpoint!r})"
+
 
 class ListSigningKeysResponse:
-    def __init__(self, grpc_list_signing_keys_response: Any, endpoint: str):  # type: ignore[misc]
+    def __init__(self, next_token: Optional[str], signing_keys: List[SigningKey]):
         """Initializes ListSigningKeysResponse to handle list signing keys response.
 
         Args:
             grpc_list_signing_keys_response: Protobuf based response returned by Scs.
         """
-        self._next_token: Optional[str] = (
-            grpc_list_signing_keys_response.next_token  # type: ignore[misc]
-            if grpc_list_signing_keys_response.next_token != ""  # type: ignore[misc]
-            else None
-        )
-        self._signing_keys: List[SigningKey] = [  # type: ignore[misc]
-            SigningKey(signing_key, endpoint)  # type: ignore[misc]
-            for signing_key in grpc_list_signing_keys_response.signing_key  # type: ignore[misc]
-        ]
+        self._next_token = next_token
+        self._signing_keys = signing_keys
 
     def next_token(self) -> Optional[str]:
         """Returns next token."""
@@ -274,3 +377,22 @@ class ListSigningKeysResponse:
     def signing_keys(self) -> List[SigningKey]:
         """Returns all signing keys."""
         return self._signing_keys
+
+    @staticmethod
+    def from_grpc_response(grpc_list_signing_keys_response: Any, endpoint: str) -> "ListSigningKeysResponse":  # type: ignore[misc]
+        next_token: Optional[str] = (
+            grpc_list_signing_keys_response.next_token  # type: ignore[misc]
+            if grpc_list_signing_keys_response.next_token != ""  # type: ignore[misc]
+            else None
+        )
+        signing_keys: List[SigningKey] = [  # type: ignore[misc]
+            SigningKey.from_grpc_response(signing_key, endpoint)  # type: ignore[misc]
+            for signing_key in grpc_list_signing_keys_response.signing_key  # type: ignore[misc]
+        ]
+        return ListSigningKeysResponse(next_token, signing_keys)
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"ListSigningKeysResponse(next_token={self._next_token!r}, signing_keys={self._signing_keys!r})"

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -63,9 +63,9 @@ class CacheMultiSetResponse:
 
 
 class CacheGetResponse:
-    def __init__(self, value: bytes, result: CacheGetStatus):
+    def __init__(self, value: bytes, status: CacheGetStatus):
         self._value = value
-        self._result = result
+        self._status = status
 
     @staticmethod
     def from_grpc_response(grpc_get_response: Any) -> "CacheGetResponse":  # type: ignore[misc]
@@ -80,9 +80,9 @@ class CacheGetResponse:
         value: bytes = grpc_get_response.cache_body  # type: ignore[misc]
 
         if grpc_get_response.result == cache_client_types.Hit:  # type: ignore[misc]
-            result = CacheGetStatus.HIT
+            status = CacheGetStatus.HIT
         elif grpc_get_response.result == cache_client_types.Miss:  # type: ignore[misc]
-            result = CacheGetStatus.MISS
+            status = CacheGetStatus.MISS
         else:
             _momento_logger.debug(
                 f"Get received unsupported ECacheResult: {grpc_get_response.result}"  # type: ignore[misc]
@@ -90,26 +90,26 @@ class CacheGetResponse:
             raise error_converter.convert_ecache_result(
                 grpc_get_response.result, grpc_get_response.message, "GET"  # type: ignore[misc]
             )
-        return CacheGetResponse(value=value, result=result)
+        return CacheGetResponse(value=value, status=status)
 
     def value(self) -> Optional[str]:
         """Returns value stored in cache as utf-8 string if there was Hit. Returns None otherwise."""
-        if self._result == CacheGetStatus.HIT:
+        if self._status == CacheGetStatus.HIT:
             return self._value.decode("utf-8")
         return None
 
     def value_as_bytes(self) -> Optional[bytes]:
         """Returns value stored in cache as bytes if there was Hit. Returns None otherwise."""
-        if self._result == CacheGetStatus.HIT:
+        if self._status == CacheGetStatus.HIT:
             return self._value
         return None
 
     def status(self) -> CacheGetStatus:
         """Returns get operation result such as HIT or MISS."""
-        return self._result
+        return self._status
 
     def __repr__(self) -> str:
-        return f"CacheGetResponse(value={self._value!r}, result={self._result!r})"
+        return f"CacheGetResponse(value={self._value!r}, status={self._status!r})"
 
 
 class CacheMultiGetResponse:

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -32,7 +32,7 @@ CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2':
 ```python
 >>> get_response = client.dictionary_get(cache_name="my-cache", dictionary_name="my-dictionary", key="key1")
 >>> get_response
-CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
+CacheDictionaryGetUnaryResponse(value=b'value1', status=<CacheGetStatus.HIT: 1>)
 
 >>> get_response.status()
 <CacheGetStatus.HIT: 1>
@@ -46,12 +46,12 @@ CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>)
 ```python
 >>> get_response = client.dictionary_multi_get("my-cache", "my-dictionary", "key1", "key2", "key7")
 >>> get_response
-CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
+CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], status=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
 
 >>> get_response.to_list()
-[CacheDictionaryGetUnaryResponse(value=b'value1', result=<CacheGetStatus.HIT: 1>),
- CacheDictionaryGetUnaryResponse(value=b'value2', result=<CacheGetStatus.HIT: 1>),
- CacheDictionaryGetUnaryResponse(value=None, result=<CacheGetStatus.MISS: 2>)]
+[CacheDictionaryGetUnaryResponse(value=b'value1', status=<CacheGetStatus.HIT: 1>),
+ CacheDictionaryGetUnaryResponse(value=b'value2', status=<CacheGetStatus.HIT: 1>),
+ CacheDictionaryGetUnaryResponse(value=None, status=<CacheGetStatus.MISS: 2>)]
 
  >>> get_response.status()
  [<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>]
@@ -65,7 +65,7 @@ CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], results=[<C
 ```python
 >>> dictionary_get_all_response = client.dictionary_get_all(cache_name="my-cache", dictionary_name="my-dictionary")
 >>> dictionary_get_all_response
-CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, result=<CacheGetStatus.HIT: 1>)
+CacheDictionaryGetAllResponse(value={b'key1': b'value1', b'key2': b'value2'}, status=<CacheGetStatus.HIT: 1>)
 
 >>> dictionary_get_all_response.value()
 {'key1': 'value1', 'key2': 'value2'}

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -144,7 +144,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         dictionary_get_response = await self.get(cache_name, dictionary_name)
         if dictionary_get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetUnaryResponse(
-                value=None, result=CacheGetStatus.MISS
+                value=None, status=CacheGetStatus.MISS
             )
 
         dictionary: BytesDictionary = deserialize_dictionary(
@@ -155,10 +155,10 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             value = dictionary[_as_bytes(key, "Unsupported type for key: ")]
         except KeyError:
             return CacheDictionaryGetUnaryResponse(
-                value=None, result=CacheGetStatus.MISS
+                value=None, status=CacheGetStatus.MISS
             )
 
-        return CacheDictionaryGetUnaryResponse(value=value, result=CacheGetStatus.HIT)
+        return CacheDictionaryGetUnaryResponse(value=value, status=CacheGetStatus.HIT)
 
     async def dictionary_multi_get(
         self,
@@ -184,7 +184,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         if dictionary_get_response.status() == CacheGetStatus.MISS:
             return CacheDictionaryGetMultiResponse(
                 values=[None for _ in range(len(keys))],
-                results=[CacheGetStatus.MISS for _ in range(len(keys))],
+                status=[CacheGetStatus.MISS for _ in range(len(keys))],
             )
 
         dictionary: BytesDictionary = deserialize_dictionary(
@@ -202,7 +202,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
                 values.append(None)
                 results.append(CacheGetStatus.MISS)
 
-        return CacheDictionaryGetMultiResponse(values=values, results=results)
+        return CacheDictionaryGetMultiResponse(values=values, status=results)
 
     async def dictionary_get_all(
         self, cache_name: str, dictionary_name: str
@@ -218,10 +218,10 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         """
         get_response = await self.get(cache_name, dictionary_name)
         if get_response.status() == CacheGetStatus.MISS:
-            return CacheDictionaryGetAllResponse(value=None, result=CacheGetStatus.MISS)
+            return CacheDictionaryGetAllResponse(value=None, status=CacheGetStatus.MISS)
 
         value = deserialize_dictionary(cast(bytes, get_response.value_as_bytes()))
-        return CacheDictionaryGetAllResponse(value=value, result=CacheGetStatus.HIT)
+        return CacheDictionaryGetAllResponse(value=value, status=CacheGetStatus.HIT)
 
 
 def init(

--- a/src/momento/incubating/cache_operation_types.py
+++ b/src/momento/incubating/cache_operation_types.py
@@ -13,9 +13,9 @@ Dictionary = Union[StringDictionary, BytesDictionary]
 
 
 class CacheDictionaryGetUnaryResponse:
-    def __init__(self, value: Optional[DictionaryValue], result: CacheGetStatus):
+    def __init__(self, value: Optional[DictionaryValue], status: CacheGetStatus):
         self._value = value
-        self._result = result
+        self._status = status
 
     def value(self) -> Optional[str]:
         if self.status() == CacheGetStatus.MISS:
@@ -28,57 +28,57 @@ class CacheDictionaryGetUnaryResponse:
         return cast(bytes, self._value)
 
     def status(self) -> CacheGetStatus:
-        return self._result
+        return self._status
 
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, CacheDictionaryGetUnaryResponse)
             and self._value == other._value
-            and self._result == other._result
+            and self._status == other._status
         )
 
     def __str__(self) -> str:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionaryGetUnaryResponse(value={self._value!r}, result={self._result!r})"
+        return f"CacheDictionaryGetUnaryResponse(value={self._value!r}, status={self._status!r})"
 
 
 class CacheDictionaryGetMultiResponse:
     def __init__(
-        self, values: List[Optional[DictionaryValue]], results: List[CacheGetStatus]
+        self, values: List[Optional[DictionaryValue]], status: List[CacheGetStatus]
     ):
         self._values = values
-        self._results = results
+        self._status = status
 
     def to_list(self) -> List[CacheDictionaryGetUnaryResponse]:
         return [
-            CacheDictionaryGetUnaryResponse(value, result)
-            for value, result in zip(self._values, self._results)
+            CacheDictionaryGetUnaryResponse(value, status)
+            for value, status in zip(self._values, self._status)
         ]
 
     def values(self) -> List[Optional[str]]:
         return [
             _bytes_to_string(cast(bytes, value))
-            if result == CacheGetStatus.HIT
+            if status == CacheGetStatus.HIT
             else None
-            for value, result in zip(self._values, self._results)
+            for value, status in zip(self._values, self._status)
         ]
 
     def values_as_bytes(self) -> List[Optional[bytes]]:
         return [
-            cast(bytes, value) if result == CacheGetStatus.HIT else None
-            for value, result in zip(self._values, self._results)
+            cast(bytes, value) if status == CacheGetStatus.HIT else None
+            for value, status in zip(self._values, self._status)
         ]
 
     def status(self) -> List[CacheGetStatus]:
-        return self._results
+        return self._status
 
     def __str__(self) -> str:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionaryGetMultiResponse(values={self._values!r}, results={self._results!r})"
+        return f"CacheDictionaryGetMultiResponse(values={self._values!r}, status={self._status!r})"
 
 
 class CacheDictionarySetUnaryResponse:
@@ -131,9 +131,9 @@ class CacheDictionarySetMultiResponse:
 
 
 class CacheDictionaryGetAllResponse:
-    def __init__(self, value: Optional[BytesDictionary], result: CacheGetStatus):
+    def __init__(self, value: Optional[BytesDictionary], status: CacheGetStatus):
         self._value = value
-        self._result = result
+        self._status = status
 
     def value(self) -> Optional[StringDictionary]:
         """Get the dictionary as stored in the cache.
@@ -158,10 +158,10 @@ class CacheDictionaryGetAllResponse:
         return self._value
 
     def status(self) -> CacheGetStatus:
-        return self._result
+        return self._status
 
     def __str__(self) -> str:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheDictionaryGetAllResponse(value={self._value!r}, result={self._result!r})"
+        return f"CacheDictionaryGetAllResponse(value={self._value!r}, status={self._status!r})"

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -161,7 +161,6 @@ class TestMomento(unittest.TestCase):
                 simple_cache.create_cache(str(uuid.uuid4()))
 
     # list_caches
-
     def test_list_caches_succeeds(self):
         cache_name = str(uuid.uuid4())
 


### PR DESCRIPTION
Closes #113 

Most of the response objects were lacking `__repr__` methods. Before users could expect output like this:

```python
>>> client.get("my-cache", "my-key")
<momento.cache_client_operations.CacheGetResponse at 0x7f8e6d292770>
```

which is not very helpful. Now we have output like this:

```python
>>> client.get("my-cache", "my-key")
CacheGetResponse(value=b'my-value, status=<CacheGetStatus.HIT: 1>)

>>> client.multi_get("my-cache", "key1", "key2")
CacheMultiGetResponse(responses=[CacheGetResponse(value=b'value1', status=<CacheGetStatus.HIT: 1>), CacheGetResponse(value=b'value2', status=<CacheGetStatus.HIT: 1>)])
```
which is much more informative and civilized.