### PR TITLE
chore: rename "multi" methods and responses.

### DIFF
--- a/src/momento/aio/_scs_data_client.py
+++ b/src/momento/aio/_scs_data_client.py
@@ -70,12 +70,12 @@ class _ScsDataClient:
             _momento_logger.debug(f"Set failed for {str(key)} with response: {e}")
             raise _cache_service_errors_converter.convert(e)
 
-    async def multi_set(
+    async def set_multi(
         self,
         cache_name: str,
         items: Union[Mapping[str, str], Mapping[bytes, bytes]],
         ttl_seconds: Optional[int] = None,
-    ) -> cache_sdk_ops.CacheMultiSetResponse:
+    ) -> cache_sdk_ops.CacheSetMultiResponse:
         _validate_cache_name(cache_name)
 
         try:
@@ -99,7 +99,7 @@ class _ScsDataClient:
                 response.key_as_bytes(): response.value_as_bytes()
                 for response in responses
             }
-            return cache_sdk_ops.CacheMultiSetResponse(items=items_as_bytes)
+            return cache_sdk_ops.CacheSetMultiResponse(items=items_as_bytes)
         except Exception as e:
             _momento_logger.debug(f"multi-set failed with error: {e}")
             # re-raise any error caught here is fatal error with overall handling of request objects
@@ -125,11 +125,11 @@ class _ScsDataClient:
             _momento_logger.debug(f"Get failed for {str(key)} with response: {e}")
             raise _cache_service_errors_converter.convert(e)
 
-    async def multi_get(
+    async def get_multi(
         self,
         cache_name: str,
         *keys: Union[str, bytes],
-    ) -> cache_sdk_ops.CacheMultiGetResponse:
+    ) -> cache_sdk_ops.CacheGetMultiResponse:
         _validate_cache_name(cache_name)
         try:
             request_promises = [self.get(cache_name, key) for key in keys]
@@ -144,10 +144,10 @@ class _ScsDataClient:
                 if isinstance(response, Exception):
                     raise response
         except Exception as e:
-            _momento_logger.debug(f"multi_get failed with response: {e}")
+            _momento_logger.debug(f"get_multi failed with response: {e}")
             raise _cache_service_errors_converter.convert(e)
 
-        return cache_sdk_ops.CacheMultiGetResponse(responses=responses)
+        return cache_sdk_ops.CacheGetMultiResponse(responses=responses)
 
     async def delete(
         self, cache_name: str, key: Union[str, bytes]

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -36,8 +36,8 @@ from ..cache_operation_types import (
     CacheSetResponse,
     CacheGetResponse,
     CacheDeleteResponse,
-    CacheMultiSetResponse,
-    CacheMultiGetResponse,
+    CacheSetMultiResponse,
+    CacheGetMultiResponse,
 )
 
 
@@ -174,12 +174,12 @@ class SimpleCacheClient:
             self._data_client.get_endpoint(), next_token
         )
 
-    async def multi_set(
+    async def set_multi(
         self,
         cache_name: str,
         items: Union[Mapping[str, str], Mapping[bytes, bytes]],
         ttl_seconds: Optional[int] = None,
-    ) -> CacheMultiSetResponse:
+    ) -> CacheSetMultiResponse:
         """Store items in the cache.
 
         Args:
@@ -188,7 +188,7 @@ class SimpleCacheClient:
             ttl_seconds: (Optional[int]): The TTL to apply to each item. Defaults to None.
 
         Returns:
-            CacheMultiSetResponse
+            CacheSetMultiResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -197,7 +197,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        return await self._data_client.multi_set(cache_name, items, ttl_seconds)
+        return await self._data_client.set_multi(cache_name, items, ttl_seconds)
 
     async def set(
         self,
@@ -227,9 +227,9 @@ class SimpleCacheClient:
         """
         return await self._data_client.set(cache_name, key, value, ttl_seconds)
 
-    async def multi_get(
+    async def get_multi(
         self, cache_name: str, *keys: Union[str, bytes]
-    ) -> CacheMultiGetResponse:
+    ) -> CacheGetMultiResponse:
         """Retrieve multiple items from the cache.
 
         Args:
@@ -237,7 +237,7 @@ class SimpleCacheClient:
             keys: (Union[str, bytes]): The keys used to retrieve the items.
 
         Returns:
-            CacheMultiGetResponse
+            CacheGetMultiResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -246,7 +246,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        return await self._data_client.multi_get(cache_name, *keys)
+        return await self._data_client.get_multi(cache_name, *keys)
 
     async def get(self, cache_name: str, key: str) -> CacheGetResponse:
         """Retrieve an item from the cache

--- a/src/momento/cache_operation_types.py
+++ b/src/momento/cache_operation_types.py
@@ -47,7 +47,7 @@ class CacheSetResponse:
         return f"CacheSetResponse(key={self._key!r}, value={self._value!r})"
 
 
-class CacheMultiSetResponse:
+class CacheSetMultiResponse:
     def __init__(self, items: Mapping[bytes, bytes]):
         self._items = items
 
@@ -64,7 +64,7 @@ class CacheMultiSetResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheMultiSetResponse(items={self._items!r})"
+        return f"CacheSetMultiResponse(items={self._items!r})"
 
 
 class CacheGetResponse:
@@ -120,7 +120,7 @@ class CacheGetResponse:
         return f"CacheGetResponse(value={self._value!r}, status={self._status!r})"
 
 
-class CacheMultiGetResponse:
+class CacheGetMultiResponse:
     def __init__(self, responses: List[CacheGetResponse]):
         self._responses = responses
 
@@ -142,7 +142,7 @@ class CacheMultiGetResponse:
         return self.__repr__()
 
     def __repr__(self) -> str:
-        return f"CacheMultiGetResponse(responses={self._responses!r})"
+        return f"CacheGetMultiResponse(responses={self._responses!r})"
 
 
 class CacheDeleteResponse:

--- a/src/momento/incubating/README.md
+++ b/src/momento/incubating/README.md
@@ -25,8 +25,8 @@ CacheDictionarySetUnaryResponse(dictionary_name='my-dictionary', key=b'key1', va
 2. Set multiple items in a dictionary
 
 ```python
->>> client.dictionary_multi_set(cache_name="my-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
-CacheDictionarySetResponse(dictionary_name='my-dictionary', dictionary={b'key2': b'value2', b'key3': b'value3'})
+>>> client.dictionary_set_multi(cache_name="my-cache", dictionary_name="my-dictionary", dictionary={"key2": "value2", "key3": "value3"}, refresh_ttl=False)
+CacheDictionarySetMultiResponse(dictionary_name='my-dictionary', dictionary={b'key2': b'value2', b'key3': b'value3'})
 ```
 
 3. Get one value from a dictionary
@@ -46,7 +46,7 @@ CacheDictionaryGetUnaryResponse(value=b'value1', status=<CacheGetStatus.HIT: 1>)
 4. Get multiple values from a dictionary
 
 ```python
->>> get_response = client.dictionary_multi_get("my-cache", "my-dictionary", "key1", "key2", "key7")
+>>> get_response = client.dictionary_get_multi("my-cache", "my-dictionary", "key1", "key2", "key7")
 >>> get_response
 CacheDictionaryGetMultiResponse(values=[b'value1', b'value2', None], status=[<CacheGetStatus.HIT: 1>, <CacheGetStatus.HIT: 1>, <CacheGetStatus.MISS: 2>])
 

--- a/src/momento/incubating/aio/simple_cache_client.py
+++ b/src/momento/incubating/aio/simple_cache_client.py
@@ -83,7 +83,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             dictionary_name=dictionary_name, key=bytes_key, value=bytes_value
         )
 
-    async def dictionary_multi_set(
+    async def dictionary_set_multi(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -161,7 +161,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
 
         return CacheDictionaryGetUnaryResponse(value=value, status=CacheGetStatus.HIT)
 
-    async def dictionary_multi_get(
+    async def dictionary_get_multi(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -254,8 +254,8 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             CacheExistsResponse: Wrapper object containing the results
                 of the exists test.
         """
-        multi_get_response = await self.multi_get(cache_name, *keys)
-        mask = [status == CacheGetStatus.HIT for status in multi_get_response.status()]
+        get_multi_response = await self.get_multi(cache_name, *keys)
+        mask = [status == CacheGetStatus.HIT for status in get_multi_response.status()]
         return CacheExistsResponse(keys, mask)
 
 

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -73,7 +73,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         )
         return wait_for_coroutine(self._loop, coroutine)
 
-    def dictionary_multi_set(
+    def dictionary_set_multi(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -98,7 +98,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         Returns:
             CacheDictionarySetMultiResponse: data stored in the cache
         """
-        coroutine = self._momento_async_client.dictionary_multi_set(
+        coroutine = self._momento_async_client.dictionary_set_multi(
             cache_name,
             dictionary_name,
             dictionary,
@@ -129,7 +129,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         )
         return wait_for_coroutine(self._loop, coroutine)
 
-    def dictionary_multi_get(
+    def dictionary_get_multi(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -146,7 +146,7 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
             CacheDictionaryGetMultiResponse: a wrapper over a list of values
                 and statuses.
         """
-        coroutine = self._momento_async_client.dictionary_multi_get(
+        coroutine = self._momento_async_client.dictionary_get_multi(
             cache_name, dictionary_name, *keys
         )
         return wait_for_coroutine(self._loop, coroutine)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -12,8 +12,8 @@ from .cache_operation_types import (
     CreateSigningKeyResponse,
     DeleteCacheResponse,
     ListCachesResponse,
-    CacheMultiGetResponse,
-    CacheMultiSetResponse,
+    CacheGetMultiResponse,
+    CacheSetMultiResponse,
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )
@@ -197,12 +197,12 @@ class SimpleCacheClient:
         coroutine = self._momento_async_client.set(cache_name, key, value, ttl_seconds)
         return wait_for_coroutine(self._loop, coroutine)
 
-    def multi_set(
+    def set_multi(
         self,
         cache_name: str,
         items: Union[Mapping[str, str], Mapping[bytes, bytes]],
         ttl_seconds: Optional[int] = None,
-    ) -> CacheMultiSetResponse:
+    ) -> CacheSetMultiResponse:
         """Store items in the cache.
 
         Args:
@@ -211,7 +211,7 @@ class SimpleCacheClient:
             ttl_seconds: (Optional[int]): The TTL to apply to each item. Defaults to None.
 
         Returns:
-            CacheMultiSetResponse
+            CacheSetMultiResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -220,7 +220,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        coroutine = self._momento_async_client.multi_set(cache_name, items, ttl_seconds)
+        coroutine = self._momento_async_client.set_multi(cache_name, items, ttl_seconds)
         return wait_for_coroutine(self._loop, coroutine)
 
     def get(self, cache_name: str, key: str) -> CacheGetResponse:
@@ -243,9 +243,9 @@ class SimpleCacheClient:
         coroutine = self._momento_async_client.get(cache_name, key)
         return wait_for_coroutine(self._loop, coroutine)
 
-    def multi_get(
+    def get_multi(
         self, cache_name: str, *keys: Union[str, bytes]
-    ) -> CacheMultiGetResponse:
+    ) -> CacheGetMultiResponse:
         """Retrieve multiple items from the cache.
 
         Args:
@@ -253,7 +253,7 @@ class SimpleCacheClient:
             keys: (Union[str, bytes]): The keys used to retrieve the items.
 
         Returns:
-            CacheMultiGetResponse
+            CacheGetMultiResponse
 
         Raises:
             InvalidArgumentError: If validation fails for the provided method arguments.
@@ -262,7 +262,7 @@ class SimpleCacheClient:
             AuthenticationError: If the provided Momento Auth Token is invalid.
             InternalServerError: If server encountered an unknown error while trying to retrieve the item.
         """
-        coroutine = self._momento_async_client.multi_get(cache_name, *keys)
+        coroutine = self._momento_async_client.get_multi(cache_name, *keys)
         return wait_for_coroutine(self._loop, coroutine)
 
     def delete(self, cache_name: str, key: str) -> CacheDeleteResponse:

--- a/tests/incubating/test_dictionary.py
+++ b/tests/incubating/test_dictionary.py
@@ -34,7 +34,7 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            get_response = simple_cache.dictionary_multi_get(
+            get_response = simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
             )
             self.assertEqual(3, len(get_response.to_list()))
@@ -54,7 +54,7 @@ class TestMomento(unittest.TestCase):
         ) as simple_cache:
             # Test with key as string
             dictionary = {"key1": "value1"}
-            set_response = simple_cache.dictionary_multi_set(
+            set_response = simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict",
                 dictionary=dictionary,
@@ -65,7 +65,7 @@ class TestMomento(unittest.TestCase):
 
             # Test as bytes
             dictionary = {b"key1": b"value1"}
-            set_response = simple_cache.dictionary_multi_set(
+            set_response = simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict2",
                 dictionary=dictionary,
@@ -101,7 +101,7 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            simple_cache.dictionary_multi_set(
+            simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict3",
                 dictionary={"key1": "value1"},
@@ -117,7 +117,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             with self.assertRaises(ValueError):
-                simple_cache.dictionary_multi_get(
+                simple_cache.dictionary_get_multi(
                     _TEST_CACHE_NAME, "my-dictionary", *[]
                 )
 
@@ -138,7 +138,7 @@ class TestMomento(unittest.TestCase):
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"mydict4-{i}"
 
-                simple_cache.dictionary_multi_set(
+                simple_cache.dictionary_set_multi(
                     cache_name=_TEST_CACHE_NAME,
                     dictionary_name=dictionary_name,
                     dictionary=dictionary,
@@ -164,13 +164,13 @@ class TestMomento(unittest.TestCase):
             dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
-            simple_cache.dictionary_multi_set(
+            simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            get_response = simple_cache.dictionary_multi_get(
+            get_response = simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
             )
 
@@ -189,7 +189,7 @@ class TestMomento(unittest.TestCase):
             ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
-            get_response = simple_cache.dictionary_multi_get(
+            get_response = simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
             )
             self.assertTrue(
@@ -215,7 +215,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
-            simple_cache.dictionary_multi_set(
+            simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict6",
                 dictionary=dictionary,

--- a/tests/incubating/test_dictionary_async.py
+++ b/tests/incubating/test_dictionary_async.py
@@ -34,7 +34,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            get_response = await simple_cache.dictionary_multi_get(
+            get_response = await simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
             )
             self.assertEqual(3, len(get_response.to_list()))
@@ -54,7 +54,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         ) as simple_cache:
             # Test with key as string
             dictionary = {"key1": "value1"}
-            set_response = await simple_cache.dictionary_multi_set(
+            set_response = await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict",
                 dictionary=dictionary,
@@ -65,7 +65,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
 
             # Test as bytes
             dictionary = dictionary = {b"key1": b"value1"}
-            set_response = await simple_cache.dictionary_multi_set(
+            set_response = await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict2",
                 dictionary=dictionary,
@@ -118,7 +118,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             with self.assertRaises(ValueError):
-                await simple_cache.dictionary_multi_get(
+                await simple_cache.dictionary_get_multi(
                     _TEST_CACHE_NAME, "my-dictionary", *[]
                 )
 
@@ -139,7 +139,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 # Use distinct hash names to avoid collisions with already finished tests
                 dictionary_name = f"mydict4-{i}"
 
-                await simple_cache.dictionary_multi_set(
+                await simple_cache.dictionary_set_multi(
                     cache_name=_TEST_CACHE_NAME,
                     dictionary_name=dictionary_name,
                     dictionary=dictionary,
@@ -165,13 +165,13 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             dictionary_name = "mydict10"
             dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
 
-            await simple_cache.dictionary_multi_set(
+            await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            get_response = await simple_cache.dictionary_multi_get(
+            get_response = await simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
             )
 
@@ -190,7 +190,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             ]
             self.assertEqual(get_response.to_list(), individual_responses)
 
-            get_response = await simple_cache.dictionary_multi_get(
+            get_response = await simple_cache.dictionary_get_multi(
                 _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
             )
             self.assertTrue(
@@ -216,7 +216,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             dictionary = {"key1": "value1", "key2": "value2"}
-            await simple_cache.dictionary_multi_set(
+            await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name="mydict6",
                 dictionary=dictionary,

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -382,7 +382,7 @@ class TestMomento(unittest.TestCase):
             with self.assertRaises(errors.TimeoutError):
                 simple_cache.get(_TEST_CACHE_NAME, "foo")
 
-    def test_multi_get_and_set(self):
+    def test_get_multi_and_set(self):
         items = {
             "foo1": "bar1",
             "foo2": "bar2",
@@ -390,10 +390,10 @@ class TestMomento(unittest.TestCase):
             "foo4": "bar4",
             "foo5": "bar5",
         }
-        set_resp = self.client.multi_set(cache_name=_TEST_CACHE_NAME, items=items)
+        set_resp = self.client.set_multi(cache_name=_TEST_CACHE_NAME, items=items)
         self.assertEqual(items, set_resp.items())
 
-        get_resp = self.client.multi_get(
+        get_resp = self.client.get_multi(
             _TEST_CACHE_NAME, "foo5", "foo1", "foo2", "foo3"
         )
         values = get_resp.values()
@@ -402,23 +402,23 @@ class TestMomento(unittest.TestCase):
         self.assertEqual("bar2", values[2])
         self.assertEqual("bar3", values[3])
 
-    def test_multi_get_failure(self):
+    def test_get_multi_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
         ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
-                simple_cache.multi_get(
+                simple_cache.get_multi(
                     _TEST_CACHE_NAME, "key1", "key2", "key3", "key4", "key5", "key6"
                 )
 
-    def test_multi_set_failure(self):
+    def test_set_multi_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
         ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
-                simple_cache.multi_set(
+                simple_cache.set_multi(
                     cache_name=_TEST_CACHE_NAME,
                     items={
                         "fizz1": "buzz1",

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -407,7 +407,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 await simple_cache.get(_TEST_CACHE_NAME, "foo")
 
     # Multi op tests
-    async def test_multi_get_and_set(self):
+    async def test_get_multi_and_set(self):
         items = {
             "foo1": "bar1",
             "foo2": "bar2",
@@ -415,10 +415,10 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             "foo4": "bar4",
             "foo5": "bar5",
         }
-        set_resp = await self.client.multi_set(cache_name=_TEST_CACHE_NAME, items=items)
+        set_resp = await self.client.set_multi(cache_name=_TEST_CACHE_NAME, items=items)
         self.assertEqual(items, set_resp.items())
 
-        get_resp = await self.client.multi_get(
+        get_resp = await self.client.get_multi(
             _TEST_CACHE_NAME, "foo5", "foo1", "foo2", "foo3"
         )
         values = get_resp.values()
@@ -427,23 +427,23 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         self.assertEqual("bar2", values[2])
         self.assertEqual("bar3", values[3])
 
-    async def test_multi_get_failure(self):
+    async def test_get_multi_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
         ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
-                await simple_cache.multi_get(
+                await simple_cache.get_multi(
                     _TEST_CACHE_NAME, "key1", "key2", "key3", "key4", "key5", "key6"
                 )
 
-    async def test_multi_set_failure(self):
+    async def test_set_multi_failure(self):
         # Start with a cache client with impossibly small request timeout to force failures
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS, request_timeout_ms=1
         ) as simple_cache:
             with self.assertRaises(errors.TimeoutError):
-                await simple_cache.multi_set(
+                await simple_cache.set_multi(
                     cache_name=_TEST_CACHE_NAME,
                     items={
                         "fizz1": "buzz1",


### PR DESCRIPTION
The previous naming convention preferred modifiers before commands, as
in `multi_get`, `dictionary_multi_get`. This ordering makes it
difficult to group commands under the IDE and in documentation. The
new ordering `get_multi`, `dictionary_get_multi` eases this.

With this way, now the following will be completions of
`dictionary_get`:

`dictionary_get`, `dictionary_get_multi`, `dictionary_get_all`