### PR TITLE
refactor: Reduce pass-through args in BasicPythonLoadGen.

### DIFF
--- a/examples/example_load_gen.py
+++ b/examples/example_load_gen.py
@@ -47,6 +47,7 @@ class BasicPythonLoadGenOptions:
     show_stats_interval_seconds: int
     total_seconds_to_run: int
 
+
 @dataclass
 class BasicPythonLoadGenContext:
     start_time: float
@@ -285,9 +286,7 @@ If you have questions or need help experimenting further, please reach out to us
 """
 
 
-async def main(
-    options: BasicPythonLoadGenOptions
-) -> None:
+async def main(options: BasicPythonLoadGenOptions) -> None:
     initialize_logging(options.log_level)
     load_generator = BasicPythonLoadGen(options)
     await load_generator.run()


### PR DESCRIPTION
The load-gen script passes through a lot of individual variables which makes it unwieldy to change its options. Instead, make them available as BasicPythonLoadGen attributes.

* Group config variables in BasicPythonLoadGenOptions.
  * Make it an BasicPythonLoadGen attribute.
* Make BasicPythonLoadGenContext a BasicPythonLoadGen attribute.