### PR TITLE
chore: refactor credential provider, add string provider

### DIFF
--- a/src/momento/auth/__init__.py
+++ b/src/momento/auth/__init__.py
@@ -1,1 +1,1 @@
-from .credential_provider import CredentialProvider, EnvMomentoTokenProvider
+from .credential_provider import CredentialProvider

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -1,49 +1,47 @@
+from __future__ import annotations
+
 import os
-from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Optional
 
 from . import momento_endpoint_resolver
 
 
-class CredentialProvider(ABC):
+@dataclass
+class CredentialProvider:
     """Provides information that the SimpleCacheClient needs in order to establish a connection to and authenticate with
     the Momento service.
     """
 
-    @abstractmethod
-    def get_auth_token(self) -> str:
-        pass
+    auth_token: str
+    control_endpoint: str
+    cache_endpoint: str
 
-    @abstractmethod
-    def get_control_endpoint(self) -> str:
-        pass
-
-    @abstractmethod
-    def get_cache_endpoint(self) -> str:
-        pass
-
-
-class EnvMomentoTokenProvider(CredentialProvider):
-    def __init__(self, env_var_name: str, control_endpoint: Optional[str] = None, cache_endpoint: Optional[str] = None):
+    @staticmethod
+    def from_environment_variable(
+        env_var_name: str,
+        control_endpoint: Optional[str] = None,
+        cache_endpoint: Optional[str] = None,
+    ) -> CredentialProvider:
         """Reads and parses a Momento auth token stored as an environment variable.
 
-        :param env_var_name: name of the environment variable from which the auth token will be read
-        :param control_endpoint: optionally overrides the default control endpoint
-        :param cache_endpoint: optionally overrides the default control endpoint
+        Args:
+            env_var_name (str): Name of the environment variable from which the auth token will be read
+            control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            Defaults to None.
+            cache_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            Defaults to None.
+
+        Raises:
+            RuntimeError: _description_
+
+        Returns:
+            CredentialProvider: _description_
         """
-        token = os.getenv(env_var_name)
-        if not token:
+        auth_token = os.getenv(env_var_name)
+        if not auth_token:
             raise RuntimeError(f"Missing required environment variable {env_var_name}")
-        self._auth_token = token
-        endpoints = momento_endpoint_resolver.resolve(self._auth_token)
-        self._control_endpoint = control_endpoint or endpoints.control_endpoint
-        self._cache_endpoint = cache_endpoint or endpoints.cache_endpoint
-
-    def get_auth_token(self) -> str:
-        return self._auth_token
-
-    def get_control_endpoint(self) -> str:
-        return self._control_endpoint
-
-    def get_cache_endpoint(self) -> str:
-        return self._cache_endpoint
+        endpoints = momento_endpoint_resolver.resolve(auth_token)
+        control_endpoint = control_endpoint or endpoints.control_endpoint
+        cache_endpoint = cache_endpoint or endpoints.cache_endpoint
+        return CredentialProvider(auth_token, control_endpoint, cache_endpoint)

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -33,14 +33,34 @@ class CredentialProvider:
             Defaults to None.
 
         Raises:
-            RuntimeError: _description_
+            RuntimeError: if the environment variable is missing
 
         Returns:
-            CredentialProvider: _description_
+            CredentialProvider
         """
         auth_token = os.getenv(env_var_name)
         if not auth_token:
             raise RuntimeError(f"Missing required environment variable {env_var_name}")
+        return CredentialProvider.from_string(auth_token, control_endpoint, cache_endpoint)
+
+    @staticmethod
+    def from_string(
+        auth_token: str,
+        control_endpoint: Optional[str] = None,
+        cache_endpoint: Optional[str] = None,
+    ) -> CredentialProvider:
+        """Reads and parses a Momento auth token.
+
+        Args:
+            auth_token (str): the Momento auth token
+            control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            Defaults to None.
+            cache_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            Defaults to None.
+
+        Returns:
+            CredentialProvider
+        """
         endpoints = momento_endpoint_resolver.resolve(auth_token)
         control_endpoint = control_endpoint or endpoints.control_endpoint
         cache_endpoint = cache_endpoint or endpoints.cache_endpoint

--- a/src/momento/internal/aio/_scs_control_client.py
+++ b/src/momento/internal/aio/_scs_control_client.py
@@ -36,7 +36,7 @@ class _ScsControlClient:
     """Momento Internal."""
 
     def __init__(self, credential_provider: CredentialProvider):
-        endpoint = credential_provider.get_control_endpoint()
+        endpoint = credential_provider.control_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache control client instantiated with endpoint: %s", endpoint)
         self._grpc_manager = _ControlGrpcManager(credential_provider)

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -45,7 +45,7 @@ class _ScsDataClient:
     """Internal"""
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider, default_ttl: timedelta):
-        endpoint = credential_provider.get_cache_endpoint()
+        endpoint = credential_provider.cache_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache data client instantiated with endpoint: %s", endpoint)
         self._endpoint = endpoint

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -18,9 +18,9 @@ class _ControlGrpcManager:
 
     def __init__(self, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
-            target=credential_provider.get_control_endpoint(),
+            target=credential_provider.control_endpoint,
             credentials=grpc.ssl_channel_credentials(),
-            interceptors=_interceptors(credential_provider.get_auth_token()),
+            interceptors=_interceptors(credential_provider.auth_token),
         )
 
     async def close(self) -> None:
@@ -37,9 +37,9 @@ class _DataGrpcManager:
 
     def __init__(self, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
-            target=credential_provider.get_cache_endpoint(),
+            target=credential_provider.cache_endpoint,
             credentials=grpc.ssl_channel_credentials(),
-            interceptors=_interceptors(credential_provider.get_auth_token()),
+            interceptors=_interceptors(credential_provider.auth_token),
             # Here is where you would pass override configuration to the underlying C gRPC layer.
             # However, I have tried several different tuning options here and did not see any
             # performance improvements, so sticking with the defaults for now.

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -36,7 +36,7 @@ class _ScsControlClient:
     """Momento Internal."""
 
     def __init__(self, credential_provider: CredentialProvider):
-        endpoint = credential_provider.get_control_endpoint()
+        endpoint = credential_provider.control_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache control client instantiated with endpoint: %s", endpoint)
         self._grpc_manager = _ControlGrpcManager(credential_provider)

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -45,7 +45,7 @@ class _ScsDataClient:
     """Internal"""
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider, default_ttl: timedelta):
-        endpoint = credential_provider.get_cache_endpoint()
+        endpoint = credential_provider.cache_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache data client instantiated with endpoint: %s", endpoint)
         self._endpoint = endpoint

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -22,11 +22,9 @@ class _ControlGrpcManager:
 
     def __init__(self, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
-            target=credential_provider.get_control_endpoint(), credentials=grpc.ssl_channel_credentials()
+            target=credential_provider.control_endpoint, credentials=grpc.ssl_channel_credentials()
         )
-        intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_interceptors(credential_provider.get_auth_token())
-        )
+        intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = control_client.ScsControlStub(intercept_channel)
 
     def close(self) -> None:
@@ -43,12 +41,10 @@ class _DataGrpcManager:
 
     def __init__(self, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
-            target=credential_provider.get_cache_endpoint(),
+            target=credential_provider.cache_endpoint,
             credentials=grpc.ssl_channel_credentials(),
         )
-        intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_interceptors(credential_provider.get_auth_token())
-        )
+        intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = cache_client.ScsStub(intercept_channel)
 
     def close(self) -> None:

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -104,7 +104,7 @@ class SimpleCacheClient:
         self._logger = logs.logger
         self._next_client_index = 0
         self._control_client = _ScsControlClient(credential_provider)
-        self._cache_endpoint = credential_provider.get_cache_endpoint()
+        self._cache_endpoint = credential_provider.cache_endpoint
         self._data_clients = [
             _ScsDataClient(configuration, credential_provider, default_ttl)
             for _ in range(SimpleCacheClient._NUM_CLIENTS)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -104,7 +104,7 @@ class SimpleCacheClientAsync:
         self._logger = logs.logger
         self._next_client_index = 0
         self._control_client = _ScsControlClient(credential_provider)
-        self._cache_endpoint = credential_provider.get_cache_endpoint()
+        self._cache_endpoint = credential_provider.cache_endpoint
         self._data_clients = [
             _ScsDataClient(configuration, credential_provider, default_ttl)
             for _ in range(SimpleCacheClientAsync._NUM_CLIENTS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import pytest_asyncio
 
 from momento import SimpleCacheClient, SimpleCacheClientAsync
-from momento.auth import EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration, Laptop
 from tests.utils import unique_test_cache_name
 
@@ -17,7 +17,7 @@ from tests.utils import unique_test_cache_name
 
 TEST_CONFIGURATION = Laptop.latest()
 
-TEST_AUTH_PROVIDER = EnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+TEST_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
 
 TEST_CACHE_NAME: Optional[str] = os.getenv("TEST_CACHE_NAME")
 if not TEST_CACHE_NAME:
@@ -33,14 +33,14 @@ BAD_AUTH_TOKEN: str = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoi
 
 
 @pytest.fixture(scope="session")
-def credential_provider() -> EnvMomentoTokenProvider:
+def credential_provider() -> CredentialProvider:
     return TEST_AUTH_PROVIDER
 
 
 @pytest.fixture(scope="session")
-def bad_token_credential_provider() -> EnvMomentoTokenProvider:
+def bad_token_credential_provider() -> CredentialProvider:
     os.environ["BAD_AUTH_TOKEN"] = BAD_AUTH_TOKEN
-    return EnvMomentoTokenProvider("BAD_AUTH_TOKEN")
+    return CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
 
 
 @pytest.fixture(scope="session")
@@ -75,7 +75,7 @@ def event_loop() -> asyncio.AbstractEventLoop:  # type: ignore
 @pytest.fixture(scope="session")
 def client() -> SimpleCacheClient:
     configuration = Laptop.latest()
-    credential_provider = EnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+    credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
     with SimpleCacheClient(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         _client.create_cache(TEST_CACHE_NAME)
@@ -88,7 +88,7 @@ def client() -> SimpleCacheClient:
 @pytest_asyncio.fixture(scope="session")
 async def client_async() -> SimpleCacheClientAsync:
     configuration = Laptop.latest()
-    credential_provider = EnvMomentoTokenProvider("TEST_AUTH_TOKEN")
+    credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
     async with SimpleCacheClientAsync(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         # TODO consider deleting cache on when test runner shuts down

--- a/tests/momento/auth/test_credential_provider.py
+++ b/tests/momento/auth/test_credential_provider.py
@@ -1,0 +1,58 @@
+import os
+
+import jwt
+import pytest
+
+from momento.auth.credential_provider import CredentialProvider
+from tests.utils import uuid_str
+
+test_email = "user@test.com"
+test_control_endpoint = "control.test.com"
+test_cache_endpoint = "cache.test.com"
+test_message = {"sub": test_email, "cp": test_control_endpoint, "c": test_cache_endpoint}
+test_token = jwt.encode(test_message, "secret", algorithm="HS512")
+test_env_var_name = uuid_str()
+os.environ[test_env_var_name] = test_token
+
+
+@pytest.mark.parametrize(
+    "provider, auth_token, control_endpoint, cache_endpoint",
+    [
+        (CredentialProvider.from_string(auth_token=test_token), test_token, test_control_endpoint, test_cache_endpoint),
+        (
+            CredentialProvider.from_string(
+                auth_token=test_token,
+                control_endpoint="give.me.control.test.com",
+                cache_endpoint="secret.cache.test.com",
+            ),
+            test_token,
+            "give.me.control.test.com",
+            "secret.cache.test.com",
+        ),
+        (
+            CredentialProvider.from_environment_variable(env_var_name=test_env_var_name),
+            test_token,
+            test_control_endpoint,
+            test_cache_endpoint,
+        ),
+        (
+            CredentialProvider.from_environment_variable(
+                env_var_name=test_env_var_name,
+                control_endpoint="give.me.control.test.com",
+                cache_endpoint="secret.cache.test.com",
+            ),
+            test_token,
+            "give.me.control.test.com",
+            "secret.cache.test.com",
+        ),
+    ],
+)
+def test_endpoints(provider, auth_token, control_endpoint, cache_endpoint) -> None:
+    assert provider.auth_token == auth_token
+    assert provider.control_endpoint == control_endpoint
+    assert provider.cache_endpoint == cache_endpoint
+
+
+def test_env_token_raises_if_not_exists() -> None:
+    with pytest.raises(RuntimeError, match=r"Missing required environment variable"):
+        CredentialProvider.from_environment_variable(env_var_name=uuid_str())

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Callable, Union
 
 from momento import SimpleCacheClient
-from momento.auth import EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
@@ -60,7 +60,7 @@ TConnectionValidator = Callable[[SimpleCacheClient, str], CacheResponse]
 
 def a_connection_validator() -> None:
     def throws_authentication_exception_for_bad_token(
-        bad_token_credential_provider: EnvMomentoTokenProvider,
+        bad_token_credential_provider: CredentialProvider,
         configuration: Configuration,
         cache_name: str,
         default_ttl_seconds: timedelta,
@@ -73,7 +73,7 @@ def a_connection_validator() -> None:
 
     def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
-        credential_provider: EnvMomentoTokenProvider,
+        credential_provider: CredentialProvider,
         cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Awaitable, Callable, Union
 
 from momento import SimpleCacheClientAsync
-from momento.auth import EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
@@ -60,7 +60,7 @@ TConnectionValidator = Callable[[SimpleCacheClientAsync, str], Awaitable[CacheRe
 
 def a_connection_validator() -> None:
     async def throws_authentication_exception_for_bad_token(
-        bad_token_credential_provider: EnvMomentoTokenProvider,
+        bad_token_credential_provider: CredentialProvider,
         configuration: Configuration,
         cache_name: str,
         default_ttl_seconds: timedelta,
@@ -75,7 +75,7 @@ def a_connection_validator() -> None:
 
     async def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
-        credential_provider: EnvMomentoTokenProvider,
+        credential_provider: CredentialProvider,
         cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import momento.errors as errors
 from momento import SimpleCacheClient
-from momento.auth import EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheGet, CacheSet, CreateCache, DeleteCache, ListCaches
@@ -61,7 +61,7 @@ def test_create_cache_with_bad_cache_name_throws_exception(
 
 
 def test_create_cache_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider,
+    bad_token_credential_provider: CredentialProvider,
     configuration: Configuration,
     default_ttl_seconds: timedelta,
     unique_cache_name,
@@ -121,7 +121,7 @@ def test_delete_with_bad_cache_name_throws_exception(client: SimpleCacheClient, 
 
 
 def test_delete_cache_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider, configuration: Configuration, default_ttl_seconds: timedelta
+    bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
     with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
         response = client.delete_cache(uuid_str())
@@ -155,7 +155,7 @@ def test_list_caches_succeeds(client: SimpleCacheClient, cache_name: str) -> Non
 
 
 def test_list_caches_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider, configuration: Configuration, default_ttl_seconds: timedelta
+    bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
     with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
         response = client.list_caches()

--- a/tests/momento/simple_cache_client/test_control_async.py
+++ b/tests/momento/simple_cache_client/test_control_async.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import momento.errors as errors
 from momento import SimpleCacheClientAsync
-from momento.auth import EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheGet, CacheSet, CreateCache, DeleteCache, ListCaches
@@ -63,7 +63,7 @@ async def test_create_cache_with_bad_cache_name_throws_exception(
 
 
 async def test_create_cache_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider,
+    bad_token_credential_provider: CredentialProvider,
     configuration: Configuration,
     default_ttl_seconds: timedelta,
     unique_cache_name_async,
@@ -127,7 +127,7 @@ async def test_delete_with_bad_cache_name_throws_exception(
 
 
 async def test_delete_cache_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider, configuration: Configuration, default_ttl_seconds: timedelta
+    bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
     async with SimpleCacheClientAsync(
         configuration, bad_token_credential_provider, default_ttl_seconds
@@ -163,7 +163,7 @@ async def test_list_caches_succeeds(client_async: SimpleCacheClientAsync, cache_
 
 
 async def test_list_caches_throws_authentication_exception_for_bad_token(
-    bad_token_credential_provider: EnvMomentoTokenProvider, configuration: Configuration, default_ttl_seconds: timedelta
+    bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
     async with SimpleCacheClientAsync(
         configuration, bad_token_credential_provider, default_ttl_seconds

--- a/tests/momento/simple_cache_client/test_init.py
+++ b/tests/momento/simple_cache_client/test_init.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 
 from momento import SimpleCacheClient
-from momento.auth import CredentialProvider, EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import InvalidArgumentException
 
@@ -19,7 +19,7 @@ def test_init_throws_exception_when_client_uses_negative_default_ttl(
 def test_init_throws_exception_for_non_jwt_token(configuration: Configuration, default_ttl_seconds: timedelta) -> None:
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
         os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
-        credential_provider = EnvMomentoTokenProvider("BAD_AUTH_TOKEN")
+        credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
         SimpleCacheClient(configuration, credential_provider, default_ttl_seconds)
 
 

--- a/tests/momento/simple_cache_client/test_init_async.py
+++ b/tests/momento/simple_cache_client/test_init_async.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pytest
 
 from momento import SimpleCacheClientAsync
-from momento.auth import CredentialProvider, EnvMomentoTokenProvider
+from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import InvalidArgumentException
 
@@ -21,7 +21,7 @@ async def test_init_throws_exception_for_non_jwt_token(
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
         os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
-        credential_provider = EnvMomentoTokenProvider("BAD_AUTH_TOKEN")
+        credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
         SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds)
 
 


### PR DESCRIPTION
Make credential provider pythonic. Add the equivalent of StringMomentoAuthProvider as a static constructor.

Closes #223 
