### PR TITLE
feat: list_concatenate_front()

### DIFF
--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -9,7 +9,7 @@ DEFAULT_LIST_CONVERSION_ERROR = "Could not decode List[bytes] to UTF-8"
 
 
 def _is_valid_name(name: str) -> bool:
-    return name is not None and isinstance(name, str)
+    return name is not None and isinstance(name, str) and name != ""
 
 
 def _validate_cache_name(cache_name: str) -> None:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -8,6 +8,7 @@ from momento_wire_types.cacheclient_pb2 import (
     _GetRequest,
     _GetResponse,
     _ListConcatenateBackRequest,
+    _ListConcatenateFrontRequest,
     _ListFetchRequest,
     _SetRequest,
     _SetResponse,
@@ -47,6 +48,8 @@ from momento.responses import (
     CacheGetResponse,
     CacheListConcatenateBack,
     CacheListConcatenateBackResponse,
+    CacheListConcatenateFront,
+    CacheListConcatenateFrontResponse,
     CacheListFetch,
     CacheListFetchResponse,
     CacheSet,
@@ -183,6 +186,39 @@ class _ScsDataClient:
         except Exception as e:
             self._log_request_error("list_concatenate_back", e)
             return CacheListConcatenateBack.Error(convert_error(e))
+
+    def list_concatenate_front(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_back_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateFrontResponse:
+        try:
+            self._log_issuing_request("ListConcatenateFront", {})
+            _validate_cache_name(cache_name)
+            _validate_list_name(list_name)
+
+            item_ttl = self._default_ttl if ttl.ttl is None else ttl.ttl
+            request = _ListConcatenateFrontRequest()
+            request.list_name = _as_bytes(list_name, "Unsupported type for list_name: ")
+            request.values.extend(_list_as_bytes(values, "Unsupported type for values: "))
+            request.ttl_milliseconds = int(item_ttl.total_seconds() * 1000)
+            request.refresh_ttl = ttl.refresh_ttl
+            if truncate_back_to_size is not None:
+                request.truncate_back_to_size = truncate_back_to_size
+
+            response = self._build_stub().ListConcatenateFront(
+                request,
+                metadata=make_metadata(cache_name),
+                timeout=self._default_deadline_seconds,
+            )
+            self._log_received_response("ListConcatenateFront", {"list_name": str(request.list_name)})
+            return CacheListConcatenateFront.Success(response.list_length)
+        except Exception as e:
+            self._log_request_error("list_concatenate_front", e)
+            return CacheListConcatenateFront.Error(convert_error(e))
 
     def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
         try:

--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -13,6 +13,8 @@ from .control import (
 from .list_data import (
     CacheListConcatenateBack,
     CacheListConcatenateBackResponse,
+    CacheListConcatenateFront,
+    CacheListConcatenateFrontResponse,
     CacheListFetch,
     CacheListFetchResponse,
 )

--- a/src/momento/responses/list_data/__init__.py
+++ b/src/momento/responses/list_data/__init__.py
@@ -2,4 +2,8 @@ from .list_concatenate_back import (
     CacheListConcatenateBack,
     CacheListConcatenateBackResponse,
 )
+from .list_concatenate_front import (
+    CacheListConcatenateFront,
+    CacheListConcatenateFrontResponse,
+)
 from .list_fetch import CacheListFetch, CacheListFetchResponse

--- a/src/momento/responses/list_data/list_concatenate_front.py
+++ b/src/momento/responses/list_data/list_concatenate_front.py
@@ -1,0 +1,41 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheListConcatenateFrontResponse(CacheResponse):
+    """Response type for a `list_concatenate_front` request. Its subtypes are:
+
+    - `CacheListConcatenateFront.Success`
+    - `CacheListConcatenateFront.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheListConcatenateFront(ABC):
+    """Groups all `CacheListConcatenateFrontResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheListConcatenateFrontResponse):
+        """Indicates the concatenation was successful."""
+
+        list_length: int
+        """The number of values in the list after this concatenation"""
+
+    @dataclass
+    class Error(CacheListConcatenateFrontResponse, ErrorResponseMixin):
+        """Indicates an error occured in the request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -38,6 +38,7 @@ from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
     CacheListConcatenateBackResponse,
+    CacheListConcatenateFrontResponse,
     CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
@@ -411,6 +412,16 @@ class SimpleCacheClient:
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
         return self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
+
+    def list_concatenate_front(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_back_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateFrontResponse:
+        return self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
 
     def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
         return self._data_client.list_fetch(cache_name, list_name)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -134,36 +134,13 @@ class SimpleCacheClient:
             cache_name (str): Name of the cache to be created.
 
         Returns:
-            CreateCacheResponse: result of the create cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CreateCacheResponse:
+
+            This response is resolved to one of:
 
             - `CreateCache.Success`
             - `CreateCache.AlreadyExists`
             - `CreateCache.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CreateCache.Success():
-                        ...
-                    case CreateCache.CacheAlreadyExists():
-                        ...
-                    case CreateCache.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CreateCache.Success):
-                    ...
-                elif isinstance(response, CreateCache.AlreadyExists):
-                    ...
-                elif isinstance(response, CreateCache.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._control_client.create_cache(cache_name)
 
@@ -174,31 +151,12 @@ class SimpleCacheClient:
             cache_name (str): Name of the cache to be deleted.
 
         Returns:
-            DeleteCacheResponse: result of the delete cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            DeleteCacheResponse:
+
+            This response is resolved to one of:
 
             - `DeleteCache.Success`
             - `DeleteCache.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case DeleteCache.Success():
-                        ...
-                    case DeleteCache.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, DeleteCache.Success):
-                    ...
-                elif isinstance(response, DeleteCache.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._control_client.delete_cache(cache_name)
 
@@ -209,31 +167,12 @@ class SimpleCacheClient:
             next_token: A token to specify where to start paginating. This is the NextToken from a previous response.
 
         Returns:
-            ListCachesResponse: result of the delete cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            ListCachesResponse:
+
+            This response is resolved to one of:
 
             - `ListCaches.Success`
             - `ListCaches.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case ListCaches.Success():
-                        ...
-                    case ListCaches.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, ListCaches.Success):
-                    ...
-                elif isinstance(response, ListCaches.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._control_client.list_caches(next_token)
 
@@ -297,31 +236,12 @@ class SimpleCacheClient:
             Defaults to client TTL. If specified must be strictly positive.
 
         Returns:
-            CacheSetResponse: result of the set operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheSetResponse:
+
+            This response is resolved to one of:
 
             - `CacheSet.Success`
             - `CacheSet.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheSet.Success():
-                        ...
-                    case CacheSet.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheSet.Success):
-                    ...
-                elif isinstance(response, CacheSet.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._data_client.set(cache_name, key, value, ttl)
 
@@ -333,34 +253,13 @@ class SimpleCacheClient:
             key (TScalarKey): The key to lookup.
 
         Returns:
-            CacheGetResponse: the status of the get operation and the associated value. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheGetResponse:
+
+            This response is resolved to one of:
 
             - `CacheGet.Hit`
             - `CacheGet.Miss`
             - `CacheGet.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheGet.Hit() as hit:
-                        return hit.value_string
-                    case CacheGet.Miss():
-                        ... # Handle miss
-                    case CacheGet.Error():
-                        ...
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheGet.Hit):
-                    ...
-                elif isinstance(response, CacheGet.Miss):
-                    ...
-                elif isinstance(response, CacheGet.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._data_client.get(cache_name, key)
 
@@ -372,31 +271,12 @@ class SimpleCacheClient:
             key (TScalarKey): The key to delete.
 
         Returns:
-            CacheDeleteResponse: result of the delete operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheDeleteResponse:
+
+            This response is resolved to one of:
 
             - `CacheDelete.Success`
             - `CacheDelete.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheDelete.Success():
-                        ...
-                    case CacheDelete.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheDelete.Success):
-                    ...
-                elif isinstance(response, CacheDelete.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return self._data_client.delete(cache_name, key)
 
@@ -411,6 +291,26 @@ class SimpleCacheClient:
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
+        """
+        Add values to the end of the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to concatenate.
+            values: (TListValues): The values to concatenate.
+            ttl: (CollectionTtl): How to treat the list's TTL. Defaults to `CollectionTtl.from_cache_ttl()`
+            truncate_front_to_size (Optional[int]): If the list exceeds this size, remove values from
+                                                    the start of the list.
+
+        Returns:
+            CacheListConcatenateBackResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListConcatenateBack.Success`
+            - `CacheListConcatenateBack.Error`
+        """
+
         return self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
 
     def list_concatenate_front(
@@ -421,9 +321,46 @@ class SimpleCacheClient:
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListConcatenateFrontResponse:
+        """
+        Add values to the start of the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to concatenate.
+            values: (TListValues): The values to concatenate.
+            ttl: (CollectionTtl): How to treat the list's TTL. Defaults to `CollectionTtl.from_cache_ttl()`
+            truncate_back_to_size (Optional[int]): If the list exceeds this size, remove values from
+                                                   the end of the list.
+
+        Returns:
+            CacheListConcatenateFrontResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListConcatenateFront.Success`
+            - `CacheListConcatenateFront.Error`
+        """
+
         return self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
 
     def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
+        """
+        Gets all values from the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to fetch.
+
+        Returns:
+            CacheListFetchResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListFetch.Hit`
+            - `CacheListFetch.Miss`
+            - `CacheListFetch.Error`
+        """
+
         return self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -135,12 +135,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CreateCacheResponse:
-
-            This response is resolved to one of:
-
-            - `CreateCache.Success`
-            - `CreateCache.AlreadyExists`
-            - `CreateCache.Error`
         """
         return await self._control_client.create_cache(cache_name)
 
@@ -152,11 +146,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             DeleteCacheResponse:
-
-            This response is resolved to one of:
-
-            - `DeleteCache.Success`
-            - `DeleteCache.Error`
         """
         return await self._control_client.delete_cache(cache_name)
 
@@ -168,11 +157,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             ListCachesResponse:
-
-            This response is resolved to one of:
-
-            - `ListCaches.Success`
-            - `ListCaches.Error`
         """
         return await self._control_client.list_caches(next_token)
 
@@ -237,11 +221,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheSetResponse:
-
-            This response is resolved to one of:
-
-            - `CacheSet.Success`
-            - `CacheSet.Error`
         """
         return await self._data_client.set(cache_name, key, value, ttl)
 
@@ -254,12 +233,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheGetResponse:
-
-            This response is resolved to one of:
-
-            - `CacheGet.Hit`
-            - `CacheGet.Miss`
-            - `CacheGet.Error`
         """
         return await self._data_client.get(cache_name, key)
 
@@ -272,11 +245,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheDeleteResponse:
-
-            This response is resolved to one of:
-
-            - `CacheDelete.Success`
-            - `CacheDelete.Error`
         """
         return await self._data_client.delete(cache_name, key)
 
@@ -304,11 +272,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheListConcatenateBackResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListConcatenateBack.Success`
-            - `CacheListConcatenateBack.Error`
         """
 
         return await self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
@@ -334,11 +297,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheListConcatenateFrontResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListConcatenateFront.Success`
-            - `CacheListConcatenateFront.Error`
         """
 
         return await self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
@@ -353,12 +311,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheListFetchResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListFetch.Hit`
-            - `CacheListFetch.Miss`
-            - `CacheListFetch.Error`
         """
 
         return await self._data_client.list_fetch(cache_name, list_name)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -38,6 +38,7 @@ from momento.responses import (
     CacheDeleteResponse,
     CacheGetResponse,
     CacheListConcatenateBackResponse,
+    CacheListConcatenateFrontResponse,
     CacheListFetchResponse,
     CacheSetResponse,
     CreateCacheResponse,
@@ -411,6 +412,16 @@ class SimpleCacheClientAsync:
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
         return await self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
+
+    async def list_concatenate_front(
+        self,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+        truncate_back_to_size: Optional[int] = None,
+    ) -> CacheListConcatenateFrontResponse:
+        return await self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
 
     async def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
         return await self._data_client.list_fetch(cache_name, list_name)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -134,36 +134,13 @@ class SimpleCacheClientAsync:
             cache_name (str): Name of the cache to be created.
 
         Returns:
-            CreateCacheResponse: result of the create cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CreateCacheResponse:
+
+            This response is resolved to one of:
 
             - `CreateCache.Success`
             - `CreateCache.AlreadyExists`
             - `CreateCache.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CreateCache.Success():
-                        ...
-                    case CreateCache.CacheAlreadyExists():
-                        ...
-                    case CreateCache.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CreateCache.Success):
-                    ...
-                elif isinstance(response, CreateCache.AlreadyExists):
-                    ...
-                elif isinstance(response, CreateCache.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._control_client.create_cache(cache_name)
 
@@ -174,31 +151,12 @@ class SimpleCacheClientAsync:
             cache_name (str): Name of the cache to be deleted.
 
         Returns:
-            DeleteCacheResponse: result of the delete cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            DeleteCacheResponse:
+
+            This response is resolved to one of:
 
             - `DeleteCache.Success`
             - `DeleteCache.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case DeleteCache.Success():
-                        ...
-                    case DeleteCache.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, DeleteCache.Success):
-                    ...
-                elif isinstance(response, DeleteCache.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._control_client.delete_cache(cache_name)
 
@@ -209,31 +167,12 @@ class SimpleCacheClientAsync:
             next_token: A token to specify where to start paginating. This is the NextToken from a previous response.
 
         Returns:
-            ListCachesResponse: result of the delete cache operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            ListCachesResponse:
+
+            This response is resolved to one of:
 
             - `ListCaches.Success`
             - `ListCaches.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case ListCaches.Success():
-                        ...
-                    case ListCaches.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, ListCaches.Success):
-                    ...
-                elif isinstance(response, ListCaches.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._control_client.list_caches(next_token)
 
@@ -297,31 +236,12 @@ class SimpleCacheClientAsync:
             Defaults to client TTL. If specified must be strictly positive.
 
         Returns:
-            CacheSetResponse: result of the set operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheSetResponse:
+
+            This response is resolved to one of:
 
             - `CacheSet.Success`
             - `CacheSet.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheSet.Success():
-                        ...
-                    case CacheSet.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheSet.Success):
-                    ...
-                elif isinstance(response, CacheSet.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._data_client.set(cache_name, key, value, ttl)
 
@@ -333,34 +253,13 @@ class SimpleCacheClientAsync:
             key (TScalarKey): The key to lookup.
 
         Returns:
-            CacheGetResponse: the status of the get operation and the associated value. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheGetResponse:
+
+            This response is resolved to one of:
 
             - `CacheGet.Hit`
             - `CacheGet.Miss`
             - `CacheGet.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheGet.Hit() as hit:
-                        return hit.value_string
-                    case CacheGet.Miss():
-                        ... # Handle miss
-                    case CacheGet.Error():
-                        ...
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheGet.Hit):
-                    ...
-                elif isinstance(response, CacheGet.Miss):
-                    ...
-                elif isinstance(response, CacheGet.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._data_client.get(cache_name, key)
 
@@ -372,31 +271,12 @@ class SimpleCacheClientAsync:
             key (TScalarKey): The key to delete.
 
         Returns:
-            CacheDeleteResponse: result of the delete operation. This result
-            is resolved to a type-safe object of one of the following subtypes:
+            CacheDeleteResponse:
+
+            This response is resolved to one of:
 
             - `CacheDelete.Success`
             - `CacheDelete.Error`
-
-            Pattern matching can be used to operate on the appropriate subtype.
-            For example, in python 3.10+:
-
-                match response:
-                    case CacheDelete.Success():
-                        ...
-                    case CacheDelete.Error():
-                        ...
-                    case _:
-                        # Shouldn't happen
-
-            or equivalently in earlier versions of python:
-
-                if isinstance(response, CacheDelete.Success):
-                    ...
-                elif isinstance(response, CacheDelete.Error):
-                    ...
-                else:
-                    # Shouldn't happen
         """
         return await self._data_client.delete(cache_name, key)
 
@@ -411,6 +291,26 @@ class SimpleCacheClientAsync:
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
+        """
+        Add values to the end of the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to concatenate.
+            values: (TListValues): The values to concatenate.
+            ttl: (CollectionTtl): How to treat the list's TTL. Defaults to `CollectionTtl.from_cache_ttl()`
+            truncate_front_to_size (Optional[int]): If the list exceeds this size, remove values from
+                                                    the start of the list.
+
+        Returns:
+            CacheListConcatenateBackResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListConcatenateBack.Success`
+            - `CacheListConcatenateBack.Error`
+        """
+
         return await self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
 
     async def list_concatenate_front(
@@ -421,9 +321,46 @@ class SimpleCacheClientAsync:
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListConcatenateFrontResponse:
+        """
+        Add values to the start of the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to concatenate.
+            values: (TListValues): The values to concatenate.
+            ttl: (CollectionTtl): How to treat the list's TTL. Defaults to `CollectionTtl.from_cache_ttl()`
+            truncate_back_to_size (Optional[int]): If the list exceeds this size, remove values from
+                                                   the end of the list.
+
+        Returns:
+            CacheListConcatenateFrontResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListConcatenateFront.Success`
+            - `CacheListConcatenateFront.Error`
+        """
+
         return await self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
 
     async def list_fetch(self, cache_name: TCacheName, list_name: TListName) -> CacheListFetchResponse:
+        """
+        Gets all values from the list.
+
+        Args:
+            cache_name (TCacheName): The cache where the list is.
+            list_name (TListName): The name of the list to fetch.
+
+        Returns:
+            CacheListFetchResponse:
+
+            This response is resolved to one of:
+
+            - `CacheListFetch.Hit`
+            - `CacheListFetch.Miss`
+            - `CacheListFetch.Error`
+        """
+
         return await self._data_client.list_fetch(cache_name, list_name)
 
     # SET COLLECTION METHODS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import random
 from datetime import timedelta
 from typing import Optional, cast
 
@@ -9,7 +10,13 @@ import pytest_asyncio
 from momento import SimpleCacheClient, SimpleCacheClientAsync
 from momento.auth import EnvMomentoTokenProvider
 from momento.config import Configuration, Laptop
-from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
+from momento.typing import (
+    TCacheName,
+    TListName,
+    TListValues,
+    TListValuesBytes,
+    TListValuesStr,
+)
 from tests.utils import unique_test_cache_name, uuid_bytes, uuid_str
 
 #######################
@@ -62,6 +69,11 @@ def list_name() -> TListName:
 @pytest.fixture
 def values_bytes() -> TListValuesBytes:
     return [uuid_bytes(), uuid_bytes(), uuid_bytes()]
+
+
+@pytest.fixture()
+def values() -> TListValues:
+    return random.choice(([uuid_bytes(), uuid_bytes(), uuid_bytes()], [uuid_str(), uuid_str(), uuid_str()]))
 
 
 @pytest.fixture

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -30,7 +30,7 @@ def a_cache_name_validator() -> None:
         response = cache_name_validator("")
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache header is empty"
+        assert response.inner_exception.message == "Cache name must be a non-empty string"
 
     def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = cache_name_validator(1)  # type: ignore

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -30,7 +30,7 @@ def a_cache_name_validator() -> None:
         response = await cache_name_validator("")
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache header is empty"
+        assert response.inner_exception.message == "Cache name must be a non-empty string"
 
     async def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = await cache_name_validator(1)  # type: ignore

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -6,9 +6,20 @@ from pytest_describe import behaves_like
 
 from momento import SimpleCacheClient
 from momento.errors import MomentoErrorCode
-from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
+from momento.responses import (
+    CacheListConcatenateBack,
+    CacheListConcatenateFront,
+    CacheListFetch,
+    CacheResponse,
+)
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
+from momento.typing import (
+    TCacheName,
+    TListName,
+    TListValues,
+    TListValuesBytes,
+    TListValuesStr,
+)
 from tests.utils import uuid_str
 
 from .shared_behaviors import (
@@ -19,6 +30,52 @@ from .shared_behaviors import (
 )
 
 TListNameValidator = Callable[[TListName], CacheResponse]
+TListConcatenator = Callable[[TListName, TListValues], CacheResponse]
+
+
+def a_list_concatenator() -> None:
+    def it_returns_the_new_list_length(
+        list_concatenator: TListConcatenator,
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+    ) -> None:
+        resp = list_concatenator(cache_name, list_name, values)
+        length = len(values)
+        assert resp.list_length == length
+
+        resp = list_concatenator(cache_name, list_name, values)
+        length += len(values)
+        assert resp.list_length == length
+
+    def with_bytes_it_succeeds(
+        list_concatenator: TListConcatenator,
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_bytes: TListValuesBytes,
+    ) -> None:
+        concat_resp = list_concatenator(cache_name, list_name, values_bytes)
+        assert concat_resp.list_length == len(values_bytes)
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_bytes == values_bytes
+
+    def with_strings_it_succeeds(
+        list_concatenator: TListConcatenator,
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_str: TListValuesStr,
+    ) -> None:
+        concat_resp = list_concatenator(cache_name, list_name, values_str)
+        assert concat_resp.list_length == len(values_str)
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_string == values_str
 
 
 def a_list_name_validator() -> None:
@@ -151,3 +208,53 @@ def describe_list_concatenate_back() -> None:
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
         assert fetch_resp.values_string == values_str
+
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+@behaves_like(a_list_concatenator)
+def describe_list_concatenate_front() -> None:
+    @fixture
+    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client.list_concatenate_front, list_name=list_name, values=[uuid_str()])
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return client.list_concatenate_front(cache_name, list_name, [uuid_str()])
+
+        return _connection_validator
+
+    @fixture
+    def list_concatenator(client: SimpleCacheClient, list_name: TListName, values: TListValues) -> TListConcatenator:
+        return partial(client.list_concatenate_front)
+
+    def it_truncates_the_back(
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+    ) -> None:
+        truncate_to = 4
+
+        concat_resp = client.list_concatenate_front(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["one", "two", "three"],
+            truncate_back_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateFront.Success)
+        assert concat_resp.list_length <= truncate_to
+
+        concat_resp = client.list_concatenate_front(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["four", "five", "six"],
+            truncate_back_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateFront.Success)
+        assert concat_resp.list_length <= truncate_to
+
+        fetch_resp = client.list_fetch(cache_name, list_name)
+        assert fetch_resp.values_string == ["four", "five", "six", "one"]

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -6,9 +6,20 @@ from pytest_describe import behaves_like
 
 from momento import SimpleCacheClientAsync
 from momento.errors import MomentoErrorCode
-from momento.responses import CacheListConcatenateBack, CacheListFetch, CacheResponse
+from momento.responses import (
+    CacheListConcatenateBack,
+    CacheListConcatenateFront,
+    CacheListFetch,
+    CacheResponse,
+)
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import TCacheName, TListName, TListValuesBytes, TListValuesStr
+from momento.typing import (
+    TCacheName,
+    TListName,
+    TListValues,
+    TListValuesBytes,
+    TListValuesStr,
+)
 from tests.utils import uuid_str
 
 from .shared_behaviors_async import (
@@ -19,6 +30,52 @@ from .shared_behaviors_async import (
 )
 
 TListNameValidator = Callable[[TListName], Awaitable[CacheResponse]]
+TListConcatenator = Callable[[TListName, TListValues], Awaitable[CacheResponse]]
+
+
+def a_list_concatenator() -> None:
+    async def it_returns_the_new_list_length(
+        list_concatenator: TListConcatenator,
+        client_async: SimpleCacheClientAsync,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values: TListValues,
+    ) -> None:
+        resp = await list_concatenator(cache_name, list_name, values)
+        length = len(values)
+        assert resp.list_length == length
+
+        resp = await list_concatenator(cache_name, list_name, values)
+        length += len(values)
+        assert resp.list_length == length
+
+    async def with_bytes_it_succeeds(
+        list_concatenator: TListConcatenator,
+        client_async: SimpleCacheClientAsync,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_bytes: TListValuesBytes,
+    ) -> None:
+        concat_resp = await list_concatenator(cache_name, list_name, values_bytes)
+        assert concat_resp.list_length == len(values_bytes)
+
+        fetch_resp = await client_async.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_bytes == values_bytes
+
+    async def with_strings_it_succeeds(
+        list_concatenator: TListConcatenator,
+        client_async: SimpleCacheClientAsync,
+        cache_name: TCacheName,
+        list_name: TListName,
+        values_str: TListValuesStr,
+    ) -> None:
+        concat_resp = await list_concatenator(cache_name, list_name, values_str)
+        assert concat_resp.list_length == len(values_str)
+
+        fetch_resp = await client_async.list_fetch(cache_name, list_name)
+        assert isinstance(fetch_resp, CacheListFetch.Hit)
+        assert fetch_resp.values_string == values_str
 
 
 def a_list_name_validator() -> None:
@@ -75,6 +132,7 @@ def describe_list_fetch() -> None:
 
 @behaves_like(a_cache_name_validator)
 @behaves_like(a_connection_validator)
+@behaves_like(a_list_concatenator)
 def describe_list_concatenate_back() -> None:
     @fixture
     def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
@@ -91,19 +149,11 @@ def describe_list_concatenate_back() -> None:
 
         return _connection_validator
 
-    async def it_returns_the_new_list_length(
-        client_async: SimpleCacheClientAsync,
-        cache_name: TCacheName,
-        list_name: TListName,
-        values_bytes: TListValuesBytes,
-    ) -> None:
-        resp = await client_async.list_concatenate_back(cache_name, list_name, values_bytes)
-        length = len(values_bytes)
-        assert resp.list_length == length
-
-        resp = await client_async.list_concatenate_back(cache_name, list_name, values_bytes)
-        length += len(values_bytes)
-        assert resp.list_length == length
+    @fixture
+    def list_concatenator(
+        client_async: SimpleCacheClientAsync, list_name: TListName, values: TListValues
+    ) -> TListConcatenator:
+        return partial(client_async.list_concatenate_back)
 
     async def it_truncates_the_front(
         client_async: SimpleCacheClientAsync,
@@ -133,25 +183,56 @@ def describe_list_concatenate_back() -> None:
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert fetch_resp.values_string == ["three", "four", "five", "six"]
 
-    async def with_bytes_it_succeeds(
+
+@behaves_like(a_cache_name_validator)
+@behaves_like(a_connection_validator)
+@behaves_like(a_list_concatenator)
+def describe_list_concatenate_front() -> None:
+    @fixture
+    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+        list_name = uuid_str()
+        return partial(client_async.list_concatenate_front, list_name=list_name, values=[uuid_str()])
+
+    @fixture
+    def connection_validator() -> TConnectionValidator:
+        async def _connection_validator(
+            client_async: SimpleCacheClientAsync, cache_name: TCacheName
+        ) -> ErrorResponseMixin:
+            list_name = uuid_str()
+            return await client_async.list_concatenate_front(cache_name, list_name, [uuid_str()])
+
+        return _connection_validator
+
+    @fixture
+    def list_concatenator(
+        client_async: SimpleCacheClientAsync, list_name: TListName, values: TListValues
+    ) -> TListConcatenator:
+        return partial(client_async.list_concatenate_front)
+
+    async def it_truncates_the_back(
         client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
-        values_bytes: TListValuesBytes,
     ) -> None:
-        concat_resp = await client_async.list_concatenate_back(cache_name, list_name, values_bytes)
-        assert isinstance(concat_resp, CacheListConcatenateBack.Success)
+        truncate_to = 4
+
+        concat_resp = await client_async.list_concatenate_front(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["one", "two", "three"],
+            truncate_back_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateFront.Success)
+        assert concat_resp.list_length <= truncate_to
+
+        concat_resp = await client_async.list_concatenate_front(
+            cache_name=cache_name,
+            list_name=list_name,
+            values=["four", "five", "six"],
+            truncate_back_to_size=truncate_to,
+        )
+        assert isinstance(concat_resp, CacheListConcatenateFront.Success)
+        assert concat_resp.list_length <= truncate_to
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_bytes == values_bytes
-
-    async def with_strings_it_succeeds(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values_str: TListValuesStr
-    ) -> None:
-        resp = await client_async.list_concatenate_back(cache_name, list_name, values_str)
-        assert isinstance(resp, CacheListConcatenateBack.Success)
-
-        fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == values_str
+        assert fetch_resp.values_string == ["four", "five", "six", "one"]


### PR DESCRIPTION
This PR is to establish an agreed upon doc style for the collection methods.

* Document all the list methods.
* Test list name validation (the tests were there but not used)
* Validate that names are not empty strings
  * Something was doing it at a lower level for cache names, but we don't have that for collection names.
  
For #174 