### PR TITLE
feat: Add common response __str__ and __repr__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ disallow_subclassing_any    = false
 [[tool.mypy.overrides]]
 module = [
   "momento_wire_types.*",
-  "grpc.*"
+  "grpc.*",
+  "google.*"
 ]
 ignore_missing_imports      = true
 

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 from . import momento_endpoint_resolver
 
@@ -65,3 +65,11 @@ class CredentialProvider:
         control_endpoint = control_endpoint or endpoints.control_endpoint
         cache_endpoint = cache_endpoint or endpoints.cache_endpoint
         return CredentialProvider(auth_token, control_endpoint, cache_endpoint)
+
+    def __repr__(self) -> str:
+        attributes: Dict[str, str] = vars(self)
+        attributes["auth_token"] = self._obscure(attributes["auth_token"])
+        return f"{self.__class__.__name__}{attributes}"
+
+    def _obscure(self, value: str) -> str:
+        return f"{value[:10]}...{value[-10:]}"

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -69,7 +69,8 @@ class CredentialProvider:
     def __repr__(self) -> str:
         attributes: Dict[str, str] = vars(self)
         attributes["auth_token"] = self._obscure(attributes["auth_token"])
-        return f"{self.__class__.__name__}{attributes}"
+        message = ", ".join(f"{k}={v!r}" for k, v in attributes.items())
+        return f"{self.__class__.__name__}({message})"
 
     def _obscure(self, value: str) -> str:
         return f"{value[:10]}...{value[-10:]}"

--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -48,7 +48,7 @@ from .list_data import (
     CacheListRemoveValue,
     CacheListRemoveValueResponse,
 )
-from .response import CacheResponse
+from .response import CacheResponse, ControlResponse
 from .scalar_data import (
     CacheDelete,
     CacheDeleteResponse,

--- a/src/momento/responses/control/create_cache.py
+++ b/src/momento/responses/control/create_cache.py
@@ -1,12 +1,11 @@
 from abc import ABC
-from dataclasses import dataclass
 
-from momento.errors import SdkException
+from momento.responses.response import ControlResponse
 
 from ..mixins import ErrorResponseMixin
 
 
-class CreateCacheResponse(ABC):
+class CreateCacheResponse(ControlResponse):
     """Parent response type for a create cache request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
@@ -44,23 +43,15 @@ class CreateCacheResponse(ABC):
 class CreateCache(ABC):
     """Groups all `CreateCacheResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CreateCacheResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class CacheAlreadyExists(CreateCacheResponse):
         """Indicates that a cache with the requested name has already been created in the requesting account."""
 
-    @dataclass
     class Error(CreateCacheResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/control/delete_cache.py
+++ b/src/momento/responses/control/delete_cache.py
@@ -1,12 +1,11 @@
 from abc import ABC
-from dataclasses import dataclass
 
-from momento.errors import SdkException
+from momento.responses.response import ControlResponse
 
 from ..mixins import ErrorResponseMixin
 
 
-class DeleteCacheResponse(ABC):
+class DeleteCacheResponse(ControlResponse):
     """Parent response type for a delete cache request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
@@ -39,19 +38,12 @@ class DeleteCacheResponse(ABC):
 class DeleteCache(ABC):
     """Groups all `DeleteCacheResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(DeleteCacheResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(DeleteCacheResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/control/list_caches.py
+++ b/src/momento/responses/control/list_caches.py
@@ -6,12 +6,12 @@ from typing import List, Optional
 
 from momento_wire_types.controlclient_pb2 import _ListCachesResponse
 
-from momento.errors import SdkException
+from momento.responses.response import ControlResponse
 
 from ..mixins import ErrorResponseMixin
 
 
-class ListCachesResponse(ABC):
+class ListCachesResponse(ControlResponse):
     """Parent response type for a list caches request. The
     response object is resolved to a type-safe object of one of
     the following subtypes:
@@ -52,7 +52,7 @@ class CacheInfo:
 class ListCaches(ABC):
     """Groups all `ListCachesResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(ListCachesResponse):
         """Indicates the request was successful."""
 
@@ -76,15 +76,9 @@ class ListCaches(ABC):
             caches = [CacheInfo(cache.cache_name) for cache in grpc_list_cache_response.cache]  # type: ignore[misc]
             return ListCaches.Success(caches=caches, next_token=next_token)
 
-    @dataclass
     class Error(ListCachesResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_fetch.py
+++ b/src/momento/responses/dictionary_data/dictionary_fetch.py
@@ -21,7 +21,7 @@ class CacheDictionaryFetchResponse(CacheResponse):
 class CacheDictionaryFetch(ABC):
     """Groups all `CacheDictionaryFetchResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheDictionaryFetchResponse):
         """Indicates the dictionary exists and its items were fetched."""
 
@@ -52,7 +52,6 @@ class CacheDictionaryFetch(ABC):
 
             return {k.decode("utf-8"): v.decode("utf-8") for k, v in self.value_dictionary_bytes_bytes.items()}
 
-    @dataclass
     class Miss(CacheDictionaryFetchResponse):
         """Indicates the dictionary does not exist."""
 

--- a/src/momento/responses/dictionary_data/dictionary_fetch.py
+++ b/src/momento/responses/dictionary_data/dictionary_fetch.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -58,15 +56,9 @@ class CacheDictionaryFetch(ABC):
     class Miss(CacheDictionaryFetchResponse):
         """Indicates the dictionary does not exist."""
 
-    @dataclass
     class Error(CacheDictionaryFetchResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_get_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_field.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 
@@ -45,15 +43,9 @@ class CacheDictionaryGetField(ABC):
     class Miss(CacheDictionaryGetFieldResponse):
         """Indicates the dictionary or dictionary field does not exist."""
 
-    @dataclass
     class Error(CacheDictionaryGetFieldResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_get_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_field.py
@@ -19,7 +19,7 @@ class CacheDictionaryGetFieldResponse(CacheResponse):
 class CacheDictionaryGetField(ABC):
     """Groups all `CacheDictionaryGetFieldResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheDictionaryGetFieldResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 
@@ -39,7 +39,6 @@ class CacheDictionaryGetField(ABC):
             """
             return self.field_bytes.decode("utf-8")
 
-    @dataclass
     class Miss(CacheDictionaryGetFieldResponse):
         """Indicates the dictionary or dictionary field does not exist."""
 

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 from .dictionary_get_field import (
@@ -91,15 +89,9 @@ class CacheDictionaryGetFields(ABC):
     class Miss(CacheDictionaryGetFieldsResponse):
         """Indicates the dictionary does not exist."""
 
-    @dataclass
     class Error(CacheDictionaryGetFieldsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -25,7 +25,7 @@ class CacheDictionaryGetFieldsResponse(CacheResponse):
 class CacheDictionaryGetFields(ABC):
     """Groups all `CacheDictionaryGetFieldsResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheDictionaryGetFieldsResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 
@@ -85,7 +85,6 @@ class CacheDictionaryGetFields(ABC):
                 if isinstance(response, CacheDictionaryGetField.Hit)
             }
 
-    @dataclass
     class Miss(CacheDictionaryGetFieldsResponse):
         """Indicates the dictionary does not exist."""
 

--- a/src/momento/responses/dictionary_data/dictionary_increment.py
+++ b/src/momento/responses/dictionary_data/dictionary_increment.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -27,15 +25,9 @@ class CacheDictionaryIncrement(ABC):
         value: int
         """The value of the field post-increment."""
 
-    @dataclass
     class Error(CacheDictionaryIncrementResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_increment.py
+++ b/src/momento/responses/dictionary_data/dictionary_increment.py
@@ -18,7 +18,7 @@ class CacheDictionaryIncrementResponse(CacheResponse):
 class CacheDictionaryIncrement(ABC):
     """Groups all `CacheDictionaryIncrementResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(CacheDictionaryIncrementResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/dictionary_data/dictionary_remove_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_field.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheDictionaryRemoveFieldResponse(CacheResponse):
 class CacheDictionaryRemoveField(ABC):
     """Groups all `CacheDictionaryRemoveFieldResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheDictionaryRemoveFieldResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/dictionary_data/dictionary_remove_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_field.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheDictionaryRemoveField(ABC):
     class Success(CacheDictionaryRemoveFieldResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheDictionaryRemoveFieldResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_remove_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_fields.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheDictionaryRemoveFieldsResponse(CacheResponse):
 class CacheDictionaryRemoveFields(ABC):
     """Groups all `CacheDictionaryRemoveFieldsResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheDictionaryRemoveFieldsResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/dictionary_data/dictionary_remove_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_remove_fields.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheDictionaryRemoveFields(ABC):
     class Success(CacheDictionaryRemoveFieldsResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheDictionaryRemoveFieldsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_set_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_field.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheDictionarySetFieldResponse(CacheResponse):
 class CacheDictionarySetField(ABC):
     """Groups all `CacheDictionarySetFieldResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheDictionarySetFieldResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/dictionary_data/dictionary_set_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_field.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheDictionarySetField(ABC):
     class Success(CacheDictionarySetFieldResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheDictionarySetFieldResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/dictionary_data/dictionary_set_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_fields.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheDictionarySetFieldsResponse(CacheResponse):
 class CacheDictionarySetFields(ABC):
     """Groups all `CacheDictionarySetFieldsResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheDictionarySetFieldsResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/dictionary_data/dictionary_set_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_set_fields.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheDictionarySetFields(ABC):
     class Success(CacheDictionarySetFieldsResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheDictionarySetFieldsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -27,15 +25,9 @@ class CacheListConcatenateBack(ABC):
         list_length: int
         """The number of values in the list after this concatenation"""
 
-    @dataclass
     class Error(CacheListConcatenateBackResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -18,7 +18,7 @@ class CacheListConcatenateBackResponse(CacheResponse):
 class CacheListConcatenateBack(ABC):
     """Groups all `CacheListConcatenateBackResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(CacheListConcatenateBackResponse):
         """Indicates the concatenation was successful."""
 

--- a/src/momento/responses/list_data/list_concatenate_front.py
+++ b/src/momento/responses/list_data/list_concatenate_front.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -27,15 +25,9 @@ class CacheListConcatenateFront(ABC):
         list_length: int
         """The number of values in the list after this concatenation"""
 
-    @dataclass
     class Error(CacheListConcatenateFrontResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_concatenate_front.py
+++ b/src/momento/responses/list_data/list_concatenate_front.py
@@ -18,7 +18,7 @@ class CacheListConcatenateFrontResponse(CacheResponse):
 class CacheListConcatenateFront(ABC):
     """Groups all `CacheListConcatenateFrontResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(CacheListConcatenateFrontResponse):
         """Indicates the concatenation was successful."""
 

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -48,15 +46,9 @@ class CacheListFetch(ABC):
     class Miss(CacheListFetchResponse):
         """Indicates the list does not exist."""
 
-    @dataclass
     class Error(CacheListFetchResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -21,7 +21,7 @@ class CacheListFetchResponse(CacheResponse):
 class CacheListFetch(ABC):
     """Groups all `CacheListFetchResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheListFetchResponse):
         """Indicates the list exists and its values were fetched."""
 
@@ -42,7 +42,6 @@ class CacheListFetch(ABC):
 
             return [v.decode("utf-8") for v in self.values_bytes]
 
-    @dataclass
     class Miss(CacheListFetchResponse):
         """Indicates the list does not exist."""
 

--- a/src/momento/responses/list_data/list_length.py
+++ b/src/momento/responses/list_data/list_length.py
@@ -19,14 +19,13 @@ class CacheListLengthResponse(CacheResponse):
 class CacheListLength(ABC):
     """Groups all `CacheListLengthResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheListLengthResponse):
         """Indicates the list exists and its length was fetched."""
 
         length: int
         """The number of values in the list."""
 
-    @dataclass
     class Miss(CacheListLengthResponse):
         """Indicates the list does not exist."""
 

--- a/src/momento/responses/list_data/list_length.py
+++ b/src/momento/responses/list_data/list_length.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -32,15 +30,9 @@ class CacheListLength(ABC):
     class Miss(CacheListLengthResponse):
         """Indicates the list does not exist."""
 
-    @dataclass
     class Error(CacheListLengthResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_pop_back.py
+++ b/src/momento/responses/list_data/list_pop_back.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 
@@ -32,15 +30,9 @@ class CacheListPopBack(ABC):
     class Miss(CacheListPopBackResponse):
         """Indicates the list does not exist."""
 
-    @dataclass
     class Error(CacheListPopBackResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_pop_back.py
+++ b/src/momento/responses/list_data/list_pop_back.py
@@ -19,14 +19,13 @@ class CacheListPopBackResponse(CacheResponse):
 class CacheListPopBack(ABC):
     """Groups all `CacheListPopBack` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheListPopBackResponse, ValueStringMixin):
         """Indicates the request was successful."""
 
         value_bytes: bytes
         """The value popped from the list. Use the `value_string` property to access the value as a string."""
 
-    @dataclass
     class Miss(CacheListPopBackResponse):
         """Indicates the list does not exist."""
 

--- a/src/momento/responses/list_data/list_pop_front.py
+++ b/src/momento/responses/list_data/list_pop_front.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 
@@ -32,15 +30,9 @@ class CacheListPopFront(ABC):
     class Miss(CacheListPopFrontResponse):
         """Indicates the list does not exist."""
 
-    @dataclass
     class Error(CacheListPopFrontResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_pop_front.py
+++ b/src/momento/responses/list_data/list_pop_front.py
@@ -19,14 +19,13 @@ class CacheListPopFrontResponse(CacheResponse):
 class CacheListPopFront(ABC):
     """Groups all `CacheListPopFront` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheListPopFrontResponse, ValueStringMixin):
         """Indicates the request was successful."""
 
         value_bytes: bytes
         """The value popped from the list. Use the `value_string` property to access the value as a string."""
 
-    @dataclass
     class Miss(CacheListPopFrontResponse):
         """Indicates the list does not exist."""
 

--- a/src/momento/responses/list_data/list_push_back.py
+++ b/src/momento/responses/list_data/list_push_back.py
@@ -18,7 +18,7 @@ class CacheListPushBackResponse(CacheResponse):
 class CacheListPushBack(ABC):
     """Groups all `CacheListPushBackResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(CacheListPushBackResponse):
         """Indicates the push was successful."""
 

--- a/src/momento/responses/list_data/list_push_back.py
+++ b/src/momento/responses/list_data/list_push_back.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -27,15 +25,9 @@ class CacheListPushBack(ABC):
         list_length: int
         """The number of values in the list after this push"""
 
-    @dataclass
     class Error(CacheListPushBackResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_push_front.py
+++ b/src/momento/responses/list_data/list_push_front.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -27,15 +25,9 @@ class CacheListPushFront(ABC):
         list_length: int
         """The number of values in the list after this push"""
 
-    @dataclass
     class Error(CacheListPushFrontResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_push_front.py
+++ b/src/momento/responses/list_data/list_push_front.py
@@ -18,7 +18,7 @@ class CacheListPushFrontResponse(CacheResponse):
 class CacheListPushFront(ABC):
     """Groups all `CacheListPushFrontResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Success(CacheListPushFrontResponse):
         """Indicates the push was successful."""
 

--- a/src/momento/responses/list_data/list_remove_value.py
+++ b/src/momento/responses/list_data/list_remove_value.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheListRemoveValue(ABC):
     class Success(CacheListRemoveValueResponse):
         """Indicates removing the values was successful."""
 
-    @dataclass
     class Error(CacheListRemoveValueResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/list_data/list_remove_value.py
+++ b/src/momento/responses/list_data/list_remove_value.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheListRemoveValueResponse(CacheResponse):
 class CacheListRemoveValue(ABC):
     """Groups all `CacheListRemoveValueResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheListRemoveValueResponse):
         """Indicates removing the values was successful."""
 

--- a/src/momento/responses/mixins.py
+++ b/src/momento/responses/mixins.py
@@ -27,16 +27,6 @@ class ValueStringMixin:
         """
         return self.value_bytes.decode("utf-8")
 
-    def __str__(self) -> str:
-        value = self._truncate_string(self.value_string)
-        return f"{self.__class__.__name__}: value={value}"
-
-    def _truncate_string(self, string: str, max_length: int = 32) -> str:
-        if len(string) < max_length:
-            return string
-
-        return f"{string[:max_length]}..."
-
 
 class ErrorResponseMixin:
     _error: SdkException
@@ -58,3 +48,6 @@ class ErrorResponseMixin:
     def message(self) -> str:
         """An explanation of conditions that caused and potential ways to resolve the error."""
         return f"{self._error.message_wrapper}: {self._error.message}"
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__qualname__} {self.error_code}: {self.message}"

--- a/src/momento/responses/mixins.py
+++ b/src/momento/responses/mixins.py
@@ -6,15 +6,7 @@ if typing.TYPE_CHECKING:
 else:
     Protocol = object
 
-from typing import Type, TypeVar
-
 from momento.errors import MomentoErrorCode, SdkException
-
-
-class HasValueBytesProtocol(Protocol):
-    @property
-    def value_bytes(self) -> bytes:
-        ...
 
 
 class ValueStringMixin:
@@ -24,8 +16,10 @@ class ValueStringMixin:
         str: the utf-8 encoding of the data
     """
 
+    value_bytes: bytes
+
     @property
-    def value_string(self: HasValueBytesProtocol) -> str:
+    def value_string(self) -> str:
         """Convert the bytes `value` to a UTF-8 string
 
         Returns:
@@ -33,35 +27,34 @@ class ValueStringMixin:
         """
         return self.value_bytes.decode("utf-8")
 
+    def __str__(self) -> str:
+        value = self._truncate_string(self.value_string)
+        return f"{self.__class__.__name__}: value={value}"
 
-class HasErrorProtocol(Protocol):
-    @property
-    def _error(self) -> SdkException:
-        ...
+    def _truncate_string(self, string: str, max_length: int = 32) -> str:
+        if len(string) < max_length:
+            return string
 
-
-TError = TypeVar("TError", bound="ErrorResponseMixin")
+        return f"{string[:max_length]}..."
 
 
 class ErrorResponseMixin:
+    _error: SdkException
+
     def __init__(self, _error: SdkException):
-        ...
+        self._error = _error
 
     @property
-    def inner_exception(self: HasErrorProtocol) -> SdkException:
+    def inner_exception(self) -> SdkException:
         """The SdkException object used to construct the response."""
         return self._error
 
     @property
-    def error_code(self: HasErrorProtocol) -> MomentoErrorCode:
+    def error_code(self) -> MomentoErrorCode:
         """The `MomentoErrorCode` value for the particular error object."""
         return self._error.error_code
 
     @property
-    def message(self: HasErrorProtocol) -> str:
+    def message(self) -> str:
         """An explanation of conditions that caused and potential ways to resolve the error."""
         return f"{self._error.message_wrapper}: {self._error.message}"
-
-    @classmethod
-    def from_sdkexception(cls: Type[TError], _error: SdkException) -> TError:
-        return cls(_error)

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -16,9 +16,9 @@ class Response(ABC):
         if not attributes:
             return f"{class_name}()"
 
-        message = {k: self._truncate_value(v) for k, v in attributes.items()}
+        message = ", ".join(f"{k}={self._truncate_value(v)!r}" for k, v in attributes.items())
 
-        return f"{class_name}({message!r})"
+        return f"{class_name}({message})"
 
     @no_type_check
     def _truncate_value(self, value: Any, max_length: int = 32) -> Any:

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -35,6 +35,16 @@ class Response(ABC):
         else:
             return value
 
+    @no_type_check
+    def __eq__(self, other: object) -> bool:
+        if other is None:
+            return False
+
+        if type(self) != type(other):
+            return False
+
+        return vars(self) == vars(other)
+
 
 class CacheResponse(Response):
     ...

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -1,8 +1,44 @@
+from __future__ import annotations
+
 from abc import ABC
+from typing import Any, no_type_check
 
 
-class CacheResponse(ABC):
+class Response(ABC):
     """Parent of all responses"""
 
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}"
+    # We need to work with Any.
+    @no_type_check
+    def __repr__(self) -> str:
+        class_name = self.__class__.__qualname__
+        attributes = vars(self)
+
+        if not attributes:
+            return f"{class_name}()"
+
+        message = {k: self._truncate_value(v) for k, v in attributes.items()}
+
+        return f"{class_name}({message!r})"
+
+    @no_type_check
+    def _truncate_value(self, value: Any, max_length: int = 32) -> Any:
+        if type(value) == bytes:
+            if len(value) < max_length:
+                return value
+
+            return value[:max_length] + b"..."
+        elif type(value) == str:
+            if len(value) < max_length:
+                return value
+
+            return value[:max_length] + "..."
+        else:
+            return value
+
+
+class CacheResponse(Response):
+    ...
+
+
+class ControlResponse(Response):
+    ...

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -45,6 +45,12 @@ class Response(ABC):
 
         return vars(self) == vars(other)
 
+    @no_type_check
+    def __hash__(self) -> int:
+        state = [type(self)]
+        state.extend(sorted(vars(self).items(), key=lambda x: x[0]))
+        return hash(tuple(state))
+
 
 class CacheResponse(Response):
     ...

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -3,3 +3,6 @@ from abc import ABC
 
 class CacheResponse(ABC):
     """Parent of all responses"""
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}"

--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheDelete(ABC):
     class Success(CacheDeleteResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheDeleteResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/scalar_data/delete.py
+++ b/src/momento/responses/scalar_data/delete.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheDeleteResponse(CacheResponse):
 class CacheDelete(ABC):
     """Groups all `CacheDeleteResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheDeleteResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -30,7 +30,7 @@ class CacheGet(ABC):
     class Miss(CacheGetResponse):
         """Contains the results of a cache miss"""
 
-    class Error(ErrorResponseMixin, CacheGetResponse):
+    class Error(CacheGetResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin, ValueStringMixin
 from ..response import CacheResponse
 
@@ -33,15 +31,9 @@ class CacheGet(ABC):
     class Miss(CacheGetResponse):
         """Contains the results of a cache miss"""
 
-    @dataclass
-    class Error(CacheGetResponse, ErrorResponseMixin):
+    class Error(ErrorResponseMixin, CacheGetResponse):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -19,7 +19,7 @@ class CacheGetResponse(CacheResponse):
 class CacheGet(ABC):
     """Groups all `CacheGetResponse` derived types under a common namespace."""
 
-    @dataclass
+    @dataclass(repr=False)
     class Hit(CacheGetResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 
@@ -27,7 +27,6 @@ class CacheGet(ABC):
         """The value returned from the cache for the specified key. Use the
         `value_string` property to access the value as a string."""
 
-    @dataclass
     class Miss(CacheGetResponse):
         """Contains the results of a cache miss"""
 

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheSetResponse(CacheResponse):
 class CacheSet(ABC):
     """Groups all `CacheSetResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheSetResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/scalar_data/set.py
+++ b/src/momento/responses/scalar_data/set.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheSet(ABC):
     class Success(CacheSetResponse):
         """Indicates the request was successful."""
 
-    @dataclass
     class Error(CacheSetResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/scalar_data/set_if_not_exists.py
+++ b/src/momento/responses/scalar_data/set_if_not_exists.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -29,15 +27,9 @@ class CacheSetIfNotExists(ABC):
     class NotStored(CacheSetIfNotExistsResponse):
         """Indicates the key existed and no value was set."""
 
-    @dataclass
     class Error(CacheSetIfNotExistsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/scalar_data/set_if_not_exists.py
+++ b/src/momento/responses/scalar_data/set_if_not_exists.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -19,11 +18,9 @@ class CacheSetIfNotExistsResponse(CacheResponse):
 class CacheSetIfNotExists(ABC):
     """Groups all `CacheSetIfNotExistsResponse` derived types under a common namespace."""
 
-    @dataclass
     class Stored(CacheSetIfNotExistsResponse):
         """Indicates the key did not exist and the value was set."""
 
-    @dataclass
     class NotStored(CacheSetIfNotExistsResponse):
         """Indicates the key existed and no value was set."""
 

--- a/src/momento/responses/set_data/set_add_element.py
+++ b/src/momento/responses/set_data/set_add_element.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheSetAddElement(ABC):
     class Success(CacheSetAddElementResponse):
         """Indicates the element was added."""
 
-    @dataclass
     class Error(CacheSetAddElementResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/set_data/set_add_element.py
+++ b/src/momento/responses/set_data/set_add_element.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheSetAddElementResponse(CacheResponse):
 class CacheSetAddElement(ABC):
     """Groups all `CacheSetAddElementResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheSetAddElementResponse):
         """Indicates the element was added."""
 

--- a/src/momento/responses/set_data/set_add_elements.py
+++ b/src/momento/responses/set_data/set_add_elements.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheSetAddElementsResponse(CacheResponse):
 class CacheSetAddElements(ABC):
     """Groups all `CacheSetAddElementsResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheSetAddElementsResponse):
         """Indicates the elements were added."""
 

--- a/src/momento/responses/set_data/set_add_elements.py
+++ b/src/momento/responses/set_data/set_add_elements.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheSetAddElements(ABC):
     class Success(CacheSetAddElementsResponse):
         """Indicates the elements were added."""
 
-    @dataclass
     class Error(CacheSetAddElementsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/set_data/set_fetch.py
+++ b/src/momento/responses/set_data/set_fetch.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -47,15 +45,9 @@ class CacheSetFetch(ABC):
     class Miss(CacheSetFetchResponse):
         """Indicates the set does not exist."""
 
-    @dataclass
     class Error(CacheSetFetchResponse, ErrorResponseMixin):
         """Indicates an error occured in the request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/set_data/set_fetch.py
+++ b/src/momento/responses/set_data/set_fetch.py
@@ -41,7 +41,6 @@ class CacheSetFetch(ABC):
 
             return {v.decode("utf-8") for v in self.value_set_bytes}
 
-    @dataclass
     class Miss(CacheSetFetchResponse):
         """Indicates the set does not exist."""
 

--- a/src/momento/responses/set_data/set_remove_element.py
+++ b/src/momento/responses/set_data/set_remove_element.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheSetRemoveElement(ABC):
     class Success(CacheSetRemoveElementResponse):
         """Indicates the element was removed."""
 
-    @dataclass
     class Error(CacheSetRemoveElementResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/set_data/set_remove_element.py
+++ b/src/momento/responses/set_data/set_remove_element.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheSetRemoveElementResponse(CacheResponse):
 class CacheSetRemoveElement(ABC):
     """Groups all `CacheSetRemoveElementResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheSetRemoveElementResponse):
         """Indicates the element was removed."""
 

--- a/src/momento/responses/set_data/set_remove_elements.py
+++ b/src/momento/responses/set_data/set_remove_elements.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
 
-from momento.errors import SdkException
-
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
 
@@ -24,15 +22,9 @@ class CacheSetRemoveElements(ABC):
     class Success(CacheSetRemoveElementsResponse):
         """Indicates the elements were removed."""
 
-    @dataclass
     class Error(CacheSetRemoveElementsResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:
 
         - `error_code`: `MomentoErrorCode` value for the error.
         - `messsage`: a detailed error message.
         """
-
-        _error: SdkException
-
-        def __init__(self, _error: SdkException):
-            self._error = _error

--- a/src/momento/responses/set_data/set_remove_elements.py
+++ b/src/momento/responses/set_data/set_remove_elements.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from dataclasses import dataclass
 
 from ..mixins import ErrorResponseMixin
 from ..response import CacheResponse
@@ -18,7 +17,6 @@ class CacheSetRemoveElementsResponse(CacheResponse):
 class CacheSetRemoveElements(ABC):
     """Groups all `CacheSetRemoveElementsResponse` derived types under a common namespace."""
 
-    @dataclass
     class Success(CacheSetRemoveElementsResponse):
         """Indicates the elements were removed."""
 

--- a/tests/momento/internal/test_credential_provider.py
+++ b/tests/momento/internal/test_credential_provider.py
@@ -1,0 +1,10 @@
+import re
+
+from momento.auth import CredentialProvider
+
+
+def describe_credential_provider() -> None:
+    def it_obscures_the_auth_token(bad_token_credential_provider: CredentialProvider) -> None:
+        cp = bad_token_credential_provider
+        assert not re.search(r"{cp.auth_token}", cp.__repr__())
+        assert not re.search(r"{cp.auth_token}", str(cp))

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -172,8 +172,8 @@ def test_list_caches_with_next_token_works(client: SimpleCacheClient, cache_name
 def test_create_list_revoke_signing_keys(client: SimpleCacheClient) -> None:
     create_resp = client.create_signing_key(timedelta(minutes=30))
     list_resp = client.list_signing_keys()
-    assert create_resp.key_id() in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+    assert create_resp.key_id in [signing_key.key_id for signing_key in list_resp.signing_keys]
 
-    client.revoke_signing_key(create_resp.key_id())
+    client.revoke_signing_key(create_resp.key_id)
     list_resp = client.list_signing_keys()
-    assert create_resp.key_id() not in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+    assert create_resp.key_id not in [signing_key.key_id for signing_key in list_resp.signing_keys]

--- a/tests/momento/simple_cache_client/test_control_async.py
+++ b/tests/momento/simple_cache_client/test_control_async.py
@@ -182,8 +182,8 @@ async def test_list_caches_with_next_token_works(client_async: SimpleCacheClient
 async def test_create_list_revoke_signing_keys(client_async: SimpleCacheClientAsync) -> None:
     create_resp = await client_async.create_signing_key(timedelta(minutes=30))
     list_resp = await client_async.list_signing_keys()
-    assert create_resp.key_id() in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+    assert create_resp.key_id in [signing_key.key_id for signing_key in list_resp.signing_keys]
 
-    await client_async.revoke_signing_key(create_resp.key_id())
+    await client_async.revoke_signing_key(create_resp.key_id)
     list_resp = await client_async.list_signing_keys()
-    assert create_resp.key_id() not in [signing_key.key_id() for signing_key in list_resp.signing_keys()]
+    assert create_resp.key_id not in [signing_key.key_id for signing_key in list_resp.signing_keys]


### PR DESCRIPTION
This does most of #194. I need to move on. This can be merged as is and the rest followed up on.

* All responses have a common base class with a common `__str__` and `__repr__`.
* Error responses get their own customized version.
* Fix the signature of a GRPC response.
* Fix the ListSigningKeys docs.
* Obscure the auth_token when stringifying so it doesn't show up in logs.
* Simplify the mixins
* Remove boilerplate code from responses.
* Take advantage of dataclasses.
* Remove unnecessary dataclasses.

Review notes:
* Make sure all dataclasses have repr=False otherwise `@dataclass` provides their own and the response won't use the common `__repr__`.

What's missing is...
* Tests
* Truncating collections.