### PR TITLE
fix: spelling of "Framework" in project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ keywords = ["Momento", "caching", "key-value store", "serverless"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Operating System :: OS Independent",
+  "Framework :: AsyncIO",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Topic :: Internet",


### PR DESCRIPTION
Trying to fix.
https://github.com/momentohq/client-sdk-python/actions/runs/3292488002/jobs/5427927954

```
 - Uploading momento-0.16.0-py3-none-any.whl 100%
HTTP Error 400: Invalid value for classifiers. Error: Classifier 'Framework :: AsnycIO' is not a valid classifier. | b"<html>\n <head>\n  <title>400 Invalid value for classifiers. Error: Classifier 'Framework :: AsnycIO' is not a valid classifier.\n \n <body>\n  <h1>400 Invalid value for classifiers. Error: Classifier 'Framework :: AsnycIO' is not a valid classifier.\n  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>\nInvalid value for classifiers. Error: Classifier &#x27;Framework :: AsnycIO&#x27; is not a valid classifier.\n\n\n \n"
```