### PR TITLE
refactor: remove init functions

### DIFF
--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -45,7 +45,7 @@ from ..cache_operation_types import (
 
 
 class SimpleCacheClient:
-    """async Simple Cache client"""
+    """Async Simple Cache Client"""
 
     # For high load, we might get better performance with multiple clients, because the server is
     # configured to allow a max of 100 streams per connection.  In the javascript SDK, multiple

--- a/src/momento/aio/simple_cache_client.py
+++ b/src/momento/aio/simple_cache_client.py
@@ -73,7 +73,7 @@ class SimpleCacheClient:
                 possible to override this setting when calling the set method.
             request_timeout_ms (Optional[int], optional): An optional timeout in milliseconds to allow for Get and Set
                 operations to complete. The request will be terminated if it takes longer than this value and will
-                result in TimeoutError. Defaults to None, in which case a 5ms timeout is used.
+                result in TimeoutError. Defaults to None, in which case a 5 second timeout is used.
         Raises:
             IllegalArgumentError: If method arguments fail validations.
         """

--- a/src/momento/incubating/simple_cache_client.py
+++ b/src/momento/incubating/simple_cache_client.py
@@ -24,15 +24,29 @@ class SimpleCacheClientIncubating(SimpleCacheClient):
         self,
         auth_token: str,
         default_ttl_seconds: int,
-        data_client_operation_timeout_ms: Optional[int],
+        request_timeout_ms: Optional[int] = None,
     ):
+        """Creates a SimpleCacheClientIncubating.
+        !! Includes non-final, experimental features and APIs subject to change  !!
+
+        Args:
+            auth_token: Momento Token to authenticate the requests with Simple Cache Service
+            default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
+                possible to override this setting when calling the set method.
+            request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
+                Defaults to None, in which case 5 seconds is used. The request will be terminated if it takes longer
+                than this value and will result in TimeoutError.
+        Raises:
+            IllegalArgumentError: If method arguments fail validations
+        """
+
         warnings.warn(INCUBATING_WARNING_MSG)
         self._init_loop()
         self._momento_async_client: aio.SimpleCacheClientIncubating = (
             aio.SimpleCacheClientIncubating(
                 auth_token=auth_token,
                 default_ttl_seconds=default_ttl_seconds,
-                data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+                request_timeout_ms=request_timeout_ms,
             )
         )
 

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -35,7 +35,7 @@ class SimpleCacheClient:
                 possible to override this setting when calling the set method.
             request_timeout_ms (Optional[int], optional): An optional timeout in milliseconds to allow for Get and Set
                 operations to complete. The request will be terminated if it takes longer than this value and will
-                result in TimeoutError. Defaults to None, in which case a 5ms timeout is used.
+                result in TimeoutError. Defaults to None, in which case a 5 second timeout is used.
         Raises:
             IllegalArgumentError: If method arguments fail validations.
         """

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -25,13 +25,27 @@ class SimpleCacheClient:
         self,
         auth_token: str,
         default_ttl_seconds: int,
-        data_client_operation_timeout_ms: Optional[int],
+        request_timeout_ms: Optional[int] = None,
     ):
+        """Creates an async SimpleCacheClient
+
+        Args:
+            auth_token (str): Momento Token to authenticate the requests with Simple Cache Service
+            default_ttl_seconds (int): A default Time To Live in seconds for cache objects created by this client. It is
+                possible to override this setting when calling the set method.
+            request_timeout_ms (Optional[int], optional): An optional timeout in milliseconds to allow for Get and Set
+                operations to complete. The request will be terminated if it takes longer than this value and will
+                result in TimeoutError. Defaults to None, in which case a 5ms timeout is used.
+        Raises:
+            IllegalArgumentError: If method arguments fail validations.
+        """
+        _validate_request_timeout(request_timeout_ms)
+
         self._init_loop()
         self._momento_async_client = aio.SimpleCacheClient(
             auth_token=auth_token,
             default_ttl_seconds=default_ttl_seconds,
-            data_client_operation_timeout_ms=data_client_operation_timeout_ms,
+            request_timeout_ms=request_timeout_ms,
         )
 
     def _init_loop(self) -> None:
@@ -286,26 +300,3 @@ class SimpleCacheClient:
         """
         coroutine = self._momento_async_client.delete(cache_name, key)
         return wait_for_coroutine(self._loop, coroutine)
-
-
-def init(
-    auth_token: str,
-    item_default_ttl_seconds: int,
-    request_timeout_ms: Optional[int] = None,
-) -> SimpleCacheClient:
-    """Creates a SimpleCacheClient
-
-    Args:
-        auth_token: Momento Token to authenticate the requests with Simple Cache Service
-        item_default_ttl_seconds: A default Time To Live in seconds for cache objects created by this client. It is
-            possible to override this setting when calling the set method.
-        request_timeout_ms: An optional timeout in milliseconds to allow for Get and Set operations to complete.
-            Defaults to 5 seconds. The request will be terminated if it takes longer than this value and will result
-            in TimeoutError.
-    Returns:
-        SimpleCacheClient
-    Raises:
-        IllegalArgumentError: If method arguments fail validations
-    """
-    _validate_request_timeout(request_timeout_ms)
-    return SimpleCacheClient(auth_token, item_default_ttl_seconds, request_timeout_ms)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,11 @@ from momento.simple_cache_client import SimpleCacheClient
 from momento.aio.simple_cache_client import (
     SimpleCacheClient as SimpleCacheClientAsync,
 )
-import momento.incubating.aio.simple_cache_client as incubating_simple_cache_client_async
 from momento.incubating.aio.simple_cache_client import (
-    SimpleCacheClient as IncubatingSimpleCacheClientAsync,
+    SimpleCacheClientIncubating as IncubatingSimpleCacheClientAsync,
 )
-import momento.incubating.simple_cache_client as incubating_simple_cache_client
 from momento.incubating.simple_cache_client import (
-    SimpleCacheClient as IncubatingSimpleCacheClient,
+    SimpleCacheClientIncubating as IncubatingSimpleCacheClient,
 )
 
 
@@ -96,7 +94,7 @@ async def client_async() -> SimpleCacheClientAsync:
 
 @pytest.fixture(scope="session")
 async def incubating_client_async() -> IncubatingSimpleCacheClientAsync:
-    async with incubating_simple_cache_client_async.init(
+    async with IncubatingSimpleCacheClientAsync(
         TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS
     ) as client:
         # Ensure test cache exists
@@ -110,9 +108,7 @@ async def incubating_client_async() -> IncubatingSimpleCacheClientAsync:
 
 @pytest.fixture(scope="session")
 def incubating_client() -> IncubatingSimpleCacheClient:
-    with incubating_simple_cache_client.init(
-        TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS
-    ) as client:
+    with IncubatingSimpleCacheClient(TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS) as client:
         # Ensure test cache exists
         try:
             client.create_cache(TEST_CACHE_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ async def client_async() -> SimpleCacheClientAsync:
         yield _client
 
 
+# TODO: Test fails when this is session scope. Because of a race when closing the event loop?
 @pytest.fixture(scope="module")
 def incubating_client() -> IncubatingSimpleCacheClient:
     with IncubatingSimpleCacheClient(TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS) as client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,7 @@ from typing import cast, Optional
 import pytest
 
 import momento.errors as errors
-import momento.simple_cache_client as simple_cache_client
 from momento.simple_cache_client import SimpleCacheClient
-import momento.aio.simple_cache_client as simple_cache_client_async
 from momento.aio.simple_cache_client import (
     SimpleCacheClient as SimpleCacheClientAsync,
 )
@@ -74,7 +72,7 @@ def event_loop() -> asyncio.AbstractEventLoop:
 
 @pytest.fixture(scope="session")
 def client() -> SimpleCacheClient:
-    with simple_cache_client.init(TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS) as _client:
+    with SimpleCacheClient(TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         try:
             _client.create_cache(TEST_CACHE_NAME)
@@ -86,9 +84,7 @@ def client() -> SimpleCacheClient:
 
 @pytest.fixture(scope="session")
 async def client_async() -> SimpleCacheClientAsync:
-    async with simple_cache_client_async.init(
-        TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS
-    ) as _client:
+    async with SimpleCacheClientAsync(TEST_AUTH_TOKEN, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         try:
             await _client.create_cache(TEST_CACHE_NAME)

--- a/tests/incubating/test_dictionary.py
+++ b/tests/incubating/test_dictionary.py
@@ -6,6 +6,7 @@ import pytest
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
 from momento.incubating.simple_cache_client import SimpleCacheClientIncubating
+
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 

--- a/tests/incubating/test_dictionary.py
+++ b/tests/incubating/test_dictionary.py
@@ -5,24 +5,24 @@ import pytest
 
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
-import momento.incubating.simple_cache_client as simple_cache_client
-from momento.incubating.simple_cache_client import SimpleCacheClient
+from momento.incubating.simple_cache_client import SimpleCacheClientIncubating
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 
 
 def test_incubating_warning(
-    incubating_client: SimpleCacheClient,
     auth_token: str,
     default_ttl_seconds: int,
 ):
     with pytest.warns(UserWarning):
         warnings.simplefilter("always")
-        with simple_cache_client.init(auth_token, default_ttl_seconds):
+        with SimpleCacheClientIncubating(auth_token, default_ttl_seconds):
             pass
 
 
-def test_dictionary_get_miss(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_get_miss(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     get_response = incubating_client.dictionary_get(
         cache_name=cache_name, dictionary_name=uuid_str(), key=uuid_str()
     )
@@ -30,7 +30,7 @@ def test_dictionary_get_miss(incubating_client: SimpleCacheClient, cache_name: s
 
 
 def test_dictionary_get_multi_miss(
-    incubating_client: SimpleCacheClient, cache_name: str
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
 ):
     get_response = incubating_client.dictionary_get_multi(
         cache_name, uuid_str(), uuid_str(), uuid_str(), uuid_str()
@@ -43,7 +43,9 @@ def test_dictionary_get_multi_miss(
     assert all(value is None for value in get_response.values_as_bytes())
 
 
-def test_dictionary_set_response(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_set_response(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     # Test with key as string
     dictionary = {uuid_str(): uuid_str()}
     dictionary_name = uuid_str()
@@ -69,7 +71,9 @@ def test_dictionary_set_response(incubating_client: SimpleCacheClient, cache_nam
     assert set_response.dictionary_as_bytes() == dictionary
 
 
-def test_dictionary_set_unary(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_set_unary(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     dictionary_name = uuid_str()
     key, value = uuid_str(), uuid_str()
     set_response = incubating_client.dictionary_set(
@@ -90,7 +94,7 @@ def test_dictionary_set_unary(incubating_client: SimpleCacheClient, cache_name: 
 
 
 def test_dictionary_set_and_dictionary_get_missing_key(
-    incubating_client: SimpleCacheClient, cache_name: str
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     incubating_client.dictionary_set(
@@ -109,13 +113,15 @@ def test_dictionary_set_and_dictionary_get_missing_key(
 
 
 def test_dictionary_get_zero_length_keys(
-    incubating_client: SimpleCacheClient, cache_name: str
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
 ):
     with pytest.raises(ValueError):
         incubating_client.dictionary_get_multi(cache_name, uuid_str(), *[])
 
 
-def test_dictionary_get_hit(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_get_hit(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
     for i, (key_is_str, value_is_str) in enumerate(
         itertools.product((True, False), (True, False))
@@ -145,7 +151,7 @@ def test_dictionary_get_hit(incubating_client: SimpleCacheClient, cache_name: st
 
 
 def test_dictionary_get_multi_hit(
-    incubating_client: SimpleCacheClient, cache_name: str
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     keys = [uuid_str() for _ in range(3)]
@@ -189,14 +195,18 @@ def test_dictionary_get_multi_hit(
     ]
 
 
-def test_dictionary_get_all_miss(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_get_all_miss(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     get_response = incubating_client.dictionary_get_all(
         cache_name=cache_name, dictionary_name=uuid_str()
     )
     assert get_response.status() == CacheGetStatus.MISS
 
 
-def test_dictionary_get_all_hit(incubating_client: SimpleCacheClient, cache_name: str):
+def test_dictionary_get_all_hit(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     dictionary_name = uuid_str()
     dictionary = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
     incubating_client.dictionary_set_multi(

--- a/tests/incubating/test_dictionary_async.py
+++ b/tests/incubating/test_dictionary_async.py
@@ -5,25 +5,23 @@ import pytest
 
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
-import momento.incubating.aio.simple_cache_client as simple_cache_client
-from momento.incubating.aio.simple_cache_client import SimpleCacheClient
+from momento.incubating.aio.simple_cache_client import SimpleCacheClientIncubating
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 
 
 async def test_incubating_warning(
-    incubating_client_async: SimpleCacheClient,
     auth_token: str,
     default_ttl_seconds: int,
 ):
     with pytest.warns(UserWarning):
         warnings.simplefilter("always")
-        async with simple_cache_client.init(auth_token, default_ttl_seconds):
+        async with SimpleCacheClientIncubating(auth_token, default_ttl_seconds):
             pass
 
 
 async def test_dictionary_get_miss(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     get_response = await incubating_client_async.dictionary_get(
         cache_name=cache_name, dictionary_name=uuid_str(), key=uuid_str()
@@ -32,7 +30,7 @@ async def test_dictionary_get_miss(
 
 
 async def test_dictionary_get_multi_miss(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     get_response = await incubating_client_async.dictionary_get_multi(
         cache_name, uuid_str(), uuid_str(), uuid_str(), uuid_str()
@@ -46,7 +44,7 @@ async def test_dictionary_get_multi_miss(
 
 
 async def test_dictionary_set_response(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     # Test with key as string
     dictionary = {uuid_str(): uuid_str()}
@@ -74,7 +72,7 @@ async def test_dictionary_set_response(
 
 
 async def test_dictionary_set_unary(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     key, value = uuid_str(), uuid_str()
@@ -96,7 +94,7 @@ async def test_dictionary_set_unary(
 
 
 async def test_dictionary_set_and_dictionary_get_missing_key(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     await incubating_client_async.dictionary_set(
@@ -115,14 +113,14 @@ async def test_dictionary_set_and_dictionary_get_missing_key(
 
 
 async def test_dictionary_get_zero_length_keys(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     with pytest.raises(ValueError):
         await incubating_client_async.dictionary_get_multi(cache_name, uuid_str(), *[])
 
 
 async def test_dictionary_get_hit(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     # Test all combinations of type(key) in {str, bytes} and type(value) in {str, bytes}
     for i, (key_is_str, value_is_str) in enumerate(
@@ -153,7 +151,7 @@ async def test_dictionary_get_hit(
 
 
 async def test_dictionary_get_multi_hit(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     keys = [uuid_str() for _ in range(3)]
@@ -198,7 +196,7 @@ async def test_dictionary_get_multi_hit(
 
 
 async def test_dictionary_get_all_miss(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     get_response = await incubating_client_async.dictionary_get_all(
         cache_name=cache_name, dictionary_name=uuid_str()
@@ -207,7 +205,7 @@ async def test_dictionary_get_all_miss(
 
 
 async def test_dictionary_get_all_hit(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     dictionary_name = uuid_str()
     dictionary = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}

--- a/tests/incubating/test_dictionary_async.py
+++ b/tests/incubating/test_dictionary_async.py
@@ -6,6 +6,7 @@ import pytest
 from momento.cache_operation_types import CacheGetStatus
 from momento.incubating.cache_operation_types import CacheDictionaryGetUnaryResponse
 from momento.incubating.aio.simple_cache_client import SimpleCacheClientIncubating
+
 from momento.incubating.aio.utils import convert_dict_items_to_bytes
 from tests.utils import uuid_str, uuid_bytes, str_to_bytes
 

--- a/tests/incubating/test_exists.py
+++ b/tests/incubating/test_exists.py
@@ -1,8 +1,10 @@
-from momento.incubating.simple_cache_client import SimpleCacheClient
+from momento.incubating.simple_cache_client import SimpleCacheClientIncubating
 from tests.utils import uuid_str
 
 
-def test_exists_unary_missing(incubating_client: SimpleCacheClient, cache_name: str):
+def test_exists_unary_missing(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     key = uuid_str()
     response = incubating_client.exists(cache_name, key)
     assert not response
@@ -13,7 +15,9 @@ def test_exists_unary_missing(incubating_client: SimpleCacheClient, cache_name: 
     assert list(response.zip_keys_and_results()) == [(key, False)]
 
 
-def test_exists_unary_exists(incubating_client: SimpleCacheClient, cache_name: str):
+def test_exists_unary_exists(
+    incubating_client: SimpleCacheClientIncubating, cache_name: str
+):
     key, value = uuid_str(), uuid_str()
     incubating_client.set(cache_name, key, value)
 
@@ -27,7 +31,7 @@ def test_exists_unary_exists(incubating_client: SimpleCacheClient, cache_name: s
     assert list(response.zip_keys_and_results()) == [(key, True)]
 
 
-def test_exists_multi(incubating_client: SimpleCacheClient, cache_name: str):
+def test_exists_multi(incubating_client: SimpleCacheClientIncubating, cache_name: str):
     keys = []
     for i in range(3):
         key = uuid_str()

--- a/tests/incubating/test_exists_async.py
+++ b/tests/incubating/test_exists_async.py
@@ -1,9 +1,9 @@
-from momento.incubating.aio.simple_cache_client import SimpleCacheClient
+from momento.incubating.aio.simple_cache_client import SimpleCacheClientIncubating
 from tests.utils import uuid_str
 
 
 async def test_exists_unary_missing(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     key = uuid_str()
     response = await incubating_client_async.exists(cache_name, key)
@@ -16,7 +16,7 @@ async def test_exists_unary_missing(
 
 
 async def test_exists_unary_exists(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     key, value = uuid_str(), uuid_str()
     await incubating_client_async.set(cache_name, key, value)
@@ -32,7 +32,7 @@ async def test_exists_unary_exists(
 
 
 async def test_exists_multi(
-    incubating_client_async: SimpleCacheClient, cache_name: str
+    incubating_client_async: SimpleCacheClientIncubating, cache_name: str
 ):
     keys = []
     for i in range(3):

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 
-import momento.simple_cache_client as simple_cache_client
 from momento.simple_cache_client import SimpleCacheClient
 import momento.errors as errors
 from momento.cache_operation_types import CacheGetStatus
@@ -36,13 +35,13 @@ def test_init_throws_exception_when_client_uses_negative_default_ttl(
     auth_token: str,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, -1)
+        SimpleCacheClient(auth_token, -1)
         assert cm.exception == "TTL Seconds must be a non-negative integer"
 
 
 def test_init_throws_exception_for_non_jwt_token(default_ttl_seconds: int):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init("notanauthtoken", default_ttl_seconds)
+        SimpleCacheClient("notanauthtoken", default_ttl_seconds)
         assert cm.exception == "Invalid Auth token."
 
 
@@ -50,7 +49,7 @@ def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(
     auth_token: str, default_ttl_seconds: int
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, default_ttl_seconds, -1)
+        SimpleCacheClient(auth_token, default_ttl_seconds, -1)
         assert cm.exception == "Request timeout must be greater than zero."
 
 
@@ -58,7 +57,7 @@ def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
     auth_token: str, default_ttl_seconds: int
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, default_ttl_seconds, 0)
+        SimpleCacheClient(auth_token, default_ttl_seconds, 0)
         assert cm.exception == "Request timeout must be greater than zero."
 
 
@@ -96,7 +95,7 @@ def test_create_cache_with_bad_cache_name_throws_exception(
 def test_create_cache_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(bad_auth_token, default_ttl_seconds) as client:
+    with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client:
         with pytest.raises(errors.AuthenticationError):
             client.create_cache(uuid_str())
 
@@ -145,7 +144,7 @@ def test_delete_with_bad_cache_name_throws_exception(
 def test_delete_cache_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(bad_auth_token, default_ttl_seconds) as client:
+    with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client:
         with pytest.raises(errors.AuthenticationError):
             client.delete_cache(uuid_str())
 
@@ -173,7 +172,7 @@ def test_list_caches_succeeds(client: SimpleCacheClient, cache_name: str):
 def test_list_caches_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(bad_auth_token, default_ttl_seconds) as client:
+    with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client:
         with pytest.raises(errors.AuthenticationError):
             client.list_caches()
 
@@ -338,7 +337,7 @@ def test_set_with_bad_value_throws_exception(
 def test_set_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(bad_auth_token, default_ttl_seconds) as client:
+    with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client:
         with pytest.raises(errors.AuthenticationError):
             client.set(cache_name, "foo", "bar")
 
@@ -346,7 +345,7 @@ def test_set_throws_authentication_exception_for_bad_token(
 def test_set_throws_timeout_error_for_short_request_timeout(
     auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(
+    with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client:
         with pytest.raises(errors.TimeoutError):
@@ -400,7 +399,7 @@ def test_get_with_bad_key_throws_exception(client: SimpleCacheClient, cache_name
 def test_get_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(bad_auth_token, default_ttl_seconds) as client:
+    with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client:
         with pytest.raises(errors.AuthenticationError):
             client.get(cache_name, "foo")
 
@@ -408,7 +407,7 @@ def test_get_throws_authentication_exception_for_bad_token(
 def test_get_throws_timeout_error_for_short_request_timeout(
     auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    with simple_cache_client.init(
+    with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client:
         with pytest.raises(errors.TimeoutError):
@@ -433,7 +432,7 @@ def test_get_multi_and_set(client: SimpleCacheClient, cache_name: str):
 
 def test_get_multi_failure(auth_token: str, cache_name: str, default_ttl_seconds: int):
     # Start with a cache client with impossibly small request timeout to force failures
-    with simple_cache_client.init(
+    with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client:
         with pytest.raises(errors.TimeoutError):
@@ -447,7 +446,7 @@ def test_set_multi_failure(
     default_ttl_seconds: int,
 ):
     # Start with a cache client with impossibly small request timeout to force failures
-    with simple_cache_client.init(
+    with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client:
         with pytest.raises(errors.TimeoutError):

--- a/tests/test_momento.py
+++ b/tests/test_momento.py
@@ -184,7 +184,7 @@ def test_list_caches_with_next_token_works(client: SimpleCacheClient, cache_name
 
 
 # Signing keys
-def test_create_list_revoke_signing_keys(client: SimpleCacheClient, cache_name: str):
+def test_create_list_revoke_signing_keys(client: SimpleCacheClient):
     create_resp = client.create_signing_key(30)
     list_resp = client.list_signing_keys()
     assert create_resp.key_id() in [
@@ -287,7 +287,7 @@ def test_set_with_null_cache_name_throws_exception(
 
 
 def test_set_with_empty_cache_name_throws_exception(
-    client: SimpleCacheClient, cache_name: str
+    client: SimpleCacheClient,
 ):
     with pytest.raises(errors.BadRequestError) as cm:
         client.set("", "foo", "bar")
@@ -313,7 +313,7 @@ def test_set_negative_ttl_throws_exception(client: SimpleCacheClient, cache_name
 
 
 def test_set_with_bad_cache_name_throws_exception(
-    client: SimpleCacheClient, cache_name: str
+    client: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         client.set(1, "foo", "bar")
@@ -362,7 +362,7 @@ def test_get_with_non_existent_cache_name_throws_not_found(
 
 
 def test_get_with_null_cache_name_throws_exception(
-    client: SimpleCacheClient, cache_name: str
+    client: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         client.get(None, "foo")
@@ -370,7 +370,7 @@ def test_get_with_null_cache_name_throws_exception(
 
 
 def test_get_with_empty_cache_name_throws_exception(
-    client: SimpleCacheClient, cache_name: str
+    client: SimpleCacheClient,
 ):
     with pytest.raises(errors.BadRequestError) as cm:
         client.get("", "foo")
@@ -383,7 +383,7 @@ def test_get_with_null_key_throws_exception(client: SimpleCacheClient, cache_nam
 
 
 def test_get_with_bad_cache_name_throws_exception(
-    client: SimpleCacheClient, cache_name: str
+    client: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         client.get(1, "foo")

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -186,9 +186,7 @@ async def test_list_caches_with_next_token_works(
 
 
 # Signing keys
-async def test_create_list_revoke_signing_keys(
-    client_async: SimpleCacheClient, cache_name: str
-):
+async def test_create_list_revoke_signing_keys(client_async: SimpleCacheClient):
     create_resp = await client_async.create_signing_key(30)
     list_resp = await client_async.list_signing_keys()
     assert create_resp.key_id() in [
@@ -295,7 +293,7 @@ async def test_set_with_null_cache_name_throws_exception(
 
 
 async def test_set_with_empty_cache_name_throws_exception(
-    client_async: SimpleCacheClient, cache_name: str
+    client_async: SimpleCacheClient,
 ):
     with pytest.raises(errors.BadRequestError) as cm:
         await client_async.set("", "foo", "bar")
@@ -325,7 +323,7 @@ async def test_set_negative_ttl_throws_exception(
 
 
 async def test_set_with_bad_cache_name_throws_exception(
-    client_async: SimpleCacheClient, cache_name: str
+    client_async: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         await client_async.set(1, "foo", "bar")
@@ -376,7 +374,7 @@ async def test_get_with_non_existent_cache_name_throws_not_found(
 
 
 async def test_get_with_null_cache_name_throws_exception(
-    client_async: SimpleCacheClient, cache_name: str
+    client_async: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         await client_async.get(None, "foo")
@@ -384,7 +382,7 @@ async def test_get_with_null_cache_name_throws_exception(
 
 
 async def test_get_with_empty_cache_name_throws_exception(
-    client_async: SimpleCacheClient, cache_name: str
+    client_async: SimpleCacheClient,
 ):
     with pytest.raises(errors.BadRequestError) as cm:
         await client_async.get("", "foo")
@@ -399,7 +397,7 @@ async def test_get_with_null_key_throws_exception(
 
 
 async def test_get_with_bad_cache_name_throws_exception(
-    client_async: SimpleCacheClient, cache_name: str
+    client_async: SimpleCacheClient,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
         await client_async.get(1, "foo")

--- a/tests/test_momento_async.py
+++ b/tests/test_momento_async.py
@@ -2,8 +2,7 @@ import time
 
 import pytest
 
-import momento.aio.simple_cache_client as simple_cache_client
-from momento.simple_cache_client import SimpleCacheClient
+from momento.aio.simple_cache_client import SimpleCacheClient
 import momento.errors as errors
 from momento.cache_operation_types import CacheGetStatus
 from tests.utils import uuid_str, uuid_bytes, str_to_bytes
@@ -36,13 +35,13 @@ async def test_init_throws_exception_when_client_uses_negative_default_ttl(
     auth_token: str,
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, -1)
+        SimpleCacheClient(auth_token, -1)
         assert cm.exception == "TTL Seconds must be a non-negative integer"
 
 
 async def test_init_throws_exception_for_non_jwt_token(default_ttl_seconds: int):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init("notanauthtoken", default_ttl_seconds)
+        SimpleCacheClient("notanauthtoken", default_ttl_seconds)
         assert cm.exception == "Invalid Auth token."
 
 
@@ -50,7 +49,7 @@ async def test_init_throws_exception_when_client_uses_negative_request_timeout_m
     auth_token: str, default_ttl_seconds: int
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, default_ttl_seconds, -1)
+        SimpleCacheClient(auth_token, default_ttl_seconds, -1)
         assert cm.exception == "Request timeout must be greater than zero."
 
 
@@ -58,7 +57,7 @@ async def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
     auth_token: str, default_ttl_seconds: int
 ):
     with pytest.raises(errors.InvalidArgumentError) as cm:
-        simple_cache_client.init(auth_token, default_ttl_seconds, 0)
+        SimpleCacheClient(auth_token, default_ttl_seconds, 0)
         assert cm.exception == "Request timeout must be greater than zero."
 
 
@@ -96,9 +95,7 @@ async def test_create_cache_with_bad_cache_name_throws_exception(
 async def test_create_cache_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
-        bad_auth_token, default_ttl_seconds
-    ) as client_async:
+    async with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client_async:
         with pytest.raises(errors.AuthenticationError):
             await client_async.create_cache(uuid_str())
 
@@ -147,9 +144,7 @@ async def test_delete_with_bad_cache_name_throws_exception(
 async def test_delete_cache_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
-        bad_auth_token, default_ttl_seconds
-    ) as client_async:
+    async with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client_async:
         with pytest.raises(errors.AuthenticationError):
             await client_async.delete_cache(uuid_str())
 
@@ -177,9 +172,7 @@ async def test_list_caches_succeeds(client_async: SimpleCacheClient, cache_name:
 async def test_list_caches_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
-        bad_auth_token, default_ttl_seconds
-    ) as client_async:
+    async with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client_async:
         with pytest.raises(errors.AuthenticationError):
             await client_async.list_caches()
 
@@ -358,9 +351,7 @@ async def test_set_with_bad_value_throws_exception(
 async def test_set_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
-        bad_auth_token, default_ttl_seconds
-    ) as client_async:
+    async with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client_async:
         with pytest.raises(errors.AuthenticationError):
             await client_async.set(cache_name, "foo", "bar")
 
@@ -368,7 +359,7 @@ async def test_set_throws_authentication_exception_for_bad_token(
 async def test_set_throws_timeout_error_for_short_request_timeout(
     auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
+    async with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client_async:
         with pytest.raises(errors.TimeoutError):
@@ -426,9 +417,7 @@ async def test_get_with_bad_key_throws_exception(
 async def test_get_throws_authentication_exception_for_bad_token(
     bad_auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
-        bad_auth_token, default_ttl_seconds
-    ) as client_async:
+    async with SimpleCacheClient(bad_auth_token, default_ttl_seconds) as client_async:
         with pytest.raises(errors.AuthenticationError):
             await client_async.get(cache_name, "foo")
 
@@ -436,7 +425,7 @@ async def test_get_throws_authentication_exception_for_bad_token(
 async def test_get_throws_timeout_error_for_short_request_timeout(
     auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
-    async with simple_cache_client.init(
+    async with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client_async:
         with pytest.raises(errors.TimeoutError):
@@ -463,7 +452,7 @@ async def test_get_multi_failure(
     auth_token: str, cache_name: str, default_ttl_seconds: int
 ):
     # Start with a cache client with impossibly small request timeout to force failures
-    async with simple_cache_client.init(
+    async with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client_async:
         with pytest.raises(errors.TimeoutError):
@@ -479,7 +468,7 @@ async def test_set_multi_failure(
     default_ttl_seconds: int,
 ):
     # Start with a cache client with impossibly small request timeout to force failures
-    async with simple_cache_client.init(
+    async with SimpleCacheClient(
         auth_token, default_ttl_seconds, request_timeout_ms=1
     ) as client_async:
         with pytest.raises(errors.TimeoutError):


### PR DESCRIPTION
The `init` functions to build the cache clients are unnecessary. Because python allows keyword arguments, we can pass any and all configuration options in the constructor.

Work towards #117 