### PR TITLE
feat: use modern python type hint syntax

### DIFF
--- a/src/momento/errors/error_converter.py
+++ b/src/momento/errors/error_converter.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Optional, Tuple, Type, Union
+from __future__ import annotations
+
+from typing import Optional, Tuple, Type
 
 import grpc
 from grpc.aio import Metadata
@@ -23,7 +25,7 @@ from momento.errors import (
     UnknownServiceException,
 )
 
-grpc_status_to_exception: Dict[grpc.StatusCode, Type[SdkException]] = {
+grpc_status_to_exception: dict[grpc.StatusCode, Type[SdkException]] = {
     grpc.StatusCode.INVALID_ARGUMENT: InvalidArgumentException,
     grpc.StatusCode.INTERNAL: InternalServerException,
     grpc.StatusCode.OUT_OF_RANGE: BadRequestException,
@@ -47,13 +49,14 @@ INTERNAL_SERVER_ERROR_MESSAGE = "Unexpected exception occurred while trying to f
 SDK_ERROR_MESSAGE = "SDK Failed to process the request."
 
 
-TMetadata = Union[Metadata, List[Tuple[str, str]]]
-"""Metadata in the asynchronous gRPC client is of type Metadata, while
-metadata in the synchronous client is a list of tuples. The types are isomorphic."""
-
-
-def convert_error(exception: Exception, transport_metadata: Optional[TMetadata] = None) -> SdkException:
+def convert_error(
+    exception: Exception, transport_metadata: Optional[Metadata | list[Tuple[str, str]]] = None
+) -> SdkException:
     """Convert a low-level exception raised by gRPC to a Momento `SdkException`
+
+    Note about the metadata type: Metadata in the asynchronous gRPC client is of
+    type Metadata, while metadata in the synchronous client is a list of tuples.
+    The types are isomorphic.
 
     Args:
         exception (Exception): Low-level (transport, server-side, validation) exception
@@ -88,7 +91,7 @@ def convert_error(exception: Exception, transport_metadata: Optional[TMetadata] 
     return UnknownException(SDK_ERROR_MESSAGE, None)
 
 
-def _synchronous_metadata_to_metadata(metadata: List[Tuple[str, str]]) -> Metadata:
+def _synchronous_metadata_to_metadata(metadata: list[Tuple[str, str]]) -> Metadata:
     """Represent synchronous client metadata as a `Metadata` object.
 
     Args:

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import collections.abc
 from datetime import timedelta
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple
 
 from momento.errors import InvalidArgumentException
 from momento.typing import (
@@ -42,7 +44,7 @@ def _validate_set_name(set_name: str) -> None:
 
 
 def _as_bytes(
-    data: Union[str, bytes],
+    data: str | bytes,
     error_message: Optional[str] = DEFAULT_STRING_CONVERSION_ERROR,
 ) -> bytes:
     if isinstance(data, str):
@@ -52,7 +54,7 @@ def _as_bytes(
     raise InvalidArgumentException(f"{error_message}{type(data)}")
 
 
-def _gen_iterable_as_bytes(values: TListValuesInput, error_message: str) -> Iterable[bytes]:
+def _gen_iterable_as_bytes(values: Iterable[str | bytes], error_message: str) -> Iterable[bytes]:
     if not isinstance(values, collections.abc.Iterable):
         raise InvalidArgumentException(f"{error_message}{type(values)}")
     for value in values:

--- a/src/momento/internal/aio/_add_header_client_interceptor.py
+++ b/src/momento/internal/aio/_add_header_client_interceptor.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Union
+from __future__ import annotations
+
+from typing import Callable
 
 import grpc
 from grpc.aio import ClientCallDetails, Metadata
@@ -17,8 +19,8 @@ class Header:
 class AddHeaderClientInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
     are_only_once_headers_sent = False
 
-    def __init__(self, headers: List[Header]):
-        self._headers_to_add_once: List[Header] = list(
+    def __init__(self, headers: list[Header]):
+        self._headers_to_add_once: list[Header] = list(
             filter(lambda header: header.name in header.once_only_headers, headers)
         )
         self.headers_to_add_every_time = list(
@@ -33,7 +35,7 @@ class AddHeaderClientInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
         ],
         client_call_details: grpc.aio._interceptor.ClientCallDetails,
         request: grpc.aio._typing.RequestType,
-    ) -> Union[grpc.aio._call.UnaryUnaryCall, grpc.aio._typing.ResponseType]:
+    ) -> grpc.aio._call.UnaryUnaryCall | grpc.aio._typing.ResponseType:
 
         new_client_call_details = sanitize_client_call_details(client_call_details)
 

--- a/src/momento/internal/aio/_retry_interceptor.py
+++ b/src/momento/internal/aio/_retry_interceptor.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable, List, Union
+from typing import Callable
 
 import grpc
 
@@ -17,7 +19,7 @@ RETRIES_ENABLED = True
 MAX_ATTEMPTS = 3
 
 
-RETRYABLE_STATUS_CODES: List[grpc.StatusCode] = [
+RETRYABLE_STATUS_CODES: list[grpc.StatusCode] = [
     # # including all the status codes for reference, but
     # # commenting out the ones we don't want to retry on for now.
     # grpc.StatusCode.OK,
@@ -47,7 +49,7 @@ LOGGER = logging.getLogger("retry-interceptor")
 # https://github.com/momentohq/client-sdk-javascript/issues/80
 # TODO: we need to add backoff/jitter for the retries:
 # https://github.com/momentohq/client-sdk-javascript/issues/81
-def get_retry_interceptor_if_enabled() -> List[grpc.aio.UnaryUnaryClientInterceptor]:
+def get_retry_interceptor_if_enabled() -> list[grpc.aio.UnaryUnaryClientInterceptor]:
     if not RETRIES_ENABLED:
         return []
 
@@ -63,7 +65,7 @@ class RetryInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
         ],
         client_call_details: grpc.aio._interceptor.ClientCallDetails,
         request: grpc.aio._typing.RequestType,
-    ) -> Union[grpc.aio._call.UnaryUnaryCall, grpc.aio._typing.ResponseType]:
+    ) -> grpc.aio._call.UnaryUnaryCall | grpc.aio._typing.ResponseType:
         for try_i in range(MAX_ATTEMPTS):
             call = await continuation(client_call_details, request)
             response_code = await call.code()

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
-from typing import Dict, List, Optional
+from typing import Optional
 
 from momento_wire_types.cacheclient_pb2 import (
     Miss,
@@ -287,7 +289,7 @@ class _ScsDataClient:
 
             type = response.WhichOneof("dictionary")
             if type == "found":
-                get_responses: List[CacheDictionaryGetFieldResponse] = []
+                get_responses: list[CacheDictionaryGetFieldResponse] = []
                 for field, get_response in zip(bytes_fields, response.found.items):
                     if get_response.result == Miss:
                         get_responses.append(CacheDictionaryGetField.Miss())
@@ -762,10 +764,10 @@ class _ScsDataClient:
             self._log_request_error("set_remove_elements", e)
             return CacheSetRemoveElements.Error(convert_error(e))
 
-    def _log_received_response(self, request_type: str, request_args: Dict[str, str]) -> None:
+    def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Received a {request_type} response for {request_args}")
 
-    def _log_issuing_request(self, request_type: str, request_args: Dict[str, str]) -> None:
+    def _log_issuing_request(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Issuing a {request_type} request with {request_args}")
 
     def _log_request_error(self, request_type: str, e: Exception) -> None:

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import grpc
 import momento_wire_types.cacheclient_pb2_grpc as cache_client
@@ -63,7 +63,7 @@ class _DataGrpcManager:
         return cache_client.ScsStub(self._secure_channel)
 
 
-def _interceptors(auth_token: str) -> List[grpc.aio.ClientInterceptor]:
+def _interceptors(auth_token: str) -> list[grpc.aio.ClientInterceptor]:
     headers = [
         Header("authorization", auth_token),
         Header("agent", f"python:{_ControlGrpcManager.version}"),

--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -12,9 +12,11 @@ code from the async code, we do the following transformations:
 - lift expressions from an await expression
 - perform adhoc name replacements
 """
+from __future__ import annotations
+
 import argparse
 import re
-from typing import List, Tuple, Union
+from typing import Tuple
 
 import libcst as cst
 
@@ -50,7 +52,7 @@ class AsyncToSyncTransformer(cst.CSTTransformer):
 
     def leave_ImportFrom(
         self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
-    ) -> Union[cst.BaseSmallStatement, cst.FlattenSentinel[cst.BaseSmallStatement], cst.RemovalSentinel]:
+    ) -> cst.BaseSmallStatement | cst.FlattenSentinel[cst.BaseSmallStatement] | cst.RemovalSentinel:
         if isinstance(original_node.names, cst.ImportStar):
             return original_node
         names = [import_alias for import_alias in original_node.names if import_alias.name.value != "Awaitable"]
@@ -60,7 +62,7 @@ class AsyncToSyncTransformer(cst.CSTTransformer):
 class NameReplacement(cst.CSTTransformer):
     """Applies regex-based substitutions to names in the AST."""
 
-    def __init__(self, substitutions: List[Tuple[str, str]]) -> None:
+    def __init__(self, substitutions: list[Tuple[str, str]]) -> None:
         """Instantiate a `NameReplacement`
 
         Args:
@@ -81,7 +83,7 @@ class NameReplacement(cst.CSTTransformer):
 class SimpleStringReplacement(cst.CSTTransformer):
     """Applies regex-based substitutions to simple strings in the AST."""
 
-    def __init__(self, substitutions: List[Tuple[str, str]]) -> None:
+    def __init__(self, substitutions: list[Tuple[str, str]]) -> None:
         """Instantiate a `SimpleStringReplacement`
 
         Args:
@@ -103,7 +105,7 @@ class SimpleStringReplacement(cst.CSTTransformer):
 class Pipeline:
     """Runs a list of `cst.CSTTransformer`s in sequence."""
 
-    def __init__(self, transformers: List[cst.CSTTransformer]) -> None:
+    def __init__(self, transformers: list[cst.CSTTransformer]) -> None:
         self.transformers = transformers
 
     def transform(self, input_module: cst.Module) -> cst.Module:

--- a/src/momento/internal/synchronous/_add_header_client_interceptor.py
+++ b/src/momento/internal/synchronous/_add_header_client_interceptor.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import collections
-from typing import Callable, List, TypeVar
+from typing import Callable, TypeVar
 
 import grpc
 
@@ -35,8 +37,8 @@ class AddHeaderClientInterceptor(grpc.UnaryUnaryClientInterceptor):
     def is_not_only_once_header(header: Header) -> bool:
         return header.name not in header.once_only_headers
 
-    def __init__(self, headers: List[Header]):
-        self._headers_to_add_once: List[Header] = list(filter(AddHeaderClientInterceptor.is_only_once_header, headers))
+    def __init__(self, headers: list[Header]):
+        self._headers_to_add_once: list[Header] = list(filter(AddHeaderClientInterceptor.is_only_once_header, headers))
         self.headers_to_add_every_time = list(filter(AddHeaderClientInterceptor.is_not_only_once_header, headers))
 
     def intercept_unary_unary(

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable, List, TypeVar, Union
+from typing import Callable, TypeVar
 
 import grpc
 
@@ -20,7 +22,7 @@ ResponseType = TypeVar("ResponseType")
 RETRIES_ENABLED = True
 MAX_ATTEMPTS = 3
 
-RETRYABLE_STATUS_CODES: List[grpc.StatusCode] = [
+RETRYABLE_STATUS_CODES: list[grpc.StatusCode] = [
     # # including all the status codes for reference, but
     # # commenting out the ones we don't want to retry on for now.
     # grpc.StatusCode.OK,
@@ -50,7 +52,7 @@ LOGGER = logging.getLogger("retry-interceptor")
 # https://github.com/momentohq/client-sdk-javascript/issues/80
 # TODO: we need to add backoff/jitter for the retries:
 # https://github.com/momentohq/client-sdk-javascript/issues/81
-def get_retry_interceptor_if_enabled() -> List[grpc.UnaryUnaryClientInterceptor]:
+def get_retry_interceptor_if_enabled() -> list[grpc.UnaryUnaryClientInterceptor]:
     if not RETRIES_ENABLED:
         return []
 
@@ -63,7 +65,7 @@ class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
         continuation: Callable[[grpc.ClientCallDetails, RequestType], InterceptorCall],
         client_call_details: grpc.ClientCallDetails,
         request: RequestType,
-    ) -> Union[InterceptorCall, ResponseType]:
+    ) -> InterceptorCall | ResponseType:
         for try_i in range(MAX_ATTEMPTS):
             call = continuation(client_call_details, request)
             response_code = call.code()  # type: ignore[attr-defined]  # noqa: F401

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
-from typing import Dict, List, Optional
+from typing import Optional
 
 from momento_wire_types.cacheclient_pb2 import (
     Miss,
@@ -287,7 +289,7 @@ class _ScsDataClient:
 
             type = response.WhichOneof("dictionary")
             if type == "found":
-                get_responses: List[CacheDictionaryGetFieldResponse] = []
+                get_responses: list[CacheDictionaryGetFieldResponse] = []
                 for field, get_response in zip(bytes_fields, response.found.items):
                     if get_response.result == Miss:
                         get_responses.append(CacheDictionaryGetField.Miss())
@@ -762,10 +764,10 @@ class _ScsDataClient:
             self._log_request_error("set_remove_elements", e)
             return CacheSetRemoveElements.Error(convert_error(e))
 
-    def _log_received_response(self, request_type: str, request_args: Dict[str, str]) -> None:
+    def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Received a {request_type} response for {request_args}")
 
-    def _log_issuing_request(self, request_type: str, request_args: Dict[str, str]) -> None:
+    def _log_issuing_request(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Issuing a {request_type} request with {request_args}")
 
     def _log_request_error(self, request_type: str, e: Exception) -> None:

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import grpc
 import momento_wire_types.cacheclient_pb2_grpc as cache_client
@@ -54,6 +54,6 @@ class _DataGrpcManager:
         return self._stub
 
 
-def _interceptors(auth_token: str) -> List[grpc.UnaryUnaryClientInterceptor]:
+def _interceptors(auth_token: str) -> list[grpc.UnaryUnaryClientInterceptor]:
     headers = [Header("authorization", auth_token), Header("agent", f"python:{_ControlGrpcManager.version}")]
     return [AddHeaderClientInterceptor(headers), *get_retry_interceptor_if_enabled()]

--- a/src/momento/internal/synchronous/_utilities.py
+++ b/src/momento/internal/synchronous/_utilities.py
@@ -1,5 +1,7 @@
-from typing import List, Tuple
+from __future__ import annotations
+
+from typing import Tuple
 
 
-def make_metadata(cache_name: str) -> List[Tuple[str, str]]:
+def make_metadata(cache_name: str) -> list[Tuple[str, str]]:
     return [("cache", cache_name)]

--- a/src/momento/requests/collection_ttl.py
+++ b/src/momento/requests/collection_ttl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Optional
@@ -41,7 +43,7 @@ class CollectionTtl:
         _validate_timedelta_ttl(ttl=self.ttl, field_name="ttl")
 
     @staticmethod
-    def from_cache_ttl() -> "CollectionTtl":
+    def from_cache_ttl() -> CollectionTtl:
         """The default way to handle TTLs for collections. The default TTL
         `timedelta` that was specified when instantiating the `SimpleCacheClient`
         will be used, and the TTL for the collection will be refreshed any
@@ -53,7 +55,7 @@ class CollectionTtl:
         return CollectionTtl(ttl=None, refresh_ttl=True)
 
     @staticmethod
-    def of(ttl: timedelta) -> "CollectionTtl":
+    def of(ttl: timedelta) -> CollectionTtl:
         """Constructs a CollectionTtl with the specified `timedelta`. TTL
         for the collection will be refreshed any time the collection is
         modified.
@@ -67,7 +69,7 @@ class CollectionTtl:
         return CollectionTtl(ttl=ttl)
 
     @staticmethod
-    def refresh_ttl_if_provided(ttl: Optional[timedelta] = None) -> "CollectionTtl":
+    def refresh_ttl_if_provided(ttl: Optional[timedelta] = None) -> CollectionTtl:
         """Constructs a `CollectionTtl` with the specified `timedelta`.
         Will only refresh if the TTL is provided (ie not `null`).
 
@@ -79,7 +81,7 @@ class CollectionTtl:
         """
         return CollectionTtl(ttl=ttl, refresh_ttl=ttl is not None)
 
-    def with_refresh_ttl_on_updates(self) -> "CollectionTtl":
+    def with_refresh_ttl_on_updates(self) -> CollectionTtl:
         """Specifies that the TTL for the collection should be refreshed when
         the collection is modified.  (This is the default behavior.)
 
@@ -88,7 +90,7 @@ class CollectionTtl:
         """
         return CollectionTtl(ttl=self.ttl, refresh_ttl=True)
 
-    def with_no_refresh_ttl_on_updates(self) -> "CollectionTtl":
+    def with_no_refresh_ttl_on_updates(self) -> CollectionTtl:
         """Specifies that the TTL for the collection should not be refreshed
         when the collection is modified.  Use this if you want to ensure
         that your collection expires at the originally specified time, even

--- a/src/momento/responses/control/list_caches.py
+++ b/src/momento/responses/control/list_caches.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC
 from dataclasses import dataclass
 from typing import List, Optional
@@ -60,7 +62,7 @@ class ListCaches(ABC):
         """A token to specify where to start paging. This is the `NextToken` from a previous response."""
 
         @staticmethod
-        def from_grpc_response(grpc_list_cache_response: _ListCachesResponse) -> "ListCaches.Success":  # type: ignore[misc] # noqa: E501
+        def from_grpc_response(grpc_list_cache_response: _ListCachesResponse) -> ListCaches.Success:  # type: ignore[misc] # noqa: E501
             """Initializes ListCacheResponse to handle list cache response.
 
             Args:

--- a/src/momento/responses/control/signing_keys.py
+++ b/src/momento/responses/control/signing_keys.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 
 class CreateSigningKeyResponse:
@@ -34,7 +36,7 @@ class CreateSigningKeyResponse:
     @staticmethod
     def from_grpc_response(  # type: ignore[misc]
         grpc_create_signing_key_response: Any, endpoint: str
-    ) -> "CreateSigningKeyResponse":
+    ) -> CreateSigningKeyResponse:
         key_id: str = json.loads(grpc_create_signing_key_response.key)["kid"]
         key: str = grpc_create_signing_key_response.key
         expires_at: datetime = datetime.fromtimestamp(grpc_create_signing_key_response.expires_at)
@@ -85,7 +87,7 @@ class SigningKey:
         return self._endpoint
 
     @staticmethod
-    def from_grpc_response(grpc_listed_signing_key: Any, endpoint: str) -> "SigningKey":  # type: ignore[misc]
+    def from_grpc_response(grpc_listed_signing_key: Any, endpoint: str) -> SigningKey:  # type: ignore[misc]
         key_id: str = grpc_listed_signing_key.key_id
         expires_at: datetime = datetime.fromtimestamp(grpc_listed_signing_key.expires_at)
         return SigningKey(key_id, expires_at, endpoint)
@@ -98,7 +100,7 @@ class SigningKey:
 
 
 class ListSigningKeysResponse:
-    def __init__(self, next_token: Optional[str], signing_keys: List[SigningKey]):
+    def __init__(self, next_token: Optional[str], signing_keys: list[SigningKey]):
         """Initializes ListSigningKeysResponse to handle list signing keys response.
 
         Args:
@@ -111,7 +113,7 @@ class ListSigningKeysResponse:
         """Returns next token."""
         return self._next_token
 
-    def signing_keys(self) -> List[SigningKey]:
+    def signing_keys(self) -> list[SigningKey]:
         """Returns all signing keys."""
         return self._signing_keys
 
@@ -122,7 +124,7 @@ class ListSigningKeysResponse:
         next_token: Optional[str] = (
             grpc_list_signing_keys_response.next_token if grpc_list_signing_keys_response.next_token != "" else None
         )
-        signing_keys: List[SigningKey] = [
+        signing_keys: list[SigningKey] = [
             SigningKey.from_grpc_response(signing_key, endpoint)
             for signing_key in grpc_list_signing_keys_response.signing_key
         ]

--- a/src/momento/typing.py
+++ b/src/momento/typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterable, List, Mapping, Set, Union
 
 TCacheName = str
@@ -19,8 +21,7 @@ TDictionaryValue = TMomentoValue
 TDictionaryFields = Iterable[TDictionaryField]
 TDictionaryItems = Union[
     Mapping[TDictionaryField, TDictionaryValue],
-    # Mapping[Union[bytes, str], Union[bytes, str]] doesn't accept Mapping[str, str],
-    # So we need to add those types here too[]
+    # Mapping isn't covariant so we have to list out the types here
     Mapping[bytes, bytes],
     Mapping[bytes, str],
     Mapping[str, bytes],


### PR DESCRIPTION
Use `__future__.annotations` to use type hint syntax from 3.8+.

Closes #248 