### PR TITLE
feat: Enforce keyword args for optional arguments.

### DIFF
--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -690,7 +690,7 @@ class SimpleCacheClient:
             CacheSetAddElementResponse
         """
 
-        resp = self.set_add_elements(cache_name, set_name, {element}, ttl=ttl)
+        resp = self.set_add_elements(cache_name, set_name, (element,), ttl=ttl)
 
         if isinstance(resp, CacheSetAddElements.Success):
             return CacheSetAddElement.Success()
@@ -750,7 +750,7 @@ class SimpleCacheClient:
         Returns:
             CacheSetRemoveElementResponse
         """
-        resp = self.set_remove_elements(cache_name, set_name, {element})
+        resp = self.set_remove_elements(cache_name, set_name, (element,))
         if isinstance(resp, CacheSetRemoveElements.Success):
             return CacheSetRemoveElement.Success()
         elif isinstance(resp, CacheSetRemoveElements.Error):

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -180,7 +180,7 @@ class SimpleCacheClient:
         """
         return self._control_client.delete_cache(cache_name)
 
-    def list_caches(self, next_token: Optional[str] = None) -> ListCachesResponse:
+    def list_caches(self, *, next_token: Optional[str] = None) -> ListCachesResponse:
         """Lists all caches.
 
         Args:
@@ -220,7 +220,7 @@ class SimpleCacheClient:
         """
         return self._control_client.revoke_signing_key(key_id)
 
-    def list_signing_keys(self, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    def list_signing_keys(self, *, next_token: Optional[str] = None) -> ListSigningKeysResponse:
         """Lists all Momento signing keys for the provided auth token.
 
         Args:
@@ -362,6 +362,7 @@ class SimpleCacheClient:
         dictionary_name: str,
         field: str | bytes,
         amount: int = 1,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionaryIncrementResponse:
         """Add an integer quantity to a dictionary value.
@@ -428,6 +429,7 @@ class SimpleCacheClient:
         dictionary_name: str,
         field: str | bytes,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldResponse:
         """Set the dictionary field to a value with a given time to live (TTL) seconds.
@@ -459,6 +461,7 @@ class SimpleCacheClient:
         cache_name: str,
         dictionary_name: str,
         items: TDictionaryItems,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldsResponse:
         """Set several dictionary field-value pairs in the cache.
@@ -482,6 +485,7 @@ class SimpleCacheClient:
         cache_name: str,
         list_name: str,
         values: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
@@ -507,6 +511,7 @@ class SimpleCacheClient:
         cache_name: str,
         list_name: str,
         values: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListConcatenateFrontResponse:
@@ -588,6 +593,7 @@ class SimpleCacheClient:
         cache_name: str,
         list_name: str,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListPushBackResponse:
@@ -613,6 +619,7 @@ class SimpleCacheClient:
         cache_name: str,
         list_name: str,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListPushFrontResponse:
@@ -667,6 +674,7 @@ class SimpleCacheClient:
         cache_name: str,
         set_name: str,
         element: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheSetAddElementResponse:
         """
@@ -682,7 +690,7 @@ class SimpleCacheClient:
             CacheSetAddElementResponse
         """
 
-        resp = self.set_add_elements(cache_name, set_name, [element], ttl)
+        resp = self.set_add_elements(cache_name, set_name, {element}, ttl=ttl)
 
         if isinstance(resp, CacheSetAddElements.Success):
             return CacheSetAddElement.Success()
@@ -696,6 +704,7 @@ class SimpleCacheClient:
         cache_name: str,
         set_name: str,
         elements: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheSetAddElementsResponse:
         """
@@ -741,7 +750,7 @@ class SimpleCacheClient:
         Returns:
             CacheSetRemoveElementResponse
         """
-        resp = self.set_remove_elements(cache_name, set_name, [element])
+        resp = self.set_remove_elements(cache_name, set_name, {element})
         if isinstance(resp, CacheSetRemoveElements.Success):
             return CacheSetRemoveElement.Success()
         elif isinstance(resp, CacheSetRemoveElements.Error):

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -180,7 +180,7 @@ class SimpleCacheClientAsync:
         """
         return await self._control_client.delete_cache(cache_name)
 
-    async def list_caches(self, next_token: Optional[str] = None) -> ListCachesResponse:
+    async def list_caches(self, *, next_token: Optional[str] = None) -> ListCachesResponse:
         """Lists all caches.
 
         Args:
@@ -220,7 +220,7 @@ class SimpleCacheClientAsync:
         """
         return await self._control_client.revoke_signing_key(key_id)
 
-    async def list_signing_keys(self, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    async def list_signing_keys(self, *, next_token: Optional[str] = None) -> ListSigningKeysResponse:
         """Lists all Momento signing keys for the provided auth token.
 
         Args:
@@ -362,6 +362,7 @@ class SimpleCacheClientAsync:
         dictionary_name: str,
         field: str | bytes,
         amount: int = 1,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionaryIncrementResponse:
         """Add an integer quantity to a dictionary value.
@@ -428,6 +429,7 @@ class SimpleCacheClientAsync:
         dictionary_name: str,
         field: str | bytes,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldResponse:
         """Set the dictionary field to a value with a given time to live (TTL) seconds.
@@ -461,6 +463,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         dictionary_name: str,
         items: TDictionaryItems,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheDictionarySetFieldsResponse:
         """Set several dictionary field-value pairs in the cache.
@@ -484,6 +487,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         list_name: str,
         values: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListConcatenateBackResponse:
@@ -509,6 +513,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         list_name: str,
         values: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListConcatenateFrontResponse:
@@ -590,6 +595,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         list_name: str,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_front_to_size: Optional[int] = None,
     ) -> CacheListPushBackResponse:
@@ -615,6 +621,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         list_name: str,
         value: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         truncate_back_to_size: Optional[int] = None,
     ) -> CacheListPushFrontResponse:
@@ -669,6 +676,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         set_name: str,
         element: str | bytes,
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheSetAddElementResponse:
         """
@@ -684,7 +692,7 @@ class SimpleCacheClientAsync:
             CacheSetAddElementResponse
         """
 
-        resp = await self.set_add_elements(cache_name, set_name, [element], ttl)
+        resp = await self.set_add_elements(cache_name, set_name, {element}, ttl=ttl)
 
         if isinstance(resp, CacheSetAddElements.Success):
             return CacheSetAddElement.Success()
@@ -698,6 +706,7 @@ class SimpleCacheClientAsync:
         cache_name: str,
         set_name: str,
         elements: Iterable[str | bytes],
+        *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheSetAddElementsResponse:
         """
@@ -745,7 +754,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetRemoveElementResponse
         """
-        resp = await self.set_remove_elements(cache_name, set_name, [element])
+        resp = await self.set_remove_elements(cache_name, set_name, {element})
         if isinstance(resp, CacheSetRemoveElements.Success):
             return CacheSetRemoveElement.Success()
         elif isinstance(resp, CacheSetRemoveElements.Error):

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -692,7 +692,7 @@ class SimpleCacheClientAsync:
             CacheSetAddElementResponse
         """
 
-        resp = await self.set_add_elements(cache_name, set_name, {element}, ttl=ttl)
+        resp = await self.set_add_elements(cache_name, set_name, (element,), ttl=ttl)
 
         if isinstance(resp, CacheSetAddElements.Success):
             return CacheSetAddElement.Success()
@@ -754,7 +754,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetRemoveElementResponse
         """
-        resp = await self.set_remove_elements(cache_name, set_name, {element})
+        resp = await self.set_remove_elements(cache_name, set_name, (element,))
         if isinstance(resp, CacheSetRemoveElements.Success):
             return CacheSetRemoveElement.Success()
         elif isinstance(resp, CacheSetRemoveElements.Error):

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -7,6 +7,7 @@ from typing import Callable
 import pytest
 from pytest import fixture
 from pytest_describe import behaves_like
+from typing_extensions import Protocol
 
 from momento import SimpleCacheClient
 from momento.auth import CredentialProvider
@@ -42,7 +43,18 @@ from .shared_behaviors import (
     a_connection_validator,
 )
 
-TListAdder = Callable[[SimpleCacheClient, TListName, TListValue, CollectionTtl], CacheResponse]
+
+class TListAdder(Protocol):
+    def __call__(
+        self,
+        client: SimpleCacheClient,
+        cache_name: TCacheName,
+        list_name: TListName,
+        value: TListValue,
+        *,
+        ttl: CollectionTtl,
+    ) -> CacheResponse:
+        ...
 
 
 def a_list_adder() -> None:
@@ -59,7 +71,7 @@ def a_list_adder() -> None:
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
             for value in values:
-                list_adder(client, list_name, value, ttl)
+                list_adder(client, cache_name, list_name, value, ttl=ttl)
 
             sleep(ttl_seconds * 2)
 
@@ -74,7 +86,7 @@ def a_list_adder() -> None:
         values = ["one", "two", "three", "four"]
 
         for value in values:
-            list_adder(client, list_name, value, ttl)
+            list_adder(client, cache_name, list_name, value, ttl=ttl)
             sleep(ttl_seconds / 2)
 
         fetch_resp = client.list_fetch(cache_name, list_name)
@@ -93,7 +105,7 @@ def a_list_adder() -> None:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             value = uuid_str()
-            list_adder(client, list_name, value, ttl)
+            list_adder(client, cache_name, list_name, value, ttl=ttl)
 
             sleep(ttl_seconds / 2)
 
@@ -282,16 +294,16 @@ def describe_list_concatenate_back() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         def _list_adder(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.list_concatenate_back(cache_name, list_name, [list_value], ttl=ttl)
+            return client.list_concatenate_back(cache_name, list_name, [value], ttl=ttl)
 
         return _list_adder
 
@@ -356,16 +368,16 @@ def describe_list_concatenate_front() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         def _list_adder(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.list_concatenate_front(cache_name, list_name, [list_value], ttl=ttl)
+            return client.list_concatenate_front(cache_name, list_name, [value], ttl=ttl)
 
         return _list_adder
 
@@ -577,16 +589,15 @@ def describe_list_push_back() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         def _list_adder(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.list_push_back(cache_name, list_name, list_value, ttl=ttl)
+            return client.list_push_back(cache_name, list_name, value, ttl=ttl)
 
         return _list_adder
 
@@ -641,16 +652,16 @@ def describe_list_push_front() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         def _list_adder(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.list_push_front(cache_name, list_name, list_value, ttl=ttl)
+            return client.list_push_front(cache_name, list_name, value, ttl=ttl)
 
         return _list_adder
 

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Callable
 import pytest
 from pytest import fixture
 from pytest_describe import behaves_like
+from typing_extensions import Protocol
 
 from momento import SimpleCacheClientAsync
 from momento.auth import CredentialProvider
@@ -42,7 +43,18 @@ from .shared_behaviors_async import (
     a_connection_validator,
 )
 
-TListAdder = Callable[[SimpleCacheClientAsync, TListName, TListValue, CollectionTtl], Awaitable[CacheResponse]]
+
+class TListAdder(Protocol):
+    def __call__(
+        self,
+        client_async: SimpleCacheClientAsync,
+        cache_name: TCacheName,
+        list_name: TListName,
+        value: TListValue,
+        *,
+        ttl: CollectionTtl,
+    ) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_list_adder() -> None:
@@ -59,7 +71,7 @@ def a_list_adder() -> None:
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
             for value in values:
-                await list_adder(client, list_name, value, ttl)
+                await list_adder(client, cache_name, list_name, value, ttl=ttl)
 
             sleep(ttl_seconds * 2)
 
@@ -74,7 +86,7 @@ def a_list_adder() -> None:
         values = ["one", "two", "three", "four"]
 
         for value in values:
-            await list_adder(client_async, list_name, value, ttl)
+            await list_adder(client_async, cache_name, list_name, value, ttl=ttl)
             sleep(ttl_seconds / 2)
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
@@ -93,7 +105,7 @@ def a_list_adder() -> None:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             value = uuid_str()
-            await list_adder(client, list_name, value, ttl)
+            await list_adder(client, cache_name, list_name, value, ttl=ttl)
 
             sleep(ttl_seconds / 2)
 
@@ -288,16 +300,16 @@ def describe_list_concatenate_back() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         async def _list_adder(
             client_async: SimpleCacheClientAsync,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return await client_async.list_concatenate_back(cache_name, list_name, [list_value], ttl=ttl)
+            return await client_async.list_concatenate_back(cache_name, list_name, [value], ttl=ttl)
 
         return _list_adder
 
@@ -364,16 +376,16 @@ def describe_list_concatenate_front() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         async def _list_adder(
             client_async: SimpleCacheClientAsync,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return await client_async.list_concatenate_front(cache_name, list_name, [list_value], ttl=ttl)
+            return await client_async.list_concatenate_front(cache_name, list_name, [value], ttl=ttl)
 
         return _list_adder
 
@@ -599,16 +611,15 @@ def describe_list_push_back() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         async def _list_adder(
             client_async: SimpleCacheClientAsync,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return await client_async.list_push_back(cache_name, list_name, list_value, ttl=ttl)
+            return await client_async.list_push_back(cache_name, list_name, value, ttl=ttl)
 
         return _list_adder
 
@@ -665,16 +676,16 @@ def describe_list_push_front() -> None:
         return _connection_validator
 
     @fixture
-    def list_adder(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListAdder:
+    def list_adder() -> TListAdder:
         async def _list_adder(
             client_async: SimpleCacheClientAsync,
+            cache_name: TCacheName,
             list_name: TListName,
-            list_value: TListValue,
+            value: TListValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return await client_async.list_push_front(cache_name, list_name, list_value, ttl=ttl)
+            return await client_async.list_push_front(cache_name, list_name, value, ttl=ttl)
 
         return _list_adder
 

--- a/tests/momento/simple_cache_client/test_scalar.py
+++ b/tests/momento/simple_cache_client/test_scalar.py
@@ -37,7 +37,7 @@ def a_setter() -> None:
         key = uuid_str()
         val = uuid_str()
 
-        setter(cache_name, key, val, timedelta(seconds=2))
+        setter(cache_name, key, val, ttl=timedelta(seconds=2))
         get_response = client.get(cache_name, key)
         assert isinstance(get_response, CacheGet.Hit)
 
@@ -49,7 +49,7 @@ def a_setter() -> None:
         key1 = uuid_str()
         key2 = uuid_str()
 
-        setter(cache_name, key1, "1", timedelta(seconds=2))
+        setter(cache_name, key1, "1", ttl=timedelta(seconds=2))
         setter(cache_name, key2, "2")
 
         # Before
@@ -74,7 +74,7 @@ def a_setter() -> None:
             assert False
 
     def negative_ttl_throws_exception(setter: TSetter, client: SimpleCacheClient, cache_name: str) -> None:
-        set_response = setter(cache_name, "foo", "bar", timedelta(seconds=-1))
+        set_response = setter(cache_name, "foo", "bar", ttl=timedelta(seconds=-1))
         if isinstance(set_response, ErrorResponseMixin):
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "TTL must be a positive amount of time."

--- a/tests/momento/simple_cache_client/test_scalar_async.py
+++ b/tests/momento/simple_cache_client/test_scalar_async.py
@@ -37,7 +37,7 @@ def a_setter() -> None:
         key = uuid_str()
         val = uuid_str()
 
-        await setter(cache_name, key, val, timedelta(seconds=2))
+        await setter(cache_name, key, val, ttl=timedelta(seconds=2))
         get_response = await client_async.get(cache_name, key)
         assert isinstance(get_response, CacheGet.Hit)
 
@@ -49,7 +49,7 @@ def a_setter() -> None:
         key1 = uuid_str()
         key2 = uuid_str()
 
-        await setter(cache_name, key1, "1", timedelta(seconds=2))
+        await setter(cache_name, key1, "1", ttl=timedelta(seconds=2))
         await setter(cache_name, key2, "2")
 
         # Before
@@ -78,7 +78,7 @@ def a_setter() -> None:
     async def negative_ttl_throws_exception(
         setter: TSetter, client_async: SimpleCacheClientAsync, cache_name: str
     ) -> None:
-        set_response = await setter(cache_name, "foo", "bar", timedelta(seconds=-1))
+        set_response = await setter(cache_name, "foo", "bar", ttl=timedelta(seconds=-1))
         if isinstance(set_response, ErrorResponseMixin):
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "TTL must be a positive amount of time."


### PR DESCRIPTION
This avoids having to worry about argument order.

I left set and set_if_not_exists alone becausae it would be a backwards incompat change.

Also
* set_add_elements() and set_remove_elements() was being passed a list, not a set.

Closes #255