### PR TITLE
fix: Scalar cache response description of the request.

### DIFF
--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheDeleteResponse(CacheResponse):
-    """Parent response type for a create set request. The
+    """Parent response type for a cache delete request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
 

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheGetResponse(CacheResponse):
-    """Parent response type for a create get request. The
+    """Parent response type for a cache get request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
 

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheSetResponse(CacheResponse):
-    """Parent response type for a create set request. The
+    """Parent response type for a cache set request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
 


### PR DESCRIPTION
A few typos in the scalar response docs.

* "create X request" -> "cache X request"
* CacheDeleteResponse was talking about a set request.