### PR TITLE
fix: update example location

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -21,4 +21,4 @@ jobs:
           project_stability: alpha
           project_type: sdk
           sdk_language: Python
-          usage_example_path: ./examples/example.py
+          usage_example_path: ./examples/py310/example.py


### PR DESCRIPTION
We have updated the examples and forked based on python version. In
the previous example update we referenced the py310 synchronous
example as the canonical one. We update that here as well.
