### PR TITLE
feat: dictionary stub implementation

### DIFF
--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -10,6 +10,24 @@ from .control import (
     RevokeSigningKeyResponse,
     SigningKey,
 )
+from .dictionary_data import (
+    CacheDictionaryFetch,
+    CacheDictionaryFetchResponse,
+    CacheDictionaryGetField,
+    CacheDictionaryGetFieldResponse,
+    CacheDictionaryGetFields,
+    CacheDictionaryGetFieldsResponse,
+    CacheDictionaryIncrement,
+    CacheDictionaryIncrementResponse,
+    CacheDictionaryRemoveField,
+    CacheDictionaryRemoveFieldResponse,
+    CacheDictionaryRemoveFields,
+    CacheDictionaryRemoveFieldsResponse,
+    CacheDictionarySetField,
+    CacheDictionarySetFieldResponse,
+    CacheDictionarySetFields,
+    CacheDictionarySetFieldsResponse,
+)
 from .list_data import (
     CacheListConcatenateBack,
     CacheListConcatenateBackResponse,

--- a/src/momento/responses/dictionary_data/__init__.py
+++ b/src/momento/responses/dictionary_data/__init__.py
@@ -1,0 +1,29 @@
+from .dictionary_fetch import CacheDictionaryFetch, CacheDictionaryFetchResponse
+from .dictionary_get_field import (
+    CacheDictionaryGetField,
+    CacheDictionaryGetFieldResponse,
+)
+from .dictionary_get_fields import (
+    CacheDictionaryGetFields,
+    CacheDictionaryGetFieldsResponse,
+)
+from .dictionary_increment import (
+    CacheDictionaryIncrement,
+    CacheDictionaryIncrementResponse,
+)
+from .dictionary_remove_field import (
+    CacheDictionaryRemoveField,
+    CacheDictionaryRemoveFieldResponse,
+)
+from .dictionary_remove_fields import (
+    CacheDictionaryRemoveFields,
+    CacheDictionaryRemoveFieldsResponse,
+)
+from .dictionary_set_field import (
+    CacheDictionarySetField,
+    CacheDictionarySetFieldResponse,
+)
+from .dictionary_set_fields import (
+    CacheDictionarySetFields,
+    CacheDictionarySetFieldsResponse,
+)

--- a/src/momento/responses/dictionary_data/dictionary_fetch.py
+++ b/src/momento/responses/dictionary_data/dictionary_fetch.py
@@ -1,0 +1,71 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+from momento.typing import TDictionaryBytesBytes, TDictionaryStrBytes, TDictionaryStrStr
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionaryFetchResponse(CacheResponse):
+    """Response type for a `dictionary_fetch` request. Its subtypes are:
+
+    - `CacheDictionaryFetch.Hit`
+    - `CacheDictionaryFetch.Miss`
+    - `CacheDictionaryFetch.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionaryFetch(ABC):
+    """Groups all `CacheDictionaryFetchResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Hit(CacheDictionaryFetchResponse):
+        """Indicates the dictionary exists and its items were fetched."""
+
+        value_dictionary_bytes_bytes: TDictionaryBytesBytes
+        """The items for the fetched dictionary, as a mapping from bytes to bytes.
+
+        Returns:
+            TDictionaryBytesBytes
+        """
+
+        @property
+        def value_dictionary_string_bytes(self) -> TDictionaryStrBytes:
+            """The items for the fetched dictionary, as a mapping from utf-8 encoded strings to bytes.
+
+            Returns:
+                TDictionaryStrBytes
+            """
+
+            return {k.decode("utf-8"): v for k, v in self.value_dictionary_bytes_bytes.items()}
+
+        @property
+        def value_dictionary_string_string(self) -> TDictionaryStrStr:
+            """The items for the fetched dictionary, as a mapping from utf-8 encoded strings to utf-8 encoded strings.
+
+            Returns:
+                TDictionaryStrStr
+            """
+
+            return {k.decode("utf-8"): v.decode("utf-8") for k, v in self.value_dictionary_bytes_bytes.items()}
+
+    @dataclass
+    class Miss(CacheDictionaryFetchResponse):
+        """Indicates the dictionary does not exist."""
+
+    @dataclass
+    class Error(CacheDictionaryFetchResponse, ErrorResponseMixin):
+        """Indicates an error occured in the request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_get_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_field.py
@@ -29,6 +29,18 @@ class CacheDictionaryGetField(ABC):
         """The value returned from the cache for the specified field. Use the
         `value_string` property to access the value as a string."""
 
+        field_bytes: bytes
+        """The dictionary field that was queried."""
+
+        @property
+        def field_string(self) -> str:
+            """Convert the bytes `field` to a UTF-8 string
+
+            Returns:
+                str: UTF-8 representation of the `field`
+            """
+            return self.field_bytes.decode("utf-8")
+
     @dataclass
     class Miss(CacheDictionaryGetFieldResponse):
         """Indicates the dictionary or dictionary field does not exist."""

--- a/src/momento/responses/dictionary_data/dictionary_get_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_field.py
@@ -7,34 +7,34 @@ from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 
 
-class CacheGetResponse(CacheResponse):
-    """Parent response type for a cache `get` request. Its subtypes are:
+class CacheDictionaryGetFieldResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_get_field` request. Its subtypes are:
 
-    - `CacheGet.Hit`
-    - `CacheGet.Miss`
-    - `CacheGet.Error`
+    - `CacheDictionaryGetField.Hit`
+    - `CacheDictionaryGetField.Miss`
+    - `CacheDictionaryGetField.Error`
 
     See `SimpleCacheClient` for how to work with responses.
     """
 
 
-class CacheGet(ABC):
-    """Groups all `CacheGetResponse` derived types under a common namespace."""
+class CacheDictionaryGetField(ABC):
+    """Groups all `CacheDictionaryGetFieldResponse` derived types under a common namespace."""
 
     @dataclass
-    class Hit(CacheGetResponse, ValueStringMixin):
+    class Hit(CacheDictionaryGetFieldResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 
         value_bytes: bytes
-        """The value returned from the cache for the specified key. Use the
+        """The value returned from the cache for the specified field. Use the
         `value_string` property to access the value as a string."""
 
     @dataclass
-    class Miss(CacheGetResponse):
-        """Contains the results of a cache miss"""
+    class Miss(CacheDictionaryGetFieldResponse):
+        """Indicates the dictionary or dictionary field does not exist."""
 
     @dataclass
-    class Error(CacheGetResponse, ErrorResponseMixin):
+    class Error(CacheDictionaryGetFieldResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -35,8 +35,6 @@ class CacheDictionaryGetFields(ABC):
         """The value returned from the cache for the specified field. Use the
         `value_string` property to access the value as a string."""
 
-        fields: List[bytes]
-
         @property
         def value_dictionary_bytes_bytes(self) -> TDictionaryBytesBytes:
             """The items for the dictionary fields, as a mapping from bytes to bytes.
@@ -45,8 +43,8 @@ class CacheDictionaryGetFields(ABC):
                 TDictionaryBytesBytes
             """
             return {
-                field: response.value_bytes
-                for field, response in zip(self.fields, self.responses)
+                response.field_bytes: response.value_bytes
+                for response in self.responses
                 if isinstance(response, CacheDictionaryGetField.Hit)
             }
 
@@ -58,8 +56,8 @@ class CacheDictionaryGetFields(ABC):
                 TDictionaryStrBytes
             """
             return {
-                field.decode("utf-8"): response.value_bytes
-                for field, response in zip(self.fields, self.responses)
+                response.field_string: response.value_bytes
+                for response in self.responses
                 if isinstance(response, CacheDictionaryGetField.Hit)
             }
 
@@ -71,8 +69,8 @@ class CacheDictionaryGetFields(ABC):
                 TDictionaryStrStr
             """
             return {
-                field.decode("utf-8"): response.value_string
-                for field, response in zip(self.fields, self.responses)
+                response.field_string: response.value_string
+                for response in self.responses
                 if isinstance(response, CacheDictionaryGetField.Hit)
             }
 

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -3,7 +3,12 @@ from dataclasses import dataclass
 from typing import List
 
 from momento.errors import SdkException
-from momento.typing import TDictionaryBytesBytes, TDictionaryStrBytes, TDictionaryStrStr
+from momento.typing import (
+    TDictionaryBytesBytes,
+    TDictionaryBytesStr,
+    TDictionaryStrBytes,
+    TDictionaryStrStr,
+)
 
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
@@ -44,6 +49,19 @@ class CacheDictionaryGetFields(ABC):
             """
             return {
                 response.field_bytes: response.value_bytes
+                for response in self.responses
+                if isinstance(response, CacheDictionaryGetField.Hit)
+            }
+
+        @property
+        def value_dictionary_bytes_string(self) -> TDictionaryBytesStr:
+            """The items for the dictionary fields, as a mapping from bytes to utf-8 encoded strings.
+
+            Returns:
+                TDictionaryBytesStr
+            """
+            return {
+                response.field_bytes: response.value_string
                 for response in self.responses
                 if isinstance(response, CacheDictionaryGetField.Hit)
             }

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -1,0 +1,94 @@
+from abc import ABC
+from dataclasses import dataclass
+from typing import List
+
+from momento.errors import SdkException
+from momento.typing import TDictionaryBytesBytes, TDictionaryStrBytes, TDictionaryStrStr
+
+from ..mixins import ErrorResponseMixin, ValueStringMixin
+from ..response import CacheResponse
+from .dictionary_get_field import (
+    CacheDictionaryGetField,
+    CacheDictionaryGetFieldResponse,
+)
+
+
+class CacheDictionaryGetFieldsResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_get_fields` request. Its subtypes are:
+
+    - `CacheDictionaryGetFields.Hit`
+    - `CacheDictionaryGetFields.Miss`
+    - `CacheDictionaryGetFields.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionaryGetFields(ABC):
+    """Groups all `CacheDictionaryGetFieldsResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Hit(CacheDictionaryGetFieldsResponse, ValueStringMixin):
+        """Contains the result of a cache hit."""
+
+        responses: List[CacheDictionaryGetFieldResponse]
+        """The value returned from the cache for the specified field. Use the
+        `value_string` property to access the value as a string."""
+
+        fields: List[bytes]
+
+        @property
+        def value_dictionary_bytes_bytes(self) -> TDictionaryBytesBytes:
+            """The items for the dictionary fields, as a mapping from bytes to bytes.
+
+            Returns:
+                TDictionaryBytesBytes
+            """
+            return {
+                field: response.value_bytes
+                for field, response in zip(self.fields, self.responses)
+                if isinstance(response, CacheDictionaryGetField.Hit)
+            }
+
+        @property
+        def value_dictionary_string_bytes(self) -> TDictionaryStrBytes:
+            """The items for the dictionary fields, as a mapping from utf-8 encoded strings to bytes.
+
+            Returns:
+                TDictionaryStrBytes
+            """
+            return {
+                field.decode("utf-8"): response.value_bytes
+                for field, response in zip(self.fields, self.responses)
+                if isinstance(response, CacheDictionaryGetField.Hit)
+            }
+
+        @property
+        def value_dictionary_string_string(self) -> TDictionaryStrStr:
+            """The items for the dictionary fields, as a mapping from utf-8 encoded strings to utf-8 encoded strings.
+
+            Returns:
+                TDictionaryStrStr
+            """
+            return {
+                field.decode("utf-8"): response.value_string
+                for field, response in zip(self.fields, self.responses)
+                if isinstance(response, CacheDictionaryGetField.Hit)
+            }
+
+    @dataclass
+    class Miss(CacheDictionaryGetFieldsResponse):
+        """Indicates the dictionary does not exist."""
+
+    @dataclass
+    class Error(CacheDictionaryGetFieldsResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_increment.py
+++ b/src/momento/responses/dictionary_data/dictionary_increment.py
@@ -1,0 +1,41 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionaryIncrementResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_increment` request. Its subtypes are:
+
+    - `CacheDictionaryIncrement.Success`
+    - `CacheDictionaryIncrement.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionaryIncrement(ABC):
+    """Groups all `CacheDictionaryIncrementResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheDictionaryIncrementResponse):
+        """Indicates the request was successful."""
+
+        value: int
+        """The value of the field post-increment."""
+
+    @dataclass
+    class Error(CacheDictionaryIncrementResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_remove_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_field.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionaryRemoveFieldResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_remove_field` request. Its subtypes are:
+
+    - `CacheDictionaryRemoveField.Success`
+    - `CacheDictionaryRemoveField.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionaryRemoveField(ABC):
+    """Groups all `CacheDictionaryRemoveFieldResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheDictionaryRemoveFieldResponse):
+        """Indicates the request was successful."""
+
+    @dataclass
+    class Error(CacheDictionaryRemoveFieldResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_remove_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_fields.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionaryRemoveFieldsResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_remove_fields` request. Its subtypes are:
+
+    - `CacheDictionaryRemoveFields.Success`
+    - `CacheDictionaryRemoveFields.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionaryRemoveFields(ABC):
+    """Groups all `CacheDictionaryRemoveFieldsResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheDictionaryRemoveFieldsResponse):
+        """Indicates the request was successful."""
+
+    @dataclass
+    class Error(CacheDictionaryRemoveFieldsResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_set_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_field.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionarySetFieldResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_set_field` request. Its subtypes are:
+
+    - `CacheDictionarySetField.Success`
+    - `CacheDictionarySetField.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionarySetField(ABC):
+    """Groups all `CacheDictionarySetFieldResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheDictionarySetFieldResponse):
+        """Indicates the request was successful."""
+
+    @dataclass
+    class Error(CacheDictionarySetFieldResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_set_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_fields.py
@@ -1,0 +1,38 @@
+from abc import ABC
+from dataclasses import dataclass
+
+from momento.errors import SdkException
+
+from ..mixins import ErrorResponseMixin
+from ..response import CacheResponse
+
+
+class CacheDictionarySetFieldsResponse(CacheResponse):
+    """Parent response type for a cache `dictionary_set_fields` request. Its subtypes are:
+
+    - `CacheDictionarySetFields.Success`
+    - `CacheDictionarySetFields.Error`
+
+    See `SimpleCacheClient` for how to work with responses.
+    """
+
+
+class CacheDictionarySetFields(ABC):
+    """Groups all `CacheDictionarySetFieldsResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(CacheDictionarySetFieldsResponse):
+        """Indicates the request was successful."""
+
+    @dataclass
+    class Error(CacheDictionarySetFieldsResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request:
+
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """
+
+        _error: SdkException
+
+        def __init__(self, _error: SdkException):
+            self._error = _error

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -36,6 +36,14 @@ except ImportError as e:
 
 from momento.responses import (
     CacheDeleteResponse,
+    CacheDictionaryFetchResponse,
+    CacheDictionaryGetFieldResponse,
+    CacheDictionaryGetFieldsResponse,
+    CacheDictionaryIncrementResponse,
+    CacheDictionaryRemoveFieldResponse,
+    CacheDictionaryRemoveFieldsResponse,
+    CacheDictionarySetFieldResponse,
+    CacheDictionarySetFieldsResponse,
     CacheGetResponse,
     CacheListConcatenateBackResponse,
     CacheListConcatenateFrontResponse,
@@ -48,7 +56,18 @@ from momento.responses import (
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )
-from momento.typing import TCacheName, TListName, TListValues, TScalarKey, TScalarValue
+from momento.typing import (
+    TCacheName,
+    TDictionaryField,
+    TDictionaryFields,
+    TDictionaryItems,
+    TDictionaryName,
+    TDictionaryValue,
+    TListName,
+    TListValues,
+    TScalarKey,
+    TScalarValue,
+)
 
 
 class SimpleCacheClient:
@@ -135,12 +154,6 @@ class SimpleCacheClient:
 
         Returns:
             CreateCacheResponse:
-
-            This response is resolved to one of:
-
-            - `CreateCache.Success`
-            - `CreateCache.AlreadyExists`
-            - `CreateCache.Error`
         """
         return self._control_client.create_cache(cache_name)
 
@@ -152,11 +165,6 @@ class SimpleCacheClient:
 
         Returns:
             DeleteCacheResponse:
-
-            This response is resolved to one of:
-
-            - `DeleteCache.Success`
-            - `DeleteCache.Error`
         """
         return self._control_client.delete_cache(cache_name)
 
@@ -168,11 +176,6 @@ class SimpleCacheClient:
 
         Returns:
             ListCachesResponse:
-
-            This response is resolved to one of:
-
-            - `ListCaches.Success`
-            - `ListCaches.Error`
         """
         return self._control_client.list_caches(next_token)
 
@@ -237,11 +240,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheSetResponse:
-
-            This response is resolved to one of:
-
-            - `CacheSet.Success`
-            - `CacheSet.Error`
         """
         return self._data_client.set(cache_name, key, value, ttl)
 
@@ -254,12 +252,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheGetResponse:
-
-            This response is resolved to one of:
-
-            - `CacheGet.Hit`
-            - `CacheGet.Miss`
-            - `CacheGet.Error`
         """
         return self._data_client.get(cache_name, key)
 
@@ -272,15 +264,157 @@ class SimpleCacheClient:
 
         Returns:
             CacheDeleteResponse:
-
-            This response is resolved to one of:
-
-            - `CacheDelete.Success`
-            - `CacheDelete.Error`
         """
         return self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
+    def dictionary_fetch(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName
+    ) -> CacheDictionaryFetchResponse:
+        """Fetch the entire dictionary from the cache.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The name of the dictionary to fetch.
+
+        Returns:
+            CacheDictionaryFetchResponse: result of the fetch operation and the associated dictionary.
+        """
+        pass
+
+    def dictionary_get_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheDictionaryGetFieldResponse:
+        """Get the cache value stored for the given dictionary and field.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The dictionary to lookup.
+            field (TDictionaryField): The field in the dictionary to lookup.
+
+        Returns:
+            CacheDictionaryGetFieldResponse: the status and value for the field.
+        """
+        pass
+
+    def dictionary_get_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> CacheDictionaryGetFieldsResponse:
+        """Get several values from a dictionary.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The dictionary to lookup.
+            fields (TDictionaryFields): The fields in the dictionary to lookup.
+
+        Returns:
+            CacheDictionaryGetFieldsResponse: the status and associated value for each field.
+        """
+        pass
+
+    def dictionary_increment(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        field: TDictionaryField,
+        amount: int = 1,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> CacheDictionaryIncrementResponse:
+        """Add an integer quantity to a dictionary value.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to store the dictionary in.
+            dictionary_name (TDictionaryName): Name of the dictionary to increment in.
+            field (TDictionaryField): The field to increment.
+            amount (int, optional): The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL
+                used when initializing a cache client. Defaults to client TTL.
+                Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionaryIncrementResponse: result of the increment operation.
+        """
+        pass
+
+    def dictionary_set_field(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        field: TDictionaryField,
+        value: TDictionaryValue,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> CacheDictionarySetFieldResponse:
+        """Set the dictionary field to a value with a given time to live (TTL) seconds.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to store the dictionary in.
+            dictionary_name (TDictionaryName): Name of the dictionary to set.
+            field (TDictionaryField): The field in the dictionary to set.
+            value (TDictionaryValue): The value to be stored.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache.
+                This TTL takes precedence over the TTL used when initializing a cache client.
+                Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionarySetFieldResponse: result of the set operation.
+        """
+        pass
+
+    def dictionary_set_fields(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        items: TDictionaryItems,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> CacheDictionarySetFieldsResponse:
+        """Set several dictionary field-value pairs in the cache.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to set.
+            items (TDictionaryItems): Field value pairs to store.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache.
+                This TTL takes precedence over the TTL used when initializing a cache client.
+                Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionarySetFieldsResponse: result of the set fields operation.
+        """
+        pass
+
+    def dictionary_remove_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheDictionaryRemoveFieldResponse:
+        """Remove a field from a dictionary.
+
+        Performs a no-op if the dictionary or field do not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
+            field (TDictionaryField): Name of the field to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldResponse: result of the remove operation.
+        """
+        pass
+
+    def dictionary_remove_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> CacheDictionaryRemoveFieldsResponse:
+        """Remove fields from a dictionary.
+
+        Performs a no-op if the dictionary or a particular field does not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
+            fields (TDictionaryFields): The fields to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
+        """
+        pass
 
     # LIST COLLECTION METHODS
     def list_concatenate_back(
@@ -304,11 +438,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheListConcatenateBackResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListConcatenateBack.Success`
-            - `CacheListConcatenateBack.Error`
         """
 
         return self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
@@ -334,11 +463,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheListConcatenateFrontResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListConcatenateFront.Success`
-            - `CacheListConcatenateFront.Error`
         """
 
         return self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
@@ -353,12 +477,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheListFetchResponse:
-
-            This response is resolved to one of:
-
-            - `CacheListFetch.Hit`
-            - `CacheListFetch.Miss`
-            - `CacheListFetch.Error`
         """
 
         return self._data_client.list_fetch(cache_name, list_name)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -336,6 +336,40 @@ class SimpleCacheClient:
         """
         pass
 
+    def dictionary_remove_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheDictionaryRemoveFieldResponse:
+        """Remove a field from a dictionary.
+
+        Performs a no-op if the dictionary or field do not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
+            field (TDictionaryField): Name of the field to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldResponse: result of the remove operation.
+        """
+        pass
+
+    def dictionary_remove_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> CacheDictionaryRemoveFieldsResponse:
+        """Remove fields from a dictionary.
+
+        Performs a no-op if the dictionary or a particular field does not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
+            fields (TDictionaryFields): The fields to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
+        """
+        pass
+
     def dictionary_set_field(
         self,
         cache_name: TCacheName,
@@ -379,40 +413,6 @@ class SimpleCacheClient:
 
         Returns:
             CacheDictionarySetFieldsResponse: result of the set fields operation.
-        """
-        pass
-
-    def dictionary_remove_field(
-        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
-    ) -> CacheDictionaryRemoveFieldResponse:
-        """Remove a field from a dictionary.
-
-        Performs a no-op if the dictionary or field do not exist.
-
-        Args:
-            cache_name (TCacheName): Name of the cache to perform the lookup in.
-            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
-            field (TDictionaryField): Name of the field to remove from the dictionary.
-
-        Returns:
-            CacheDictionaryRemoveFieldResponse: result of the remove operation.
-        """
-        pass
-
-    def dictionary_remove_fields(
-        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
-    ) -> CacheDictionaryRemoveFieldsResponse:
-        """Remove fields from a dictionary.
-
-        Performs a no-op if the dictionary or a particular field does not exist.
-
-        Args:
-            cache_name (TCacheName): Name of the cache to perform the lookup in.
-            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
-            fields (TDictionaryFields): The fields to remove from the dictionary.
-
-        Returns:
-            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
         """
         pass
 

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -48,7 +48,18 @@ from momento.responses import (
     ListSigningKeysResponse,
     RevokeSigningKeyResponse,
 )
-from momento.typing import TCacheName, TListName, TListValues, TScalarKey, TScalarValue
+from momento.typing import (
+    TCacheName,
+    TDictionaryField,
+    TDictionaryFields,
+    TDictionaryItems,
+    TDictionaryName,
+    TDictionaryValue,
+    TListName,
+    TListValues,
+    TScalarKey,
+    TScalarValue,
+)
 
 
 class SimpleCacheClientAsync:
@@ -249,28 +260,56 @@ class SimpleCacheClientAsync:
         return await self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
-    async def dictionary_fetch(self) -> None:
+    async def dictionary_fetch(self, cache_name: TCacheName, dictionary_name: TDictionaryName) -> None:
         pass
 
-    async def dictionary_get_field(self) -> None:
+    async def dictionary_get_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> None:
         pass
 
-    async def dictionary_get_fields(self) -> None:
+    async def dictionary_get_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> None:
         pass
 
-    async def dictionary_increment(self) -> None:
+    async def dictionary_increment(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        field: TDictionaryField,
+        amount: int = 1,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> None:
         pass
 
-    async def dictionary_set_field(self) -> None:
+    async def dictionary_set_field(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        field: TDictionaryField,
+        value: TDictionaryValue,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> None:
         pass
 
-    async def dictionary_set_fields(self) -> None:
+    async def dictionary_set_fields(
+        self,
+        cache_name: TCacheName,
+        dictionary_name: TDictionaryName,
+        items: TDictionaryItems,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
+    ) -> None:
         pass
 
-    async def dictionary_remove_field(self) -> None:
+    async def dictionary_remove_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> None:
         pass
 
-    async def dictionary_remove_fields(self) -> None:
+    async def dictionary_remove_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> None:
         pass
 
     # LIST COLLECTION METHODS

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -36,6 +36,14 @@ except ImportError as e:
 
 from momento.responses import (
     CacheDeleteResponse,
+    CacheDictionaryFetchResponse,
+    CacheDictionaryGetFieldResponse,
+    CacheDictionaryGetFieldsResponse,
+    CacheDictionaryIncrementResponse,
+    CacheDictionaryRemoveFieldResponse,
+    CacheDictionaryRemoveFieldsResponse,
+    CacheDictionarySetFieldResponse,
+    CacheDictionarySetFieldsResponse,
     CacheGetResponse,
     CacheListConcatenateBackResponse,
     CacheListConcatenateFrontResponse,
@@ -260,17 +268,19 @@ class SimpleCacheClientAsync:
         return await self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
-    async def dictionary_fetch(self, cache_name: TCacheName, dictionary_name: TDictionaryName) -> None:
+    async def dictionary_fetch(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName
+    ) -> CacheDictionaryFetchResponse:
         pass
 
     async def dictionary_get_field(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
-    ) -> None:
+    ) -> CacheDictionaryGetFieldResponse:
         pass
 
     async def dictionary_get_fields(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
-    ) -> None:
+    ) -> CacheDictionaryGetFieldsResponse:
         pass
 
     async def dictionary_increment(
@@ -280,7 +290,7 @@ class SimpleCacheClientAsync:
         field: TDictionaryField,
         amount: int = 1,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> None:
+    ) -> CacheDictionaryIncrementResponse:
         pass
 
     async def dictionary_set_field(
@@ -290,7 +300,7 @@ class SimpleCacheClientAsync:
         field: TDictionaryField,
         value: TDictionaryValue,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> None:
+    ) -> CacheDictionarySetFieldResponse:
         pass
 
     async def dictionary_set_fields(
@@ -299,17 +309,17 @@ class SimpleCacheClientAsync:
         dictionary_name: TDictionaryName,
         items: TDictionaryItems,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> None:
+    ) -> CacheDictionarySetFieldsResponse:
         pass
 
     async def dictionary_remove_field(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
-    ) -> None:
+    ) -> CacheDictionaryRemoveFieldResponse:
         pass
 
     async def dictionary_remove_fields(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
-    ) -> None:
+    ) -> CacheDictionaryRemoveFieldsResponse:
         pass
 
     # LIST COLLECTION METHODS

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -336,6 +336,40 @@ class SimpleCacheClientAsync:
         """
         pass
 
+    async def dictionary_remove_field(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheDictionaryRemoveFieldResponse:
+        """Remove a field from a dictionary.
+
+        Performs a no-op if the dictionary or field do not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
+            field (TDictionaryField): Name of the field to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldResponse: result of the remove operation.
+        """
+        pass
+
+    async def dictionary_remove_fields(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
+    ) -> CacheDictionaryRemoveFieldsResponse:
+        """Remove fields from a dictionary.
+
+        Performs a no-op if the dictionary or a particular field does not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
+            fields (TDictionaryFields): The fields to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
+        """
+        pass
+
     async def dictionary_set_field(
         self,
         cache_name: TCacheName,
@@ -379,40 +413,6 @@ class SimpleCacheClientAsync:
 
         Returns:
             CacheDictionarySetFieldsResponse: result of the set fields operation.
-        """
-        pass
-
-    async def dictionary_remove_field(
-        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
-    ) -> CacheDictionaryRemoveFieldResponse:
-        """Remove a field from a dictionary.
-
-        Performs a no-op if the dictionary or field do not exist.
-
-        Args:
-            cache_name (TCacheName): Name of the cache to perform the lookup in.
-            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
-            field (TDictionaryField): Name of the field to remove from the dictionary.
-
-        Returns:
-            CacheDictionaryRemoveFieldResponse: result of the remove operation.
-        """
-        pass
-
-    async def dictionary_remove_fields(
-        self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
-    ) -> CacheDictionaryRemoveFieldsResponse:
-        """Remove fields from a dictionary.
-
-        Performs a no-op if the dictionary or a particular field does not exist.
-
-        Args:
-            cache_name (TCacheName): Name of the cache to perform the lookup in.
-            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
-            fields (TDictionaryFields): The fields to remove from the dictionary.
-
-        Returns:
-            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
         """
         pass
 

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -271,16 +271,45 @@ class SimpleCacheClientAsync:
     async def dictionary_fetch(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> CacheDictionaryFetchResponse:
+        """Fetch the entire dictionary from the cache.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The name of the dictionary to fetch.
+
+        Returns:
+            CacheDictionaryFetchResponse: result of the fetch operation and the associated dictionary.
+        """
         pass
 
     async def dictionary_get_field(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
     ) -> CacheDictionaryGetFieldResponse:
+        """Get the cache value stored for the given dictionary and field.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The dictionary to lookup.
+            field (TDictionaryField): The field in the dictionary to lookup.
+
+        Returns:
+            CacheDictionaryGetFieldResponse: the status and value for the field.
+        """
         pass
 
     async def dictionary_get_fields(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
     ) -> CacheDictionaryGetFieldsResponse:
+        """Get several values from a dictionary.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): The dictionary to lookup.
+            fields (TDictionaryFields): The fields in the dictionary to lookup.
+
+        Returns:
+            CacheDictionaryGetFieldsResponse: the status and associated value for each field.
+        """
         pass
 
     async def dictionary_increment(
@@ -291,6 +320,19 @@ class SimpleCacheClientAsync:
         amount: int = 1,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionaryIncrementResponse:
+        """Add an integer quantity to a dictionary value.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to store the dictionary in.
+            dictionary_name (TDictionaryName): Name of the dictionary to increment in.
+            field (TDictionaryField): The field to increment.
+            amount (int, optional): The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL
+                used when initializing a cache client. Defaults to client TTL. Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionaryIncrementResponse: result of the increment operation.
+        """
         pass
 
     async def dictionary_set_field(
@@ -301,6 +343,18 @@ class SimpleCacheClientAsync:
         value: TDictionaryValue,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldResponse:
+        """Set the dictionary field to a value with a given time to live (TTL) seconds.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to store the dictionary in.
+            dictionary_name (TDictionaryName): Name of the dictionary to set.
+            field (TDictionaryField): The field in the dictionary to set.
+            value (TDictionaryValue): The value to be stored.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionarySetFieldResponse: result of the set operation.
+        """
         pass
 
     async def dictionary_set_fields(
@@ -310,16 +364,51 @@ class SimpleCacheClientAsync:
         items: TDictionaryItems,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldsResponse:
+        """Set several dictionary field-value pairs in the cache.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to set.
+            items (TDictionaryItems): Field value pairs to store.
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to CollectionTtl.from_cache_ttl().
+
+        Returns:
+            CacheDictionarySetFieldsResponse: result of the set fields operation.
+        """
         pass
 
     async def dictionary_remove_field(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
     ) -> CacheDictionaryRemoveFieldResponse:
+        """Remove a field from a dictionary.
+
+        Performs a no-op if the dictionary or field do not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the field from.
+            field (TDictionaryField): Name of the field to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldResponse: result of the remove operation.
+        """
         pass
 
     async def dictionary_remove_fields(
         self, cache_name: TCacheName, dictionary_name: TDictionaryName, fields: TDictionaryFields
     ) -> CacheDictionaryRemoveFieldsResponse:
+        """Remove fields from a dictionary.
+
+        Performs a no-op if the dictionary or a particular field does not exist.
+
+        Args:
+            cache_name (TCacheName): Name of the cache to perform the lookup in.
+            dictionary_name (TDictionaryName): Name of the dictionary to remove the fields from.
+            fields (TDictionaryFields): The fields to remove from the dictionary.
+
+        Returns:
+            CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
+        """
         pass
 
     # LIST COLLECTION METHODS

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -328,7 +328,8 @@ class SimpleCacheClientAsync:
             field (TDictionaryField): The field to increment.
             amount (int, optional): The quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
             ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL
-                used when initializing a cache client. Defaults to client TTL. Defaults to CollectionTtl.from_cache_ttl().
+                used when initializing a cache client. Defaults to client TTL.
+                Defaults to CollectionTtl.from_cache_ttl().
 
         Returns:
             CacheDictionaryIncrementResponse: result of the increment operation.
@@ -350,7 +351,9 @@ class SimpleCacheClientAsync:
             dictionary_name (TDictionaryName): Name of the dictionary to set.
             field (TDictionaryField): The field in the dictionary to set.
             value (TDictionaryValue): The value to be stored.
-            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to CollectionTtl.from_cache_ttl().
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache.
+                This TTL takes precedence over the TTL used when initializing a cache client.
+                Defaults to CollectionTtl.from_cache_ttl().
 
         Returns:
             CacheDictionarySetFieldResponse: result of the set operation.
@@ -370,7 +373,9 @@ class SimpleCacheClientAsync:
             cache_name (TCacheName): Name of the cache to perform the lookup in.
             dictionary_name (TDictionaryName): Name of the dictionary to set.
             items (TDictionaryItems): Field value pairs to store.
-            ttl (CollectionTtl, optional): TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to CollectionTtl.from_cache_ttl().
+            ttl (CollectionTtl, optional): TTL for the dictionary in cache.
+                This TTL takes precedence over the TTL used when initializing a cache client.
+                Defaults to CollectionTtl.from_cache_ttl().
 
         Returns:
             CacheDictionarySetFieldsResponse: result of the set fields operation.

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -249,6 +249,29 @@ class SimpleCacheClientAsync:
         return await self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
+    async def dictionary_fetch(self) -> None:
+        pass
+
+    async def dictionary_get_field(self) -> None:
+        pass
+
+    async def dictionary_get_fields(self) -> None:
+        pass
+
+    async def dictionary_increment(self) -> None:
+        pass
+
+    async def dictionary_set_field(self) -> None:
+        pass
+
+    async def dictionary_set_fields(self) -> None:
+        pass
+
+    async def dictionary_remove_field(self) -> None:
+        pass
+
+    async def dictionary_remove_fields(self) -> None:
+        pass
 
     # LIST COLLECTION METHODS
     async def list_concatenate_back(

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Mapping, Sequence, Union
 
 TCacheName = str
 
@@ -10,6 +10,11 @@ TScalarValue = Union[str, bytes]
 TCollectionName = str
 
 # Dictionary Types
+TDictionaryName = TCollectionName
+TDictionaryField = Union[str, bytes]
+TDictionaryValue = Union[str, bytes]
+TDictionaryFields = Sequence[TDictionaryField]
+TDictionaryItems = Mapping[TDictionaryField, TDictionaryValue]
 
 # List Types
 TListName = TCollectionName

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping, Sequence, Union
+from typing import Dict, List, Mapping, Sequence, Union
 
 TCacheName = str
 
@@ -15,6 +15,9 @@ TDictionaryField = Union[str, bytes]
 TDictionaryValue = Union[str, bytes]
 TDictionaryFields = Sequence[TDictionaryField]
 TDictionaryItems = Mapping[TDictionaryField, TDictionaryValue]
+TDictionaryBytesBytes = Dict[bytes, bytes]
+TDictionaryStrBytes = Dict[str, bytes]
+TDictionaryStrStr = Dict[str, str]
 
 # List Types
 TListName = TCollectionName

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Mapping, Sequence, Union
+from typing import Dict, Iterable, List, Mapping, Union
 
 TCacheName = str
 
@@ -13,7 +13,7 @@ TCollectionName = str
 TDictionaryName = TCollectionName
 TDictionaryField = Union[str, bytes]
 TDictionaryValue = Union[str, bytes]
-TDictionaryFields = Sequence[TDictionaryField]
+TDictionaryFields = Iterable[TDictionaryField]
 TDictionaryItems = Mapping[TDictionaryField, TDictionaryValue]
 TDictionaryBytesBytes = Dict[bytes, bytes]
 TDictionaryBytesStr = Dict[bytes, str]

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -16,6 +16,7 @@ TDictionaryValue = Union[str, bytes]
 TDictionaryFields = Sequence[TDictionaryField]
 TDictionaryItems = Mapping[TDictionaryField, TDictionaryValue]
 TDictionaryBytesBytes = Dict[bytes, bytes]
+TDictionaryBytesStr = Dict[bytes, str]
 TDictionaryStrBytes = Dict[str, bytes]
 TDictionaryStrStr = Dict[str, str]
 


### PR DESCRIPTION
Stub out the dictionary API and document it; also implement port of response types. This covers:

- `dictionary_fetch`
- `dictionary_get_field`
- `dictionary_get_fields`
- `dictionary_increment`
- `dictionary_set_field`
- `dictionary_set_fields`
- `dictionary_remove_field`
- `dictionary_remove_fields`

API, documentation, and response types will be subject to change on implementation.
