### PR TITLE
refactor: Extract internal scalar op support functions.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -63,6 +63,9 @@ disallow_any_expr           = False
 [mypy-momento.internal.common._data_client_ops]
 disallow_any_expr           = False
 
+[mypy-momento.internal.common._data_client_scalar_ops]
+disallow_any_expr           = False
+
 [mypy-momento.internal.aio._add_header_client_interceptor]
 disallow_any_expr           = False
 

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -19,14 +19,16 @@ from momento.internal._utilities import _validate_ttl
 from momento.internal.aio._scs_grpc_manager import _DataGrpcManager
 from momento.internal.aio._utilities import make_metadata
 from momento.internal.common._data_client_ops import (
+    get_default_client_deadline,
+    wrap_async_with_error_handling,
+)
+from momento.internal.common._data_client_scalar_ops import (
     construct_delete_response,
     construct_get_response,
     construct_set_response,
-    get_default_client_deadline,
     prepare_delete_request,
     prepare_get_request,
     prepare_set_request,
-    wrap_async_with_error_handling,
 )
 from momento.responses import (
     CacheDelete,

--- a/src/momento/internal/common/_data_client_ops.py
+++ b/src/momento/internal/common/_data_client_ops.py
@@ -1,29 +1,12 @@
 from datetime import timedelta
-from typing import Awaitable, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import Awaitable, Callable, List, Tuple, TypeVar
 
 from grpc.aio import Metadata
-from momento_wire_types.cacheclient_pb2 import (
-    Miss,
-    _DeleteRequest,
-    _DeleteResponse,
-    _GetRequest,
-    _GetResponse,
-    _SetRequest,
-    _SetResponse,
-)
 
 from momento import logs
 from momento.config import Configuration
 from momento.errors import SdkException, convert_error
-from momento.internal._utilities import _as_bytes, _validate_cache_name, _validate_ttl
-from momento.responses import (
-    CacheDelete,
-    CacheDeleteResponse,
-    CacheGet,
-    CacheGetResponse,
-    CacheSet,
-    CacheSetResponse,
-)
+from momento.internal._utilities import _validate_cache_name
 
 TResponse = TypeVar("TResponse")
 TGeneratedRequest = TypeVar("TGeneratedRequest")
@@ -72,53 +55,6 @@ async def wrap_async_with_error_handling(
     except Exception as e:
         _logger.warning("%s failed with exception: %s", request_type, e)
         return error_fn(convert_error(e, metadata))
-
-
-def prepare_set_request(
-    key: Union[str, bytes],
-    value: Union[str, bytes],
-    ttl: Optional[timedelta],
-    default_ttl: timedelta,
-) -> _SetRequest:
-    _logger.log(logs.TRACE, "Issuing a set request with key %s", str(key))
-    item_ttl = default_ttl if ttl is None else ttl
-    _validate_ttl(item_ttl)
-    set_request = _SetRequest()
-    set_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
-    set_request.cache_body = _as_bytes(value, "Unsupported type for value: ")
-    set_request.ttl_milliseconds = int(item_ttl.total_seconds() * 1000)
-    return set_request
-
-
-def construct_set_response(req: _SetRequest, resp: _SetResponse) -> CacheSetResponse:
-    _logger.log(logs.TRACE, "Set succeeded for key: %s", str(req.cache_key))
-    return CacheSet.Success()
-
-
-def prepare_get_request(key: Union[str, bytes]) -> _GetRequest:
-    _logger.log(logs.TRACE, "Issuing a Get request with key %s", str(key))
-    get_request = _GetRequest()
-    get_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
-    return get_request
-
-
-def construct_get_response(req: _GetRequest, resp: _GetResponse) -> CacheGetResponse:
-    _logger.log(logs.TRACE, "Received a get response for %s", str(req.cache_key))
-    if resp.result == Miss:
-        return CacheGet.Miss()
-    return CacheGet.Hit(resp.cache_body)
-
-
-def prepare_delete_request(key: Union[str, bytes]) -> _DeleteRequest:
-    _logger.log(logs.TRACE, "Issuing a Delete request with key %s", str(key))
-    delete_request = _DeleteRequest()
-    delete_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
-    return delete_request
-
-
-def construct_delete_response(req: _DeleteRequest, resp: _DeleteResponse) -> CacheDeleteResponse:
-    _logger.log(logs.TRACE, "Received a delete response for %s", str(req.cache_key))
-    return CacheDelete.Success()
 
 
 def get_default_client_deadline(configuration: Configuration) -> timedelta:

--- a/src/momento/internal/common/_data_client_scalar_ops.py
+++ b/src/momento/internal/common/_data_client_scalar_ops.py
@@ -1,0 +1,72 @@
+from datetime import timedelta
+from typing import Optional, Union
+
+from momento_wire_types.cacheclient_pb2 import (
+    Miss,
+    _DeleteRequest,
+    _DeleteResponse,
+    _GetRequest,
+    _GetResponse,
+    _SetRequest,
+    _SetResponse,
+)
+
+from momento import logs
+from momento.internal._utilities import _as_bytes, _validate_ttl
+from momento.responses import (
+    CacheDelete,
+    CacheDeleteResponse,
+    CacheGet,
+    CacheGetResponse,
+    CacheSet,
+    CacheSetResponse,
+)
+
+_logger = logs.logger
+
+
+def prepare_set_request(
+    key: Union[str, bytes],
+    value: Union[str, bytes],
+    ttl: Optional[timedelta],
+    default_ttl: timedelta,
+) -> _SetRequest:
+    _logger.log(logs.TRACE, "Issuing a set request with key %s", str(key))
+    item_ttl = default_ttl if ttl is None else ttl
+    _validate_ttl(item_ttl)
+    set_request = _SetRequest()
+    set_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
+    set_request.cache_body = _as_bytes(value, "Unsupported type for value: ")
+    set_request.ttl_milliseconds = int(item_ttl.total_seconds() * 1000)
+    return set_request
+
+
+def construct_set_response(req: _SetRequest, resp: _SetResponse) -> CacheSetResponse:
+    _logger.log(logs.TRACE, "Set succeeded for key: %s", str(req.cache_key))
+    return CacheSet.Success()
+
+
+def prepare_get_request(key: Union[str, bytes]) -> _GetRequest:
+    _logger.log(logs.TRACE, "Issuing a Get request with key %s", str(key))
+    get_request = _GetRequest()
+    get_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
+    return get_request
+
+
+def construct_get_response(req: _GetRequest, resp: _GetResponse) -> CacheGetResponse:
+    _logger.log(logs.TRACE, "Received a get response for %s", str(req.cache_key))
+    if resp.result == Miss:
+        return CacheGet.Miss()
+    return CacheGet.Hit(resp.cache_body)
+
+
+def prepare_delete_request(key: Union[str, bytes]) -> _DeleteRequest:
+    _logger.log(logs.TRACE, "Issuing a Delete request with key %s", str(key))
+    delete_request = _DeleteRequest()
+    delete_request.cache_key = _as_bytes(key, "Unsupported type for key: ")
+    return delete_request
+
+
+def construct_delete_response(req: _DeleteRequest, resp: _DeleteResponse) -> CacheDeleteResponse:
+    _logger.log(logs.TRACE, "Received a delete response for %s", str(req.cache_key))
+    return CacheDelete.Success()

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -17,14 +17,16 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.internal._utilities import _validate_ttl
 from momento.internal.common._data_client_ops import (
+    get_default_client_deadline,
+    wrap_with_error_handling,
+)
+from momento.internal.common._data_client_scalar_ops import (
     construct_delete_response,
     construct_get_response,
     construct_set_response,
-    get_default_client_deadline,
     prepare_delete_request,
     prepare_get_request,
     prepare_set_request,
-    wrap_with_error_handling,
 )
 from momento.internal.synchronous._scs_grpc_manager import _DataGrpcManager
 from momento.internal.synchronous._utilities import make_metadata


### PR DESCRIPTION
This will avoid a monolithic file and conflicts as we add collections. Each collection has its own file.

Closes #198 