### PR TITLE
fix: re-introduce retry interceptor for synchronous client

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -57,6 +57,9 @@ disallow_any_expr           = False
 [mypy-momento.internal.synchronous._add_header_client_interceptor]
 disallow_any_expr           = False
 
+[mypy-momento.internal.synchronous._retry_interceptor]
+disallow_any_expr           = False
+
 [mypy-momento.internal.common._data_client_ops]
 disallow_any_expr           = False
 

--- a/src/momento/aio/_retry_interceptor.py
+++ b/src/momento/aio/_retry_interceptor.py
@@ -2,6 +2,7 @@ import logging
 from typing import Callable, List, Union
 
 import grpc
+
 import momento.errors
 
 # TODO: This is very duplicative of the synchronous retry interceptor; we need to

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -57,7 +57,7 @@ def get_retry_interceptor_if_enabled() -> List[grpc.UnaryUnaryClientInterceptor]
 
 
 class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
-     def intercept_unary_unary(
+    def intercept_unary_unary(
         self,
         continuation: Callable[
             [grpc.ClientCallDetails, RequestType],
@@ -69,8 +69,8 @@ class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
         client_call_details: grpc.ClientCallDetails,
         # request: grpc.aio._typing.RequestType,
         request: RequestType
-    # ) -> Union[grpc.aio._call.UnaryUnaryCall, grpc.aio._typing.ResponseType]:
-     ) -> Union[InterceptorCall, ResponseType]:
+        # ) -> Union[grpc.aio._call.UnaryUnaryCall, grpc.aio._typing.ResponseType]:
+    ) -> Union[InterceptorCall, ResponseType]:
         for try_i in range(MAX_ATTEMPTS):
             # call = await continuation(client_call_details, request)
             call = continuation(client_call_details, request)

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -63,20 +63,13 @@ class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
         continuation: Callable[
             [grpc.ClientCallDetails, RequestType],
             InterceptorCall
-            # [grpc.aio._interceptor.ClientCallDetails, grpc.aio._typing.RequestType],
-            # grpc.aio._call.UnaryUnaryCall,
         ],
-        # client_call_details: grpc.aio._interceptor.ClientCallDetails,
         client_call_details: grpc.ClientCallDetails,
-        # request: grpc.aio._typing.RequestType,
         request: RequestType
-        # ) -> Union[grpc.aio._call.UnaryUnaryCall, grpc.aio._typing.ResponseType]:
     ) -> Union[InterceptorCall, ResponseType]:
         for try_i in range(MAX_ATTEMPTS):
-            # call = await continuation(client_call_details, request)
             call = continuation(client_call_details, request)
-            # response_code = await call.code()
-            response_code = call.code()
+            response_code = call.code() # type: ignore[attr-defined]  # noqa: F401
 
             if response_code == grpc.StatusCode.OK:
                 return call

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -60,16 +60,13 @@ def get_retry_interceptor_if_enabled() -> List[grpc.UnaryUnaryClientInterceptor]
 class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
     def intercept_unary_unary(
         self,
-        continuation: Callable[
-            [grpc.ClientCallDetails, RequestType],
-            InterceptorCall
-        ],
+        continuation: Callable[[grpc.ClientCallDetails, RequestType], InterceptorCall],
         client_call_details: grpc.ClientCallDetails,
-        request: RequestType
+        request: RequestType,
     ) -> Union[InterceptorCall, ResponseType]:
         for try_i in range(MAX_ATTEMPTS):
             call = continuation(client_call_details, request)
-            response_code = call.code() # type: ignore[attr-defined]  # noqa: F401
+            response_code = call.code()  # type: ignore[attr-defined]  # noqa: F401
 
             if response_code == grpc.StatusCode.OK:
                 return call

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -1,7 +1,8 @@
 import logging
-from typing import Callable, List, Union, TypeVar
+from typing import Callable, List, TypeVar, Union
 
 import grpc
+
 import momento.errors
 
 RequestType = TypeVar("RequestType")

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -5,10 +5,12 @@ import momento_wire_types.cacheclient_pb2_grpc as cache_client
 import momento_wire_types.controlclient_pb2_grpc as control_client
 import pkg_resources
 
-from momento.internal.synchronous._retry_interceptor import get_retry_interceptor_if_enabled
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     Header,
+)
+from momento.internal.synchronous._retry_interceptor import (
+    get_retry_interceptor_if_enabled,
 )
 
 

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -51,7 +51,4 @@ class _DataGrpcManager:
 
 def _interceptors(auth_token: str) -> List[grpc.UnaryUnaryClientInterceptor]:
     headers = [Header("authorization", auth_token), Header("agent", f"python:{_ControlGrpcManager.version}")]
-    return [
-        AddHeaderClientInterceptor(headers),
-        *get_retry_interceptor_if_enabled()
-    ]
+    return [AddHeaderClientInterceptor(headers), *get_retry_interceptor_if_enabled()]

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -5,6 +5,7 @@ import momento_wire_types.cacheclient_pb2_grpc as cache_client
 import momento_wire_types.controlclient_pb2_grpc as control_client
 import pkg_resources
 
+from momento.internal.synchronous._retry_interceptor import get_retry_interceptor_if_enabled
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     Header,
@@ -50,4 +51,7 @@ class _DataGrpcManager:
 
 def _interceptors(auth_token: str) -> List[grpc.UnaryUnaryClientInterceptor]:
     headers = [Header("authorization", auth_token), Header("agent", f"python:{_ControlGrpcManager.version}")]
-    return [AddHeaderClientInterceptor(headers)]
+    return [
+        AddHeaderClientInterceptor(headers),
+        *get_retry_interceptor_if_enabled()
+    ]


### PR DESCRIPTION
In an earlier commit we made some changes to the implementation
of the synchronous client to use the grpc synchronous API directly,
rather than wrapping the asyncio API, which was causing problems
in environments that used other asyncio libraries.

During the rollout of that change we mistakenly lost the retry
capabilities that we have in the asyncio client.  This commit
adds the retry suppport back in for the sync client.

This implementation is not DRY and we need to clean it up as we
are doing the work to introduce Configuration, but this will
at least unblock users for now.
