### PR TITLE
fix: pin ubuntu and poetry ci dependencies

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Bootstrap poetry
         run: |
-          curl -sL https://install.python-poetry.org | python - -y
+          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -55,7 +55,7 @@ jobs:
         run: poetry run pytest -p no:sugar -q
 
   test-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Bootstrap poetry
         run: |
-          curl -sL https://install.python-poetry.org | python - -y
+          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
@@ -88,7 +88,7 @@ jobs:
 
       - name: Bootstrap poetry
         run: |
-          curl -sL https://install.python-poetry.org | python - -y
+          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
 
       - name: Bump version
         run: poetry version ${{ needs.release.outputs.version }}

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.release.outputs.release }}
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -75,7 +75,7 @@ jobs:
         run: poetry run pytest -p no:sugar -q
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [release, test]
 
     steps:


### PR DESCRIPTION
Pins the ubuntu version to 20.04. Previously we used `ubuntu-latest`; GitHub started pointing this from 20.04 to 22.04 in October and the integration tests started failing. We have timeboxed an investigation into why 22.04 fails, but remains inconclusive. Hence in the meantime we revert to 20.04. We also pin the poetry dependency as a matter of good practice.