### PR TITLE
chore: add comments as fenceposts to reduce merge conflicts

### DIFF
--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -133,6 +133,10 @@ class _ScsDataClient:
             metadata=metadata,
         )
 
+    # DICTIONARY COLLECTION METHODS
+    # SET COLLECTION METHODS
+    # LIST COLLECTION METHODS
+
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.async_stub()
 

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -134,8 +134,10 @@ class _ScsDataClient:
         )
 
     # DICTIONARY COLLECTION METHODS
-    # SET COLLECTION METHODS
+
     # LIST COLLECTION METHODS
+
+    # SET COLLECTION METHODS
 
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.async_stub()

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -133,6 +133,10 @@ class _ScsDataClient:
             metadata=metadata,
         )
 
+    # DICTIONARY COLLECTION METHODS
+    # SET COLLECTION METHODS
+    # LIST COLLECTION METHODS
+
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.stub()
 

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -134,8 +134,10 @@ class _ScsDataClient:
         )
 
     # DICTIONARY COLLECTION METHODS
-    # SET COLLECTION METHODS
+
     # LIST COLLECTION METHODS
+
+    # SET COLLECTION METHODS
 
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.stub()

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -314,5 +314,7 @@ class SimpleCacheClient:
         return self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
-    # SET COLLECTION METHODS
+
     # LIST COLLECTION METHODS
+
+    # SET COLLECTION METHODS

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -312,3 +312,7 @@ class SimpleCacheClient:
                     # Shouldn't happen
         """
         return self._data_client.delete(cache_name, key)
+
+    # DICTIONARY COLLECTION METHODS
+    # SET COLLECTION METHODS
+    # LIST COLLECTION METHODS

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -320,6 +320,10 @@ class SimpleCacheClientAsync:
         """
         return await self._get_next_client().delete(cache_name, key)
 
+    # DICTIONARY COLLECTION METHODS
+    # SET COLLECTION METHODS
+    # LIST COLLECTION METHODS
+
     def _get_next_client(self) -> _ScsDataClient:
         client = self._data_clients[self._next_client_index]
         self._next_client_index = (self._next_client_index + 1) % len(self._data_clients)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -321,8 +321,10 @@ class SimpleCacheClientAsync:
         return await self._get_next_client().delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
-    # SET COLLECTION METHODS
+
     # LIST COLLECTION METHODS
+
+    # SET COLLECTION METHODS
 
     def _get_next_client(self) -> _ScsDataClient:
         client = self._data_clients[self._next_client_index]


### PR DESCRIPTION
Since we will be working concurrently on data structure methods, we
should reduce the likelihood of merge conflicts. By grouping the
methods under these comments we will make that less likely.
