### PR TITLE
chore: use guids in tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+mypy
+flake8
+black

--- a/tests/incubating/test_dictionary.py
+++ b/tests/incubating/test_dictionary.py
@@ -8,6 +8,7 @@ import momento.incubating.simple_cache_client as simple_cache_client
 
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
+from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 
 _AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
 _TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
@@ -26,7 +27,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=uuid_str(), key=uuid_str()
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -35,7 +36,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
+                _TEST_CACHE_NAME, uuid_str(), uuid_str(), uuid_str(), uuid_str()
             )
             self.assertEqual(3, len(get_response.to_list()))
             self.assertTrue(
@@ -53,33 +54,35 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             # Test with key as string
-            dictionary = {"key1": "value1"}
+            dictionary = {uuid_str(): uuid_str()}
+            dictionary_name = uuid_str()
             set_response = simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            self.assertEqual("mydict", set_response.dictionary_name())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary())
 
             # Test as bytes
-            dictionary = {b"key1": b"value1"}
+            dictionary = {uuid_bytes(): uuid_bytes()}
+            dictionary_name = uuid_str()
             set_response = simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict2",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            self.assertEqual("mydict2", set_response.dictionary_name())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary_as_bytes())
 
     def test_dictionary_set_unary(self):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary_name = "mydict20"
-            key, value = "my-key", "my-value"
+            dictionary_name = uuid_str()
+            key, value = uuid_str(), uuid_str()
             set_response = simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name=dictionary_name,
@@ -101,14 +104,18 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            simple_cache.dictionary_set_multi(
+            dictionary_name = uuid_str()
+            simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict3",
-                dictionary={"key1": "value1"},
+                dictionary_name=dictionary_name,
+                key=uuid_str(),
+                value=uuid_str(),
                 refresh_ttl=False,
             )
             get_response = simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", key="key2"
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                key=uuid_str(),
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -117,9 +124,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             with self.assertRaises(ValueError):
-                simple_cache.dictionary_get_multi(
-                    _TEST_CACHE_NAME, "my-dictionary", *[]
-                )
+                simple_cache.dictionary_get_multi(_TEST_CACHE_NAME, uuid_str(), *[])
 
     def test_dictionary_get_hit(self):
         with simple_cache_client.init(
@@ -129,14 +134,13 @@ class TestMomento(unittest.TestCase):
             for i, (key_is_str, value_is_str) in enumerate(
                 itertools.product((True, False), (True, False))
             ):
-                key, value = "key1", "value1"
+                key, value = uuid_str(), uuid_str()
                 if not key_is_str:
                     key = key.encode()
                 if not value_is_str:
                     value = value.encode()
                 dictionary = {key: value}
-                # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"mydict4-{i}"
+                dictionary_name = uuid_str()
 
                 simple_cache.dictionary_set_multi(
                     cache_name=_TEST_CACHE_NAME,
@@ -161,8 +165,10 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary_name = "mydict10"
-            dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
+            dictionary_name = uuid_str()
+            keys = [uuid_str() for _ in range(3)]
+            values = [uuid_str() for _ in range(3)]
+            dictionary = {k: v for k, v in zip(keys, values)}
 
             simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
@@ -171,13 +177,12 @@ class TestMomento(unittest.TestCase):
                 refresh_ttl=False,
             )
             get_response = simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
+                _TEST_CACHE_NAME, dictionary_name, *keys
             )
 
-            values = ["value1", "value2", "value3"]
             self.assertEqual(get_response.values(), values)
             self.assertEqual(
-                get_response.values_as_bytes(), [b"value1", b"value2", b"value3"]
+                get_response.values_as_bytes(), [str_to_bytes(i) for i in values]
             )
 
             results = [CacheGetStatus.HIT] * 3
@@ -190,15 +195,15 @@ class TestMomento(unittest.TestCase):
             self.assertEqual(get_response.to_list(), individual_responses)
 
             get_response = simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
+                _TEST_CACHE_NAME, dictionary_name, keys[0], keys[1], uuid_str()
             )
             self.assertTrue(
                 get_response.status(),
                 [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS],
             )
-            self.assertTrue(get_response.values(), ["value1", "value2", None])
+            self.assertTrue(get_response.values(), [values[0], values[1], None])
             self.assertTrue(
-                get_response.values_as_bytes(), [b"value1", b"value2", None]
+                get_response.values_as_bytes(), [str_to_bytes(values[0]), str_to_bytes(values[1]), None]
             )
 
     def test_dictionary_get_all_miss(self):
@@ -206,7 +211,7 @@ class TestMomento(unittest.TestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=uuid_str()
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -214,15 +219,16 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary = {"key1": "value1", "key2": "value2"}
+            dictionary_name = uuid_str()
+            dictionary = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
             simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict6",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
             get_all_response = simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name
             )
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 

--- a/tests/incubating/test_dictionary_async.py
+++ b/tests/incubating/test_dictionary_async.py
@@ -8,6 +8,7 @@ from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResp
 import momento.incubating.aio.simple_cache_client as simple_cache_client
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from momento.vendor.python.unittest.async_case import IsolatedAsyncioTestCase
+from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 
 _AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
 _TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
@@ -26,7 +27,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="hello world", key="key"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=uuid_str(), key=uuid_str()
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -35,7 +36,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = await simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, "hello world", "key1", "key2", "key3"
+                _TEST_CACHE_NAME, uuid_str(), uuid_str(), uuid_str(), uuid_str()
             )
             self.assertEqual(3, len(get_response.to_list()))
             self.assertTrue(
@@ -53,33 +54,35 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             # Test with key as string
-            dictionary = {"key1": "value1"}
+            dictionary = {uuid_str(): uuid_str()}
+            dictionary_name = uuid_str()
             set_response = await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            self.assertEqual("mydict", set_response.dictionary_name())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary())
 
             # Test as bytes
-            dictionary = dictionary = {b"key1": b"value1"}
+            dictionary = {uuid_bytes(): uuid_bytes()}
+            dictionary_name = uuid_str()
             set_response = await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict2",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
-            self.assertEqual("mydict2", set_response.dictionary_name())
+            self.assertEqual(dictionary_name, set_response.dictionary_name())
             self.assertEqual(dictionary, set_response.dictionary_as_bytes())
 
     async def test_dictionary_set_unary(self):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary_name = "mydict20"
-            key, value = "my-key", "my-value"
+            dictionary_name = uuid_str()
+            key, value = uuid_str(), uuid_str()
             set_response = await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME,
                 dictionary_name=dictionary_name,
@@ -101,15 +104,18 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
+            dictionary_name = uuid_str()
             await simple_cache.dictionary_set(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict3",
-                key="key1",
-                value="value1",
+                dictionary_name=dictionary_name,
+                key=uuid_str(),
+                value=uuid_str(),
                 refresh_ttl=False,
             )
             get_response = await simple_cache.dictionary_get(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict3", key="key2"
+                cache_name=_TEST_CACHE_NAME,
+                dictionary_name=dictionary_name,
+                key=uuid_str(),
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -119,7 +125,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         ) as simple_cache:
             with self.assertRaises(ValueError):
                 await simple_cache.dictionary_get_multi(
-                    _TEST_CACHE_NAME, "my-dictionary", *[]
+                    _TEST_CACHE_NAME, uuid_str(), *[]
                 )
 
     async def test_dictionary_get_hit(self):
@@ -130,15 +136,13 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             for i, (key_is_str, value_is_str) in enumerate(
                 itertools.product((True, False), (True, False))
             ):
-                key, value = "key1", "value1"
+                key, value = uuid_str(), uuid_str()
                 if not key_is_str:
                     key = key.encode()
                 if not value_is_str:
                     value = value.encode()
                 dictionary = {key: value}
-                # Use distinct hash names to avoid collisions with already finished tests
-                dictionary_name = f"mydict4-{i}"
-
+                dictionary_name = uuid_str()
                 await simple_cache.dictionary_set_multi(
                     cache_name=_TEST_CACHE_NAME,
                     dictionary_name=dictionary_name,
@@ -162,8 +166,10 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary_name = "mydict10"
-            dictionary = {"key1": "value1", "key2": "value2", "key3": "value3"}
+            dictionary_name = uuid_str()
+            keys = [uuid_str() for _ in range(3)]
+            values = [uuid_str() for _ in range(3)]
+            dictionary = {k: v for k, v in zip(keys, values)}
 
             await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
@@ -172,13 +178,12 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
                 refresh_ttl=False,
             )
             get_response = await simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key3"
+                _TEST_CACHE_NAME, dictionary_name, *keys
             )
 
-            values = ["value1", "value2", "value3"]
             self.assertEqual(get_response.values(), values)
             self.assertEqual(
-                get_response.values_as_bytes(), [b"value1", b"value2", b"value3"]
+                get_response.values_as_bytes(), [str_to_bytes(i) for i in values]
             )
 
             results = [CacheGetStatus.HIT] * 3
@@ -191,15 +196,16 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             self.assertEqual(get_response.to_list(), individual_responses)
 
             get_response = await simple_cache.dictionary_get_multi(
-                _TEST_CACHE_NAME, dictionary_name, "key1", "key2", "key5"
+                _TEST_CACHE_NAME, dictionary_name, keys[0], keys[1], uuid_str()
             )
             self.assertTrue(
                 get_response.status(),
                 [CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS],
             )
-            self.assertTrue(get_response.values(), ["value1", "value2", None])
+            self.assertTrue(get_response.values(), [values[0], values[1], None])
             self.assertTrue(
-                get_response.values_as_bytes(), [b"value1", b"value2", None]
+                get_response.values_as_bytes(),
+                [str_to_bytes(values[0]), str_to_bytes(values[1]), None],
             )
 
     async def test_dictionary_get_all_miss(self):
@@ -207,7 +213,7 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             get_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict5"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=uuid_str()
             )
             self.assertEqual(CacheGetStatus.MISS, get_response.status())
 
@@ -215,15 +221,16 @@ class TestMomentoAsync(IsolatedAsyncioTestCase):
         async with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            dictionary = {"key1": "value1", "key2": "value2"}
+            dictionary_name = uuid_str()
+            dictionary = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
             await simple_cache.dictionary_set_multi(
                 cache_name=_TEST_CACHE_NAME,
-                dictionary_name="mydict6",
+                dictionary_name=dictionary_name,
                 dictionary=dictionary,
                 refresh_ttl=False,
             )
             get_all_response = await simple_cache.dictionary_get_all(
-                cache_name=_TEST_CACHE_NAME, dictionary_name="mydict6"
+                cache_name=_TEST_CACHE_NAME, dictionary_name=dictionary_name
             )
             self.assertEqual(CacheGetStatus.HIT, get_all_response.status())
 

--- a/tests/incubating/test_exists.py
+++ b/tests/incubating/test_exists.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import momento.incubating.simple_cache_client as simple_cache_client
+from tests.utils import uuid_str
 
 _AUTH_TOKEN = os.getenv("TEST_AUTH_TOKEN")
 _TEST_CACHE_NAME = os.getenv("TEST_CACHE_NAME")
@@ -13,38 +14,44 @@ class TestMomento(unittest.TestCase):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            response = simple_cache.exists(_TEST_CACHE_NAME, "exists-key")
+            key = uuid_str()
+            response = simple_cache.exists(_TEST_CACHE_NAME, key)
 
             self.assertFalse(response)
             self.assertEqual(0, response.num_exists())
             self.assertEqual([False], response.results())
-            self.assertEqual(["exists-key"], response.missing_keys())
+            self.assertEqual([key], response.missing_keys())
             self.assertEqual([], response.present_keys())
-            self.assertEqual([("exists-key", False)], list(response.zip_keys_and_results()))
+            self.assertEqual(
+                [(key, False)], list(response.zip_keys_and_results())
+            )
 
     def test_exists_unary_exists(self):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
-            simple_cache.set(_TEST_CACHE_NAME, "exists-key1", "my-value")
+            key, value = uuid_str(), uuid_str()
+            simple_cache.set(_TEST_CACHE_NAME, key, value)
 
-            response = simple_cache.exists(_TEST_CACHE_NAME, "exists-key1")
+            response = simple_cache.exists(_TEST_CACHE_NAME, key)
 
             self.assertTrue(response)
             self.assertEqual(1, response.num_exists())
             self.assertEqual([True], response.results())
             self.assertEqual([], response.missing_keys())
-            self.assertEqual(["exists-key1"], response.present_keys())
-            self.assertEqual([("exists-key1", True)], list(response.zip_keys_and_results()))
+            self.assertEqual([key], response.present_keys())
+            self.assertEqual(
+                [(key, True)], list(response.zip_keys_and_results())
+            )
 
     def test_exists_multi(self):
         with simple_cache_client.init(
             _AUTH_TOKEN, _DEFAULT_TTL_SECONDS
         ) as simple_cache:
             keys = []
-            for i in range(2, 5):
-                key = f"exists-key{i}"
-                simple_cache.set(_TEST_CACHE_NAME, key, f"my-value-{i}")
+            for i in range(3):
+                key = uuid_str()
+                simple_cache.set(_TEST_CACHE_NAME, key, uuid_str())
                 keys.append(key)
 
             response = simple_cache.exists(_TEST_CACHE_NAME, *keys)
@@ -54,9 +61,12 @@ class TestMomento(unittest.TestCase):
             self.assertEqual([True] * 3, response.results())
             self.assertEqual([], response.missing_keys())
             self.assertEqual(keys, response.present_keys())
-            self.assertEqual(list(zip(keys, [True]*3)), list(response.zip_keys_and_results()))
+            self.assertEqual(
+                list(zip(keys, [True] * 3)), list(response.zip_keys_and_results())
+            )
 
-            more_keys = ["I'm not here"] + keys + ["Neither am I"]
+            missing1, missing2 = uuid_str(), uuid_str()
+            more_keys = [missing1] + keys + [missing2]
             response = simple_cache.exists(_TEST_CACHE_NAME, *more_keys)
             self.assertFalse(response)
             self.assertFalse(response.all())
@@ -64,9 +74,12 @@ class TestMomento(unittest.TestCase):
             mask = [False] + [True] * 3 + [False]
             self.assertEqual(mask, response.results())
 
-            self.assertEqual(["I'm not here", "Neither am I"], response.missing_keys())
+            self.assertEqual([missing1, missing2], response.missing_keys())
             self.assertEqual(keys, response.present_keys())
-            self.assertEqual(list(zip(more_keys, mask)), list(response.zip_keys_and_results()))
+            self.assertEqual(
+                list(zip(more_keys, mask)), list(response.zip_keys_and_results())
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,13 @@
+import uuid
+
+
+def uuid_str() -> str:
+    return str(uuid.uuid4())
+
+
+def uuid_bytes() -> bytes:
+    return uuid.uuid4().bytes
+
+
+def str_to_bytes(string: str) -> bytes:
+    return string.encode("utf-8")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,12 +2,30 @@ import uuid
 
 
 def uuid_str() -> str:
+    """Generate a UUID as a string.
+
+    Returns:
+        str: A UUID
+    """
     return str(uuid.uuid4())
 
 
 def uuid_bytes() -> bytes:
+    """Generate a UUID as bytes.
+
+    Returns:
+        bytes: A UUID
+    """
     return uuid.uuid4().bytes
 
 
 def str_to_bytes(string: str) -> bytes:
+    """Convert a string to bytes.
+
+    Args:
+        string (str): The string to convert.
+
+    Returns:
+        bytes: A UTF-8 byte representation of the string.
+    """
     return string.encode("utf-8")


### PR DESCRIPTION
Use random data in integration tests. The previous code used specific strings for keys and values. Because the integration tests run repeatedly on the same cache, this could cause undesirable behavior if the same tests are repeated in quick succession.

Work towards #117 