### PR TITLE
fix: Unpin dependencies to avoid library conflicts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ exclude = ["src/momento/internal/codegen.py"]
 python = ">=3.7,<3.12"
 
 momento-wire-types = "0.31.1"
-grpcio = "1.50.0"
+grpcio = "^1.50.0"
 # note if you bump this presigned url test need be updated
-pyjwt = "2.4.0"
+pyjwt = "^2.4.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"


### PR DESCRIPTION
Pinned dependencies invite conflicts with other libraries with the same dependencies.

Keep the minimum version, but relax the max. Stay within the major version.