### PR TITLE
chore: add collection ttl data class

### DIFF
--- a/src/momento/requests/__init__.py
+++ b/src/momento/requests/__init__.py
@@ -1,0 +1,1 @@
+from .collection_ttl import CollectionTtl

--- a/src/momento/requests/collection_ttl.py
+++ b/src/momento/requests/collection_ttl.py
@@ -5,23 +5,86 @@ from typing import Optional
 
 @dataclass
 class CollectionTtl:
+    """Represents the desired behavior for managing the TTL on collection
+    objects (dictionaries, lists, sets, etc) in your cache.
+
+    For cache operations that modify a collection, there are a few things
+    to consider.  The first time the collection is created, we need to
+    set a TTL on it.  For subsequent operations that modify the collection
+    you may choose to update the TTL in order to prolong the life of the
+    cached collection object, or you may choose to leave the TTL unmodified
+    in order to ensure that the collection expires at the original TTL.
+
+    The default behavior is to refresh the TTL (to prolong the life of the
+    collection) each time it is written.  This behavior can be modified
+    by calling the method `with_no_refresh_ttl_on_updates`.
+    """
+
     ttl: Optional[timedelta] = None
+    """The duration after which the cached collection should be expired from the cache.
+    If `null`, we use the default TTL that was passed to the `SimpleCacheClient` init method.
+    """
     refresh_ttl: bool = True
+    """If `True`, the collection's TTL will be refreshed (to prolong the life of the collection)
+    on every update.  If `False`, the collection's TTL will only be set when the collection is
+    initially created.
+    """
 
     @staticmethod
     def from_cache_ttl() -> "CollectionTtl":
+        """The default way to handle TTLs for collections. The default TTL
+        `timedelta` that was specified when instantiating the `SimpleCacheClient`
+        will be used, and the TTL for the collection will be refreshed any
+        time the collection is modified.
+
+        Returns:
+            CollectionTtl
+        """
         return CollectionTtl(ttl=None, refresh_ttl=True)
 
     @staticmethod
     def of(ttl: timedelta) -> "CollectionTtl":
+        """Constructs a CollectionTtl with the specified `timedelta`. TTL
+        for the collection will be refreshed any time the collection is
+        modified.
+
+        Args:
+            ttl (timedelta): the duration to use for the TTL
+
+        Returns:
+            CollectionTtl
+        """
         return CollectionTtl(ttl=ttl)
 
     @staticmethod
     def refresh_ttl_if_provided(ttl: Optional[timedelta] = None) -> "CollectionTtl":
+        """Constructs a `CollectionTtl` with the specified `timedelta`.
+        Will only refresh if the TTL is provided (ie not `null`).
+
+        Args:
+            ttl (Optional[timedelta], optional): the duration to use for the TTL. Defaults to None.
+
+        Returns:
+            CollectionTtl
+        """
         return CollectionTtl(ttl=ttl, refresh_ttl=ttl is not None)
 
     def with_refresh_ttl_on_updates(self) -> "CollectionTtl":
+        """Specifies that the TTL for the collection should be refreshed when
+        the collection is modified.  (This is the default behavior.)
+
+        Returns:
+            CollectionTtl
+        """
         return CollectionTtl(ttl=self.ttl, refresh_ttl=True)
 
     def with_no_refresh_ttl_on_updates(self) -> "CollectionTtl":
+        """Specifies that the TTL for the collection should not be refreshed
+        when the collection is modified.  Use this if you want to ensure
+        that your collection expires at the originally specified time, even
+        if you make modifications to the value of the collection.
+
+        Returns:
+            CollectionTtl
+        """
         return CollectionTtl(ttl=self.ttl, refresh_ttl=False)

--- a/src/momento/requests/collection_ttl.py
+++ b/src/momento/requests/collection_ttl.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+
+
+@dataclass
+class CollectionTtl:
+    ttl: Optional[timedelta] = None
+    refresh_ttl: bool = True
+
+    @staticmethod
+    def from_cache_ttl() -> "CollectionTtl":
+        return CollectionTtl(ttl=None, refresh_ttl=True)
+
+    @staticmethod
+    def of(ttl: timedelta) -> "CollectionTtl":
+        return CollectionTtl(ttl=ttl)
+
+    @staticmethod
+    def refresh_ttl_if_provided(ttl: Optional[timedelta] = None) -> "CollectionTtl":
+        return CollectionTtl(ttl=ttl, refresh_ttl=ttl is not None)
+
+    def with_refresh_ttl_on_updates(self) -> "CollectionTtl":
+        return CollectionTtl(ttl=self.ttl, refresh_ttl=True)
+
+    def with_no_refresh_ttl_on_updates(self) -> "CollectionTtl":
+        return CollectionTtl(ttl=self.ttl, refresh_ttl=False)

--- a/tests/momento/requests/test_collection_ttl.py
+++ b/tests/momento/requests/test_collection_ttl.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+from typing import Optional
+
+import pytest
+
+from momento.requests import CollectionTtl
+
+
+@pytest.mark.parametrize(
+    "collection_ttl, expected_ttl, expected_refresh_ttl",
+    [
+        (CollectionTtl(None, False), None, False),
+        (CollectionTtl(timedelta(days=1), False), timedelta(days=1), False),
+        (CollectionTtl.from_cache_ttl(), None, True),
+        (CollectionTtl.of(timedelta(days=1)), timedelta(days=1), True),
+        (CollectionTtl.refresh_ttl_if_provided(ttl=None), None, False),
+        (CollectionTtl.refresh_ttl_if_provided(ttl=timedelta(days=1)), timedelta(days=1), True),
+    ],
+)
+def test_collection_ttl_builders(
+    collection_ttl: CollectionTtl, expected_ttl: Optional[timedelta], expected_refresh_ttl: bool
+) -> None:
+    if expected_ttl is None:
+        assert collection_ttl.ttl is None, "ttl was not None but should be"
+    else:
+        assert collection_ttl.ttl == expected_ttl, "ttl did not match"
+    assert collection_ttl.refresh_ttl == expected_refresh_ttl, "refresh_ttl did not match"
+
+
+@pytest.mark.parametrize(
+    "collection_ttl",
+    [
+        (CollectionTtl(ttl=None, refresh_ttl=False)),
+        (CollectionTtl(ttl=timedelta(days=1), refresh_ttl=False)),
+        (CollectionTtl(ttl=None, refresh_ttl=True)),
+    ],
+)
+def test_with_and_without_refresh_ttl_on_updates(collection_ttl: CollectionTtl) -> None:
+    new_collection_ttl = collection_ttl.with_refresh_ttl_on_updates()
+    assert collection_ttl.ttl == new_collection_ttl.ttl, "ttl should have passed through identically but did not"
+    assert new_collection_ttl.refresh_ttl, "refresh_ttl should be true after with_refresh_ttl_on_updates but wasn't"
+
+    new_collection_ttl = collection_ttl.with_no_refresh_ttl_on_updates()
+    assert collection_ttl.ttl == new_collection_ttl.ttl, "ttl should have passed through identically but did not"
+    assert (
+        not new_collection_ttl.refresh_ttl
+    ), "refresh_ttl should be false after with_no_refresh_ttl_on_updates but wasn't"

--- a/tests/momento/requests/test_collection_ttl.py
+++ b/tests/momento/requests/test_collection_ttl.py
@@ -9,10 +9,10 @@ from momento.requests import CollectionTtl
 @pytest.mark.parametrize(
     "collection_ttl, expected_ttl, expected_refresh_ttl",
     [
-        (CollectionTtl(None, False), None, False),
-        (CollectionTtl(timedelta(days=1), False), timedelta(days=1), False),
+        (CollectionTtl(ttl=None, refresh_ttl=False), None, False),
+        (CollectionTtl(ttl=timedelta(days=1), refresh_ttl=False), timedelta(days=1), False),
         (CollectionTtl.from_cache_ttl(), None, True),
-        (CollectionTtl.of(timedelta(days=1)), timedelta(days=1), True),
+        (CollectionTtl.of(ttl=timedelta(days=1)), timedelta(days=1), True),
         (CollectionTtl.refresh_ttl_if_provided(ttl=None), None, False),
         (CollectionTtl.refresh_ttl_if_provided(ttl=timedelta(days=1)), timedelta(days=1), True),
     ],


### PR DESCRIPTION
This ports the `CollectionTtl` class from the .NET SDK. This class is
used as an argument to all the mutative collections APIs.

Closes #187 