### PR TITLE
docs: Move explaining how to use responses into SimpleCacheClient.

### DIFF
--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -8,30 +8,12 @@ from ..response import CacheResponse
 
 
 class CacheDeleteResponse(CacheResponse):
-    """Parent response type for a cache delete request. The
-    response object is resolved to a type-safe object of one of
-    the following subtypes:
+    """Parent response type for a cache delete request. It's subtypes are:
 
     - `CacheDelete.Success`
     - `CacheDelete.Error`
 
-    Pattern matching can be used to operate on the appropriate subtype.
-    For example, in python 3.10+:
-
-        match response:
-            case CacheDelete.Success():
-                ...
-            case CacheDelete.Error():
-                ...
-
-    or equivalently in earlier versions of python:
-
-        if isinstance(response, CacheDelete.Success):
-            ...
-        elif isinstance(response, CacheDelete.Error):
-            ...
-        else:
-            # Shouldn't happen
+    See `SimpleCacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheDeleteResponse(CacheResponse):
-    """Parent response type for a cache delete request. It's subtypes are:
+    """Parent response type for a cache delete request. Its subtypes are:
 
     - `CacheDelete.Success`
     - `CacheDelete.Error`

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -8,35 +8,13 @@ from ..response import CacheResponse
 
 
 class CacheGetResponse(CacheResponse):
-    """Parent response type for a cache get request. The
-    response object is resolved to a type-safe object of one of
-    the following subtypes:
+    """Parent response type for a cache get request. It's subtypes are:
 
     - `CacheGet.Hit`
     - `CacheGet.Miss`
     - `CacheGet.Error`
 
-    Pattern matching can be used to operate on the appropriate subtype.
-    For example, in python 3.10+:
-
-        match response:
-            case CacheGet.Hit() as hit:
-                return hit.value_string
-            case CacheGet.Miss():
-                ... # Handle miss
-            case CacheGet.Error():
-                ...
-
-    or equivalently in earlier versions of python:
-
-        if isinstance(response, CacheGet.Hit):
-            ...
-        elif isinstance(response, CacheGet.Miss):
-            ...
-        elif isinstance(response, CacheGet.Error):
-            ...
-        else:
-            # Shouldn't happen
+    See `SimpleCacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheGetResponse(CacheResponse):
-    """Parent response type for a cache get request. It's subtypes are:
+    """Parent response type for a cache get request. Its subtypes are:
 
     - `CacheGet.Hit`
     - `CacheGet.Miss`

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -8,30 +8,12 @@ from ..response import CacheResponse
 
 
 class CacheSetResponse(CacheResponse):
-    """Parent response type for a cache set request. The
-    response object is resolved to a type-safe object of one of
-    the following subtypes:
+    """Parent response type for a cache set request. It's subtypes are:
 
     - `CacheSet.Success`
     - `CacheSet.Error`
 
-    Pattern matching can be used to operate on the appropriate subtype.
-    For example, in python 3.10+:
-
-        match response:
-            case CacheSet.Success():
-                ...
-            case CacheSet.Error():
-                ...
-
-    or equivalently in earlier versions of python:
-
-        if isinstance(response, CacheSet.Success):
-            ...
-        elif isinstance(response, CacheSet.Error):
-            ...
-        else:
-            # Shouldn't happen
+    See `SimpleCacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -8,7 +8,7 @@ from ..response import CacheResponse
 
 
 class CacheSetResponse(CacheResponse):
-    """Parent response type for a cache set request. It's subtypes are:
+    """Parent response type for a cache set request. Its subtypes are:
 
     - `CacheSet.Success`
     - `CacheSet.Error`

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -42,7 +42,32 @@ from momento.responses import (
 
 
 class SimpleCacheClient:
-    """Synchronous Simple Cache Client"""
+    """Synchronous Simple Cache Client
+
+    Cache and control methods return a response object unique to each request.
+    The response object is resolved to a type-safe object of one of several
+    sub-types. See the documentation for each response type for details.
+
+    Pattern matching can be used to operate on the appropriate subtype.
+    For example, in python 3.10+ if you're deleting a key:
+
+        response = client.delete(cache_name, key)
+        match response:
+            case CacheDelete.Success():
+                ...they key was deleted or not found...
+            case CacheDelete.Error():
+                ...there was an error trying to delete the key...
+
+    or equivalently in earlier versions of python:
+
+        response = client.delete(cache_name, key)
+        if isinstance(response, CacheDelete.Success):
+            ...
+        elif isinstance(response, CacheDelete.Error):
+            ...
+        else:
+            raise Exception("This should never happen")
+    """
 
     def __init__(
         self,

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -42,7 +42,32 @@ from momento.responses import (
 
 
 class SimpleCacheClientAsync:
-    """Async Simple Cache Client"""
+    """Async Simple Cache Client
+
+    Cache and control methods return a response object unique to each request.
+    The response object is resolved to a type-safe object of one of several
+    sub-types. See the documentation for each response type for details.
+
+    Pattern matching can be used to operate on the appropriate subtype.
+    For example, in python 3.10+ if you're deleting a key:
+
+        response = await client.delete(cache_name, key)
+        match response:
+            case CacheDelete.Success():
+                ...they key was deleted or not found...
+            case CacheDelete.Error():
+                ...there was an error trying to delete the key...
+
+    or equivalently in earlier versions of python:
+
+        response = await client.delete(cache_name, key)
+        if isinstance(response, CacheDelete.Success):
+            ...
+        elif isinstance(response, CacheDelete.Error):
+            ...
+        else:
+            raise Exception("This should never happen")
+    """
 
     # For high load, we might get better performance with multiple clients, because the server is
     # configured to allow a max of 100 streams per connection.  In the javascript SDK, multiple


### PR DESCRIPTION
Cutting and pasting these docs will become untenable as the interface expands. Document the pattern in SimpleCacheClient and refer back to it.