### PR TITLE
fix: codegen import with one import from that is async

### DIFF
--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -53,9 +53,12 @@ class AsyncToSyncTransformer(cst.CSTTransformer):
     def leave_ImportFrom(
         self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
     ) -> cst.BaseSmallStatement | cst.FlattenSentinel[cst.BaseSmallStatement] | cst.RemovalSentinel:
+        """Strips Awaitable name from import from statements. Remove the whole line if that is the only import."""
         if isinstance(original_node.names, cst.ImportStar):
             return original_node
         names = [import_alias for import_alias in original_node.names if import_alias.name.value != "Awaitable"]
+        if len(names) == 0:
+            return cst.RemovalSentinel.REMOVE
         return updated_node.with_changes(names=names)
 
 

--- a/tests/momento/internal/test_codegen.py
+++ b/tests/momento/internal/test_codegen.py
@@ -46,6 +46,13 @@ from typing import Awaitable, BC, CD
 from typing import BC, CD
 """,
         ),
+        (
+            """
+from typing import Awaitable
+""",
+            """
+""",
+        ),
         ("2+2", "2+2"),
         (
             """


### PR DESCRIPTION
We update codegen to handle lines with:

`from typing import Awaitable`

by removing the statement entirely.