### PR TITLE
feat: First collections methods.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ do-gen-sync:
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/shared_behaviors_async.py tests/momento/simple_cache_client/shared_behaviors.py 
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_init_async.py tests/momento/simple_cache_client/test_init.py
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_control_async.py tests/momento/simple_cache_client/test_control.py
+	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_list_async.py tests/momento/simple_cache_client/test_list.py
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_scalar_async.py tests/momento/simple_cache_client/test_scalar.py
 
 .PHONY: gen-sync

--- a/poetry.lock
+++ b/poetry.lock
@@ -287,14 +287,14 @@ files = [
 
 [[package]]
 name = "momento-wire-types"
-version = "0.31.1"
+version = "0.39.0"
 description = "Momento Client Proto Generated Files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "momento-wire-types-0.31.1.tar.gz", hash = "sha256:d91ceac3c595c4c50aad1b0cffcf44ee4cee4e681d21220c63e677353b0bc21c"},
-    {file = "momento_wire_types-0.31.1-py3-none-any.whl", hash = "sha256:138c955bb2d2cae2ff91d79937da9579008174bbcb1c2a426aad8e6f790543f3"},
+    {file = "momento-wire-types-0.39.0.tar.gz", hash = "sha256:eb9b6cb09c2dc0510deb4bc21646f3c012b7f44cbe828dd3b21b5aae8c364115"},
+    {file = "momento_wire_types-0.39.0-py3-none-any.whl", hash = "sha256:0725f33938f02914eb2dfb5e57565d068d9b79b5838e1ad8fc4a6c87219959a6"},
 ]
 
 [package.dependencies]
@@ -746,4 +746,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.12"
-content-hash = "dc14579e27dede3e0c165934c49ec4e88b5f92277dfa88ab4b3d4a29d9bae835"
+content-hash = "f0203b93e7233b1070c34cccfc5ee8481d5a68400847d28ddaa65549cee4919f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.12"
 
-momento-wire-types = "0.31.1"
+momento-wire-types = "^0.39"
 grpcio = "^1.50.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -1,5 +1,6 @@
 from ._data_validation import (
     _as_bytes,
+    _list_as_bytes,
     _validate_cache_name,
     _validate_list_name,
     _validate_request_timeout,

--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -1,6 +1,7 @@
 from ._data_validation import (
     _as_bytes,
     _validate_cache_name,
+    _validate_list_name,
     _validate_request_timeout,
     _validate_ttl,
 )

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -6,9 +6,18 @@ from momento.errors import InvalidArgumentException
 DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
 
 
+def _is_valid_name(name: str) -> bool:
+    return name is not None and isinstance(name, str)
+
+
 def _validate_cache_name(cache_name: str) -> None:
-    if cache_name is None or not isinstance(cache_name, str):
+    if not _is_valid_name(cache_name):
         raise InvalidArgumentException("Cache name must be a non-empty string")
+
+
+def _validate_list_name(list_name: str) -> None:
+    if not _is_valid_name(list_name):
+        raise InvalidArgumentException("List name must be a non-empty string")
 
 
 def _as_bytes(

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from momento.errors import InvalidArgumentException
+from momento.typing import TListValues
 
 DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
+DEFAULT_LIST_CONVERSION_ERROR = "Could not decode List[bytes] to UTF-8"
 
 
 def _is_valid_name(name: str) -> bool:
@@ -29,6 +31,10 @@ def _as_bytes(
     if isinstance(data, bytes):
         return data
     raise InvalidArgumentException(error_message + str(type(data)))
+
+
+def _list_as_bytes(values: TListValues, error_message: Optional[str] = DEFAULT_LIST_CONVERSION_ERROR) -> List[bytes]:
+    return [_as_bytes(value) for value in values]
 
 
 def _validate_ttl(ttl: timedelta) -> None:

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -173,13 +173,13 @@ class _ScsDataClient:
             if truncate_front_to_size is not None:
                 request.truncate_front_to_size = truncate_front_to_size
 
-            await self._build_stub().ListConcatenateBack(
+            response = await self._build_stub().ListConcatenateBack(
                 request,
                 metadata=make_metadata(cache_name),
                 timeout=self._default_deadline_seconds,
             )
             self._log_received_response("ListConcatenateBack", {"list_name": str(request.list_name)})
-            return CacheListConcatenateBack.Success()
+            return CacheListConcatenateBack.Success(response.list_length)
         except Exception as e:
             self._log_request_error("list_concatenate_back", e)
             return CacheListConcatenateBack.Error(convert_error(e))

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -1,12 +1,13 @@
 from datetime import timedelta
 from functools import partial
-from typing import Optional
+from typing import Dict, Optional
 
 from momento_wire_types.cacheclient_pb2 import (
     _DeleteRequest,
     _DeleteResponse,
     _GetRequest,
     _GetResponse,
+    _ListConcatenateBackRequest,
     _ListFetchRequest,
     _SetRequest,
     _SetResponse,
@@ -19,6 +20,7 @@ from momento.config import Configuration
 from momento.errors import convert_error
 from momento.internal._utilities import (
     _as_bytes,
+    _list_as_bytes,
     _validate_cache_name,
     _validate_list_name,
     _validate_ttl,
@@ -37,17 +39,20 @@ from momento.internal.common._data_client_scalar_ops import (
     prepare_get_request,
     prepare_set_request,
 )
+from momento.requests import CollectionTtl
 from momento.responses import (
     CacheDelete,
     CacheDeleteResponse,
     CacheGet,
     CacheGetResponse,
+    CacheListConcatenateBack,
+    CacheListConcatenateBackResponse,
     CacheListFetch,
     CacheListFetchResponse,
     CacheSet,
     CacheSetResponse,
 )
-from momento.typing import TScalarKey, TScalarValue
+from momento.typing import TCacheName, TListName, TListValues, TScalarKey, TScalarValue
 
 
 class _ScsDataClient:
@@ -146,9 +151,42 @@ class _ScsDataClient:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
-    async def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+    async def list_concatenate_back(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_front_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateBackResponse:
         try:
-            self._logger.log(logs.TRACE, "Issuing a ListFetch request with list_name %s", str(list_name))
+            self._log_issuing_request("ListConcatenateBack", {})
+            _validate_cache_name(cache_name)
+            _validate_list_name(list_name)
+
+            item_ttl = self._default_ttl if ttl.ttl is None else ttl.ttl
+            request = _ListConcatenateBackRequest()
+            request.list_name = _as_bytes(list_name, "Unsupported type for list_name: ")
+            request.values.extend(_list_as_bytes(values, "Unsupported type for values: "))
+            request.ttl_milliseconds = int(item_ttl.total_seconds() * 1000)
+            request.refresh_ttl = ttl.refresh_ttl
+            if truncate_front_to_size is not None:
+                request.truncate_front_to_size = truncate_front_to_size
+
+            await self._build_stub().ListConcatenateBack(
+                request,
+                metadata=make_metadata(cache_name),
+                timeout=self._default_deadline_seconds,
+            )
+            self._log_received_response("ListConcatenateBack", {"list_name": str(request.list_name)})
+            return CacheListConcatenateBack.Success()
+        except Exception as e:
+            self._log_request_error("list_concatenate_back", e)
+            return CacheListConcatenateBack.Error(convert_error(e))
+
+    async def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
+        try:
+            self._log_issuing_request("ListFetch", {"list_name": str(list_name)})
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
             request = _ListFetchRequest()
@@ -158,7 +196,7 @@ class _ScsDataClient:
                 metadata=make_metadata(cache_name),
                 timeout=self._default_deadline_seconds,
             )
-            self._logger.log(logs.TRACE, "Received a ListFetch response for %s", str(request.list_name))
+            self._log_received_response("ListFetch", {"list_name": str(request.list_name)})
             if response.missing:
                 return CacheListFetch.Miss()
             return CacheListFetch.Hit(response.found)
@@ -168,8 +206,14 @@ class _ScsDataClient:
 
     # SET COLLECTION METHODS
 
+    def _log_received_response(self, request_type: str, request_args: Dict[str, str]) -> None:
+        self._logger.log(logs.TRACE, f"Received a {request_type} response for {request_args}")
+
+    def _log_issuing_request(self, request_type: str, request_args: Dict[str, str]) -> None:
+        self._logger.log(logs.TRACE, f"Issuing a {request_type} request with {request_args}")
+
     def _log_request_error(self, request_type: str, e: Exception) -> None:
-        self._logger.warning("%s failed with exception: %s", request_type, e)
+        self._logger.warning(f"{request_type} failed with exception: {e}")
 
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.async_stub()

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -173,13 +173,13 @@ class _ScsDataClient:
             if truncate_front_to_size is not None:
                 request.truncate_front_to_size = truncate_front_to_size
 
-            self._build_stub().ListConcatenateBack(
+            response = self._build_stub().ListConcatenateBack(
                 request,
                 metadata=make_metadata(cache_name),
                 timeout=self._default_deadline_seconds,
             )
             self._log_received_response("ListConcatenateBack", {"list_name": str(request.list_name)})
-            return CacheListConcatenateBack.Success()
+            return CacheListConcatenateBack.Success(response.list_length)
         except Exception as e:
             self._log_request_error("list_concatenate_back", e)
             return CacheListConcatenateBack.Error(convert_error(e))

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -7,6 +7,7 @@ from momento_wire_types.cacheclient_pb2 import (
     _DeleteResponse,
     _GetRequest,
     _GetResponse,
+    _ListFetchRequest,
     _SetRequest,
     _SetResponse,
 )
@@ -15,7 +16,13 @@ from momento_wire_types.cacheclient_pb2_grpc import ScsStub
 from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
-from momento.internal._utilities import _validate_ttl
+from momento.errors import convert_error
+from momento.internal._utilities import (
+    _as_bytes,
+    _validate_cache_name,
+    _validate_list_name,
+    _validate_ttl,
+)
 from momento.internal.common._data_client_ops import (
     get_default_client_deadline,
     wrap_with_error_handling,
@@ -35,6 +42,8 @@ from momento.responses import (
     CacheDeleteResponse,
     CacheGet,
     CacheGetResponse,
+    CacheListFetch,
+    CacheListFetchResponse,
     CacheSet,
     CacheSetResponse,
 )
@@ -137,8 +146,30 @@ class _ScsDataClient:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
+    def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+        try:
+            self._logger.log(logs.TRACE, "Issuing a ListFetch request with list_name %s", str(list_name))
+            _validate_cache_name(cache_name)
+            _validate_list_name(list_name)
+            request = _ListFetchRequest()
+            request.list_name = _as_bytes(list_name, "Unsupported type for list_name: ")
+            response = self._build_stub().ListFetch(
+                request,
+                metadata=make_metadata(cache_name),
+                timeout=self._default_deadline_seconds,
+            )
+            self._logger.log(logs.TRACE, "Received a ListFetch response for %s", str(request.list_name))
+            if response.missing:
+                return CacheListFetch.Miss()
+            return CacheListFetch.Hit(response.found)
+        except Exception as e:
+            self._log_request_error("list_fetch", e)
+            return CacheListFetch.Error(convert_error(e))
 
     # SET COLLECTION METHODS
+
+    def _log_request_error(self, request_type: str, e: Exception) -> None:
+        self._logger.warning("%s failed with exception: %s", request_type, e)
 
     def _build_stub(self) -> ScsStub:
         return self._grpc_manager.stub()

--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -10,7 +10,12 @@ from .control import (
     RevokeSigningKeyResponse,
     SigningKey,
 )
-from .list_data import CacheListFetch, CacheListFetchResponse
+from .list_data import (
+    CacheListConcatenateBack,
+    CacheListConcatenateBackResponse,
+    CacheListFetch,
+    CacheListFetchResponse,
+)
 from .response import CacheResponse
 from .scalar_data import (
     CacheDelete,

--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -10,6 +10,7 @@ from .control import (
     RevokeSigningKeyResponse,
     SigningKey,
 )
+from .list_data import CacheListFetch, CacheListFetchResponse
 from .response import CacheResponse
 from .scalar_data import (
     CacheDelete,

--- a/src/momento/responses/list_data/__init__.py
+++ b/src/momento/responses/list_data/__init__.py
@@ -1,1 +1,5 @@
+from .list_concatenate_back import (
+    CacheListConcatenateBack,
+    CacheListConcatenateBackResponse,
+)
 from .list_fetch import CacheListFetch, CacheListFetchResponse

--- a/src/momento/responses/list_data/__init__.py
+++ b/src/momento/responses/list_data/__init__.py
@@ -1,0 +1,1 @@
+from .list_fetch import CacheListFetch, CacheListFetchResponse

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -24,6 +24,9 @@ class CacheListConcatenateBack(ABC):
     class Success(CacheListConcatenateBackResponse):
         """Indicates the concatenation was successful."""
 
+        list_length: int
+        """The number of values in the list after this concatenation"""
+
     @dataclass
     class Error(CacheListConcatenateBackResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheListConcatenateBackResponse(CacheResponse):
-    """Response type for a list_concatenate_back request. Its subtypes are:
+    """Response type for a `list_concatenate_back` request. Its subtypes are:
 
     - `CacheListConcatenateBack.Success`
     - `CacheListConcatenateBack.Error`

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheListConcatenateBackResponse(CacheResponse):
+    """Response type for a list_concatenate_back request. Its subtypes are:
+
+    - `CacheListConcatenateBack.Success`
+    - `CacheListConcatenateBack.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheListConcatenateBack(ABC):
+    """Groups all `CacheListConcatenateBackResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheListConcatenateBackResponse):
+        """Indicates the concatenation was successful."""
+
+    @dataclass
+    class Error(CacheListConcatenateBackResponse, ErrorResponseMixin):
+        """Indicates an error occured in the request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -9,7 +9,7 @@ from ..response import CacheResponse
 
 
 class CacheListFetchResponse(CacheResponse):
-    """Response type for a list fetch request. Its subtypes are:
+    """Response type for a `list_fetch` request. Its subtypes are:
 
     - `CacheListFetch.Hit`
     - `CacheListFetch.Miss`

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -1,0 +1,61 @@
+from abc import ABC
+from dataclasses import dataclass
+from typing import List
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheListFetchResponse(CacheResponse):
+    """Response type for a list fetch request. Its subtypes are:
+
+    - `CacheListFetch.Hit`
+    - `CacheListFetch.Miss`
+    - `CacheListFetch.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheListFetch(ABC):
+    """Groups all `CacheListFetchResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Hit(CacheListFetchResponse):
+        """Indicates the list exists and its values were fetched."""
+
+        value_list_bytes: List[bytes]
+        """The values for the fetched list, as bytes.
+
+        Returns:
+            List[bytes]
+        """
+
+        @property
+        def value_list_string(self) -> List[str]:
+            """The values for the fetched list, as utf-8 encoded strings.
+
+            Returns:
+                List[str]
+            """
+
+            return [v.decode("utf-8") for v in self.value_list_bytes]
+
+    @dataclass
+    class Miss(CacheListFetchResponse):
+        """Indicates the list is empty."""
+
+    @dataclass
+    class Error(CacheListFetchResponse, ErrorResponseMixin):
+        """Indicates an error occured in the request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -26,7 +26,7 @@ class CacheListFetch(ABC):
     class Hit(CacheListFetchResponse):
         """Indicates the list exists and its values were fetched."""
 
-        value_list_bytes: List[bytes]
+        values_bytes: List[bytes]
         """The values for the fetched list, as bytes.
 
         Returns:
@@ -34,14 +34,14 @@ class CacheListFetch(ABC):
         """
 
         @property
-        def value_list_string(self) -> List[str]:
+        def values_string(self) -> List[str]:
             """The values for the fetched list, as utf-8 encoded strings.
 
             Returns:
                 List[str]
             """
 
-            return [v.decode("utf-8") for v in self.value_list_bytes]
+            return [v.decode("utf-8") for v in self.values_bytes]
 
     @dataclass
     class Miss(CacheListFetchResponse):

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -45,7 +45,7 @@ class CacheListFetch(ABC):
 
     @dataclass
     class Miss(CacheListFetchResponse):
-        """Indicates the list is empty."""
+        """Indicates the list does not exist."""
 
     @dataclass
     class Error(CacheListFetchResponse, ErrorResponseMixin):

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -1,8 +1,8 @@
 from abc import ABC
 from dataclasses import dataclass
-from typing import List
 
 from momento.errors import SdkException
+from momento.typing import TListValuesBytes, TListValuesStr
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -26,19 +26,19 @@ class CacheListFetch(ABC):
     class Hit(CacheListFetchResponse):
         """Indicates the list exists and its values were fetched."""
 
-        values_bytes: List[bytes]
+        values_bytes: TListValuesBytes
         """The values for the fetched list, as bytes.
 
         Returns:
-            List[bytes]
+            TListValuesBytes
         """
 
         @property
-        def values_string(self) -> List[str]:
+        def values_string(self) -> TListValuesStr:
             """The values for the fetched list, as utf-8 encoded strings.
 
             Returns:
-                List[str]
+                TListValuesStr
             """
 
             return [v.decode("utf-8") for v in self.values_bytes]

--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheDeleteResponse(CacheResponse):
-    """Parent response type for a cache delete request. Its subtypes are:
+    """Parent response type for a cache `delete` request. Its subtypes are:
 
     - `CacheDelete.Success`
     - `CacheDelete.Error`

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheGetResponse(CacheResponse):
-    """Parent response type for a cache get request. Its subtypes are:
+    """Parent response type for a cache `get` request. Its subtypes are:
 
     - `CacheGet.Hit`
     - `CacheGet.Miss`

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheSetResponse(CacheResponse):
-    """Parent response type for a cache set request. Its subtypes are:
+    """Parent response type for a cache `set` request. Its subtypes are:
 
     - `CacheSet.Success`
     - `CacheSet.Error`

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -7,6 +7,7 @@ from typing import Optional, Type
 from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
+from momento.requests import CollectionTtl
 
 try:
     from momento.internal._utilities import _validate_request_timeout
@@ -36,6 +37,7 @@ except ImportError as e:
 from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
+    CacheListConcatenateBackResponse,
     CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
@@ -45,7 +47,7 @@ from momento.responses import (
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )
-from momento.typing import TScalarKey, TScalarValue
+from momento.typing import TCacheName, TListName, TListValues, TScalarKey, TScalarValue
 
 
 class SimpleCacheClient:
@@ -400,7 +402,17 @@ class SimpleCacheClient:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
-    def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+    def list_concatenate_back(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_front_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateBackResponse:
+        return self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
+
+    def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
         return self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -60,7 +60,7 @@ class SimpleCacheClient:
     Pattern matching can be used to operate on the appropriate subtype.
     For example, in python 3.10+ if you're deleting a key:
 
-        response = await client.delete(cache_name, key)
+        response = client.delete(cache_name, key)
         match response:
             case CacheDelete.Success():
                 ...they key was deleted or not found...
@@ -69,7 +69,7 @@ class SimpleCacheClient:
 
     or equivalently in earlier versions of python:
 
-        response = await client.delete(cache_name, key)
+        response = client.delete(cache_name, key)
         if isinstance(response, CacheDelete.Success):
             ...
         elif isinstance(response, CacheDelete.Error):

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -36,6 +36,7 @@ except ImportError as e:
 from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
+    CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
     CreateSigningKeyResponse,
@@ -57,7 +58,7 @@ class SimpleCacheClient:
     Pattern matching can be used to operate on the appropriate subtype.
     For example, in python 3.10+ if you're deleting a key:
 
-        response = client.delete(cache_name, key)
+        response = await client.delete(cache_name, key)
         match response:
             case CacheDelete.Success():
                 ...they key was deleted or not found...
@@ -66,7 +67,7 @@ class SimpleCacheClient:
 
     or equivalently in earlier versions of python:
 
-        response = client.delete(cache_name, key)
+        response = await client.delete(cache_name, key)
         if isinstance(response, CacheDelete.Success):
             ...
         elif isinstance(response, CacheDelete.Error):
@@ -399,6 +400,8 @@ class SimpleCacheClient:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
+    def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+        return self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS
 

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -36,6 +36,7 @@ except ImportError as e:
 from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
+    CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
     CreateSigningKeyResponse,
@@ -399,6 +400,8 @@ class SimpleCacheClientAsync:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
+    async def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+        return await self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS
 

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -7,6 +7,7 @@ from typing import Optional, Type
 from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
+from momento.requests import CollectionTtl
 
 try:
     from momento.internal._utilities import _validate_request_timeout
@@ -36,6 +37,7 @@ except ImportError as e:
 from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
+    CacheListConcatenateBackResponse,
     CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
@@ -45,7 +47,7 @@ from momento.responses import (
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )
-from momento.typing import TScalarKey, TScalarValue
+from momento.typing import TCacheName, TListName, TListValues, TScalarKey, TScalarValue
 
 
 class SimpleCacheClientAsync:
@@ -400,7 +402,17 @@ class SimpleCacheClientAsync:
     # DICTIONARY COLLECTION METHODS
 
     # LIST COLLECTION METHODS
-    async def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+    async def list_concatenate_back(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_front_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateBackResponse:
+        return await self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
+
+    async def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
         return await self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -1,4 +1,6 @@
-from typing import Union
+from typing import List, Union
+
+TCacheName = str
 
 # Scalar Types
 TScalarKey = Union[str, bytes]
@@ -10,5 +12,7 @@ TCollectionName = str
 # Dictionary Types
 
 # List Types
+TListName = TCollectionName
+TListValues = Union[List[str], List[bytes]]
 
 # Set Types

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -13,6 +13,8 @@ TCollectionName = str
 
 # List Types
 TListName = TCollectionName
-TListValues = Union[List[str], List[bytes]]
+TListValuesBytes = List[bytes]
+TListValuesStr = List[str]
+TListValues = Union[TListValuesBytes, TListValuesStr]
 
 # Set Types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ import pytest_asyncio
 from momento import SimpleCacheClient, SimpleCacheClientAsync
 from momento.auth import EnvMomentoTokenProvider
 from momento.config import Configuration, Laptop
-from tests.utils import unique_test_cache_name
+from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
+from tests.utils import unique_test_cache_name, uuid_bytes, uuid_str
 
 #######################
 # Integration test data
@@ -49,8 +50,23 @@ def configuration() -> Configuration:
 
 
 @pytest.fixture(scope="session")
-def cache_name() -> str:
+def cache_name() -> TCacheName:
     return cast(str, TEST_CACHE_NAME)
+
+
+@pytest.fixture
+def list_name() -> TListName:
+    return uuid_str()
+
+
+@pytest.fixture
+def values_bytes() -> TListValuesBytes:
+    return [uuid_bytes(), uuid_bytes(), uuid_bytes()]
+
+
+@pytest.fixture
+def values_str() -> TListValuesStr:
+    return [uuid_str(), uuid_str(), uuid_str()]
 
 
 @pytest.fixture(scope="session")

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Callable, Union
+from typing import Callable
 
 from momento import SimpleCacheClient
 from momento.auth import EnvMomentoTokenProvider
@@ -7,10 +7,10 @@ from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import TScalarKey
+from momento.typing import TCacheName, TScalarKey
 from tests.utils import uuid_str
 
-TCacheNameValidator = Callable[[str], CacheResponse]
+TCacheNameValidator = Callable[[TCacheName], CacheResponse]
 
 
 def a_cache_name_validator() -> None:

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable
 
 from momento import SimpleCacheClientAsync
 from momento.auth import EnvMomentoTokenProvider
@@ -7,10 +7,10 @@ from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import TScalarKey
+from momento.typing import TCacheName, TScalarKey
 from tests.utils import uuid_str
 
-TCacheNameValidator = Callable[[str], Awaitable[CacheResponse]]
+TCacheNameValidator = Callable[[TCacheName], Awaitable[CacheResponse]]
 
 
 def a_cache_name_validator() -> None:

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -9,7 +9,7 @@ from momento.errors import MomentoErrorCode
 from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
-from tests.utils import uuid_bytes, uuid_str
+from tests.utils import uuid_str
 
 from .shared_behaviors import (
     TCacheNameValidator,
@@ -86,6 +86,48 @@ def describe_list_concatenate_back() -> None:
             return client.list_concatenate_back(cache_name, list_name, [uuid_str()])
 
         return _connection_validator
+
+    def it_returns_the_new_list_length(
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_bytes: TListValuesBytes,
+    ) -> None:
+        resp = client.list_concatenate_back(cache_name, list_name, values_bytes)
+        length = len(values_bytes)
+        assert resp.list_length == length
+
+        resp = client.list_concatenate_back(cache_name, list_name, values_bytes)
+        length += len(values_bytes)
+        assert resp.list_length == length
+
+    def it_truncates_the_front(
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+    ) -> None:
+        truncate_to = 4
+
+        concat_resp = client.list_concatenate_back(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["one", "two", "three"],
+            truncate_front_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateBack.Success)
+        assert concat_resp.list_length <= truncate_to
+
+        concat_resp = client.list_concatenate_back(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["four", "five", "six"],
+            truncate_front_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateBack.Success)
+        assert concat_resp.list_length <= truncate_to
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert fetch_resp.values_string == ["three", "four", "five", "six"]
 
     def with_bytes_it_succeeds(
         client: SimpleCacheClient,

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -93,11 +93,19 @@ def describe_list_concatenate_back() -> None:
         list_name: TListName,
         values_bytes: TListValuesBytes,
     ) -> None:
-        resp = client.list_concatenate_back(cache_name, list_name, values_bytes)
-        assert isinstance(resp, CacheListConcatenateBack.Success)
+        concat_resp = client.list_concatenate_back(cache_name, list_name, values_bytes)
+        assert isinstance(concat_resp, CacheListConcatenateBack.Success)
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_bytes == values_bytes
 
     def with_strings_it_succeeds(
         client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values_str: TListValuesStr
     ) -> None:
         resp = client.list_concatenate_back(cache_name, list_name, values_str)
         assert isinstance(resp, CacheListConcatenateBack.Success)
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_string == values_str

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -6,8 +6,9 @@ from pytest_describe import behaves_like
 
 from momento import SimpleCacheClient
 from momento.errors import MomentoErrorCode
-from momento.responses import CacheListFetch, CacheResponse
+from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
+from momento.typing import TCacheName
 from tests.utils import uuid_str
 
 from .shared_behaviors import (
@@ -56,14 +57,38 @@ def describe_list_fetch() -> None:
 
     @fixture
     def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: str) -> ErrorResponseMixin:
+        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
             list_name = uuid_str()
             return client.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
-    def misses_when_the_list_does_not_exist(client: SimpleCacheClient, cache_name: str) -> None:
+    def misses_when_the_list_does_not_exist(client: SimpleCacheClient, cache_name: TCacheName) -> None:
         list_name = uuid_str()
 
         resp = client.list_fetch(cache_name, list_name)
         assert isinstance(resp, CacheListFetch.Miss)
+
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+def describe_list_concatenate_back() -> None:
+    @fixture
+    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client.list_concatenate_back, list_name=list_name, values=[uuid_str()])
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return client.list_concatenate_back(cache_name, list_name, [uuid_str()])
+
+        return _connection_validator
+
+    def with_strings_it_succeeds(client: SimpleCacheClient, cache_name: TCacheName) -> None:
+        list_name = uuid_str()
+        values = [uuid_str(), uuid_str()]
+
+        resp = client.list_concatenate_back(cache_name, list_name, values)
+        assert isinstance(resp, CacheListConcatenateBack.Success)

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -18,7 +18,7 @@ from .shared_behaviors import (
     a_connection_validator,
 )
 
-TListNameValidator = Callable[[str], CacheResponse]
+TListNameValidator = Callable[[TListName], CacheResponse]
 
 
 def a_list_name_validator() -> None:

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -8,8 +8,8 @@ from momento import SimpleCacheClient
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import TCacheName
-from tests.utils import uuid_str
+from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
+from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors import (
     TCacheNameValidator,
@@ -22,8 +22,9 @@ TListNameValidator = Callable[[str], CacheResponse]
 
 
 def a_list_name_validator() -> None:
-    def with_non_existent_list_name_it_throws_not_found(list_name_validator: TListNameValidator) -> None:
-        list_name = uuid_str()
+    def with_non_existent_list_name_it_throws_not_found(
+        list_name_validator: TListNameValidator, list_name: TListName
+    ) -> None:
         response = list_name_validator(list_name)
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
@@ -63,9 +64,9 @@ def describe_list_fetch() -> None:
 
         return _connection_validator
 
-    def misses_when_the_list_does_not_exist(client: SimpleCacheClient, cache_name: TCacheName) -> None:
-        list_name = uuid_str()
-
+    def misses_when_the_list_does_not_exist(
+        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
+    ) -> None:
         resp = client.list_fetch(cache_name, list_name)
         assert isinstance(resp, CacheListFetch.Miss)
 
@@ -86,9 +87,17 @@ def describe_list_concatenate_back() -> None:
 
         return _connection_validator
 
-    def with_strings_it_succeeds(client: SimpleCacheClient, cache_name: TCacheName) -> None:
-        list_name = uuid_str()
-        values = [uuid_str(), uuid_str()]
+    def with_bytes_it_succeeds(
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_bytes: TListValuesBytes,
+    ) -> None:
+        resp = client.list_concatenate_back(cache_name, list_name, values_bytes)
+        assert isinstance(resp, CacheListConcatenateBack.Success)
 
-        resp = client.list_concatenate_back(cache_name, list_name, values)
+    def with_strings_it_succeeds(
+        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values_str: TListValuesStr
+    ) -> None:
+        resp = client.list_concatenate_back(cache_name, list_name, values_str)
         assert isinstance(resp, CacheListConcatenateBack.Success)

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -1,0 +1,69 @@
+from functools import partial
+from typing import Callable
+
+from pytest import fixture
+from pytest_describe import behaves_like
+
+from momento import SimpleCacheClient
+from momento.errors import MomentoErrorCode
+from momento.responses import CacheListFetch, CacheResponse
+from momento.responses.mixins import ErrorResponseMixin
+from tests.utils import uuid_str
+
+from .shared_behaviors import (
+    TCacheNameValidator,
+    TConnectionValidator,
+    a_cache_name_validator,
+    a_connection_validator,
+)
+
+TListNameValidator = Callable[[str], CacheResponse]
+
+
+def a_list_name_validator() -> None:
+    def with_non_existent_list_name_it_throws_not_found(list_name_validator: TListNameValidator) -> None:
+        list_name = uuid_str()
+        response = list_name_validator(list_name)
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+
+    def with_null_list_name_it_throws_exception(list_name_validator: TListNameValidator) -> None:
+        response = list_name_validator(None)  # type: ignore
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name must be a non-empty string"
+
+    def with_empty_list_name_it_throws_exception(list_name_validator: TListNameValidator) -> None:
+        response = list_name_validator("")
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name is empty"
+
+    def with_bad_list_name_throws_exception(list_name_validator: TCacheNameValidator) -> None:
+        response = list_name_validator(1)  # type: ignore
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name must be a non-empty string"
+
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+def describe_list_fetch() -> None:
+    @fixture
+    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client.list_fetch, list_name=list_name)
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient, cache_name: str) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return client.list_fetch(cache_name, list_name)
+
+        return _connection_validator
+
+    def misses_when_the_list_does_not_exist(client: SimpleCacheClient, cache_name: str) -> None:
+        list_name = uuid_str()
+
+        resp = client.list_fetch(cache_name, list_name)
+        assert isinstance(resp, CacheListFetch.Miss)

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -6,8 +6,9 @@ from pytest_describe import behaves_like
 
 from momento import SimpleCacheClientAsync
 from momento.errors import MomentoErrorCode
-from momento.responses import CacheListFetch, CacheResponse
+from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
 from momento.responses.mixins import ErrorResponseMixin
+from momento.typing import TCacheName
 from tests.utils import uuid_str
 
 from .shared_behaviors_async import (
@@ -56,14 +57,42 @@ def describe_list_fetch() -> None:
 
     @fixture
     def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync, cache_name: str) -> ErrorResponseMixin:
+        async def _connection_validator(
+            client_async: SimpleCacheClientAsync, cache_name: TCacheName
+        ) -> ErrorResponseMixin:
             list_name = uuid_str()
             return await client_async.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
-    async def misses_when_the_list_does_not_exist(client_async: SimpleCacheClientAsync, cache_name: str) -> None:
+    async def misses_when_the_list_does_not_exist(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> None:
         list_name = uuid_str()
 
         resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(resp, CacheListFetch.Miss)
+
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+def describe_list_concatenate_back() -> None:
+    @fixture
+    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client_async.list_concatenate_back, list_name=list_name, values=[uuid_str()])
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        async def _connection_validator(
+            client_async: SimpleCacheClientAsync, cache_name: TCacheName
+        ) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return await client_async.list_concatenate_back(cache_name, list_name, [uuid_str()])
+
+        return _connection_validator
+
+    async def with_strings_it_succeeds(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> None:
+        list_name = uuid_str()
+        values = [uuid_str(), uuid_str()]
+
+        resp = await client_async.list_concatenate_back(cache_name, list_name, values)
+        assert isinstance(resp, CacheListConcatenateBack.Success)

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -97,11 +97,19 @@ def describe_list_concatenate_back() -> None:
         list_name: TListName,
         values_bytes: TListValuesBytes,
     ) -> None:
-        resp = await client_async.list_concatenate_back(cache_name, list_name, values_bytes)
-        assert isinstance(resp, CacheListConcatenateBack.Success)
+        concat_resp = await client_async.list_concatenate_back(cache_name, list_name, values_bytes)
+        assert isinstance(concat_resp, CacheListConcatenateBack.Success)
+
+        fetch_resp = await client_async.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_bytes == values_bytes
 
     async def with_strings_it_succeeds(
         client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values_str: TListValuesStr
     ) -> None:
         resp = await client_async.list_concatenate_back(cache_name, list_name, values_str)
         assert isinstance(resp, CacheListConcatenateBack.Success)
+
+        fetch_resp = await client_async.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_string == values_str

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -18,7 +18,7 @@ from .shared_behaviors_async import (
     a_connection_validator,
 )
 
-TListNameValidator = Callable[[str], Awaitable[CacheResponse]]
+TListNameValidator = Callable[[TListName], Awaitable[CacheResponse]]
 
 
 def a_list_name_validator() -> None:

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -1,0 +1,69 @@
+from functools import partial
+from typing import Awaitable, Callable
+
+from pytest import fixture
+from pytest_describe import behaves_like
+
+from momento import SimpleCacheClientAsync
+from momento.errors import MomentoErrorCode
+from momento.responses import CacheListFetch, CacheResponse
+from momento.responses.mixins import ErrorResponseMixin
+from tests.utils import uuid_str
+
+from .shared_behaviors_async import (
+    TCacheNameValidator,
+    TConnectionValidator,
+    a_cache_name_validator,
+    a_connection_validator,
+)
+
+TListNameValidator = Callable[[str], Awaitable[CacheResponse]]
+
+
+def a_list_name_validator() -> None:
+    async def with_non_existent_list_name_it_throws_not_found(list_name_validator: TListNameValidator) -> None:
+        list_name = uuid_str()
+        response = await list_name_validator(list_name)
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+
+    async def with_null_list_name_it_throws_exception(list_name_validator: TListNameValidator) -> None:
+        response = await list_name_validator(None)  # type: ignore
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name must be a non-empty string"
+
+    async def with_empty_list_name_it_throws_exception(list_name_validator: TListNameValidator) -> None:
+        response = await list_name_validator("")
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name is empty"
+
+    async def with_bad_list_name_throws_exception(list_name_validator: TCacheNameValidator) -> None:
+        response = await list_name_validator(1)  # type: ignore
+        assert isinstance(response, ErrorResponseMixin)
+        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        assert response.inner_exception.message == "List name must be a non-empty string"
+
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+def describe_list_fetch() -> None:
+    @fixture
+    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client_async.list_fetch, list_name=list_name)
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync, cache_name: str) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return await client_async.list_fetch(cache_name, list_name)
+
+        return _connection_validator
+
+    async def misses_when_the_list_does_not_exist(client_async: SimpleCacheClientAsync, cache_name: str) -> None:
+        list_name = uuid_str()
+
+        resp = await client_async.list_fetch(cache_name, list_name)
+        assert isinstance(resp, CacheListFetch.Miss)


### PR DESCRIPTION
This adds the minimum of collections to exercise how we add them going forward and avoid colliding when working in parallel. listFetch and listConcatenateBack.

**Note**: all the duplicated synchronous files can be ignored for review purpose, they're all generated from the async code.

* Upgrade wire types to one that supports collections and new scalar methods.
  * Unpin the dependency to be a good citizen.
* Add list types
* Add some helpful collections fixtures
* Add cache name type (didn't use it everywhere)
* Add some helpful trace logging wrappers.

For #174 and #184