### PR TITLE
feat: Validate the CollectionTtl.ttl is positive.

### DIFF
--- a/src/momento/requests/collection_ttl.py
+++ b/src/momento/requests/collection_ttl.py
@@ -18,6 +18,9 @@ class CollectionTtl:
     The default behavior is to refresh the TTL (to prolong the life of the
     collection) each time it is written.  This behavior can be modified
     by calling the method `with_no_refresh_ttl_on_updates`.
+
+    Raises:
+        ValueError: if the ttl is not a positive amount of time.
     """
 
     ttl: Optional[timedelta] = None
@@ -29,6 +32,10 @@ class CollectionTtl:
     on every update.  If `False`, the collection's TTL will only be set when the collection is
     initially created.
     """
+
+    def __post_init__(self) -> None:
+        if self.ttl is not None and self.ttl.total_seconds() <= 0:
+            raise ValueError("the TTL must be a positive amount of time")
 
     @staticmethod
     def from_cache_ttl() -> "CollectionTtl":

--- a/tests/momento/requests/test_collection_ttl.py
+++ b/tests/momento/requests/test_collection_ttl.py
@@ -45,3 +45,15 @@ def test_with_and_without_refresh_ttl_on_updates(collection_ttl: CollectionTtl) 
     assert (
         not new_collection_ttl.refresh_ttl
     ), "refresh_ttl should be false after with_no_refresh_ttl_on_updates but wasn't"
+
+
+@pytest.mark.parametrize(
+    "ttl",
+    [
+        (timedelta(seconds=-1)),
+        (timedelta(seconds=42, minutes=-99)),
+    ],
+)
+def test_negative_ttl(ttl: timedelta) -> None:
+    with pytest.raises(ValueError, match=r"TTL must be a positive amount of time"):
+        CollectionTtl(ttl=ttl)


### PR DESCRIPTION
We do this inside CollectionTtl so we don't have to check it in every collection method.

I excluded 0 because why would you want that? We can allow it later if someone really needs it.

Closes #222 