### PR TITLE
refactor: Add a CacheResponse abstract superclass for all responses.

### DIFF
--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -6,6 +6,7 @@ from .control import (
     ListCaches,
     ListCachesResponse,
 )
+from .response import CacheResponse
 from .scalar_data import (
     CacheDelete,
     CacheDeleteResponse,

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -1,0 +1,5 @@
+from abc import ABC
+
+
+class CacheResponse(ABC):
+    """Parent of all responses"""

--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from momento.errors import SdkException
 
 from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
 
 
-class CacheDeleteResponse(ABC):
+class CacheDeleteResponse(CacheResponse):
     """Parent response type for a create set request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from momento.errors import SdkException
 
 from ..mixins import ErrorResponseMixin, ValueStringMixin
+from ..response import CacheResponse
 
 
-class CacheGetResponse(ABC):
+class CacheGetResponse(CacheResponse):
     """Parent response type for a create get request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from momento.errors import SdkException
 
 from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
 
 
-class CacheSetResponse(ABC):
+class CacheSetResponse(CacheResponse):
     """Parent response type for a create set request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:


### PR DESCRIPTION
This lets us get the type checks right for shared behaviors of all methods.