### PR TITLE
fix: remove extraneous echo from make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test:
 .PHONY: precommit
 ## Run format, lint, and test as a step before committing.
 precommit: gen-sync format lint test
-	@echo.
+
 
 .PHONY: clean
 ## Remove intermediate files


### PR DESCRIPTION
The echo in this target was a placeholder and produces an error. We
remove it.
