### PR TITLE
refactor: Clean up the signatures of shared behaviors.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ disallow_subclassing_any    = false
 [[tool.mypy.overrides]]
 module = [
   "momento_wire_types.*",
-  "grpc.*"
+  "grpc.*",
+  "pytest_describe"
 ]
 ignore_missing_imports      = true
 

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from momento.errors.error_details import MomentoErrorCode
+from momento.responses.mixins import ErrorResponseMixin
+from momento.responses.response import CacheResponse
+
+
+# Custom assertions
+def assert_response_is_error(
+    response: CacheResponse,
+    *,
+    error_code: Optional[MomentoErrorCode] = None,
+    inner_exception_message: Optional[str] = None,
+) -> None:
+    assert isinstance(response, ErrorResponseMixin)
+    if isinstance(response, ErrorResponseMixin):
+        if error_code:
+            assert response.error_code == error_code
+        if inner_exception_message:
+            assert response.inner_exception.message == inner_exception_message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ from momento.typing import (
     TListValuesInput,
     TListValuesInputBytes,
     TListValuesInputStr,
+    TScalarKey,
+    TScalarValue,
     TSetElement,
     TSetElementsInput,
     TSetElementsInputBytes,
@@ -83,6 +85,16 @@ def list_value() -> TListValue:
 
 
 @pytest.fixture
+def key() -> TScalarKey:
+    return random.choice((uuid_bytes(), uuid_str()))
+
+
+@pytest.fixture
+def value() -> TScalarValue:
+    return random.choice((uuid_bytes(), uuid_str()))
+
+
+@pytest.fixture
 def values_bytes() -> TListValuesInputBytes:
     return [uuid_bytes(), uuid_bytes(), uuid_bytes()]
 
@@ -100,6 +112,11 @@ def values_str() -> TListValuesInputStr:
 @pytest.fixture
 def dictionary_name() -> TDictionaryName:
     return uuid_str()
+
+
+@pytest.fixture
+def dictionary_field() -> TDictionaryField:
+    return random.choice((uuid_bytes(), uuid_str()))
 
 
 @pytest.fixture

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 
 from typing_extensions import Protocol
@@ -7,8 +9,8 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
-from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TScalarKey
+from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 
 
@@ -21,34 +23,31 @@ def a_cache_name_validator() -> None:
     def with_non_existent_cache_name_it_throws_not_found(cache_name_validator: TCacheNameValidator) -> None:
         cache_name = uuid_str()
         response = cache_name_validator(cache_name=cache_name)
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
-        else:
-            assert False
+        assert_response_is_error(response, error_code=MomentoErrorCode.NOT_FOUND_ERROR)
 
     def with_null_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = cache_name_validator(cache_name=None)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must be a string"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must be a string",
+        )
 
     def with_empty_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = cache_name_validator(cache_name="")
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must not be empty"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must not be empty",
+        )
 
     def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = cache_name_validator(cache_name=1)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must be a string"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must be a string",
+        )
 
 
 class TKeyValidator(Protocol):
@@ -59,18 +58,15 @@ class TKeyValidator(Protocol):
 def a_key_validator() -> None:
     def with_null_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
         response = key_validator(key=None)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        else:
-            assert False
+        assert_response_is_error(response, error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR)
 
     def with_bad_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
         response = key_validator(key=1)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Unsupported type for key: <class 'int'>",
+        )
 
 
 class TConnectionValidator(Protocol):
@@ -87,10 +83,7 @@ def a_connection_validator() -> None:
     ) -> None:
         with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
             response = connection_validator(client)
-            if isinstance(response, ErrorResponseMixin):
-                assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
-            else:
-                assert False
+            assert_response_is_error(response, error_code=MomentoErrorCode.AUTHENTICATION_ERROR)
 
     def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
@@ -101,7 +94,4 @@ def a_connection_validator() -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
         with SimpleCacheClient(configuration, credential_provider, default_ttl_seconds) as client:
             response = connection_validator(client)
-            if isinstance(response, ErrorResponseMixin):
-                assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
-            else:
-                assert False
+            assert_response_is_error(response, error_code=MomentoErrorCode.TIMEOUT_ERROR)

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
-from typing import Callable
+
+from typing_extensions import Protocol
 
 from momento import SimpleCacheClient
 from momento.auth import CredentialProvider
@@ -10,76 +11,97 @@ from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TScalarKey
 from tests.utils import uuid_str
 
-TCacheNameValidator = Callable[[TCacheName], CacheResponse]
+
+class TCacheNameValidator(Protocol):
+    def __call__(self, cache_name: TCacheName) -> CacheResponse:
+        ...
 
 
 def a_cache_name_validator() -> None:
     def with_non_existent_cache_name_it_throws_not_found(cache_name_validator: TCacheNameValidator) -> None:
         cache_name = uuid_str()
-        response = cache_name_validator(cache_name)
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+        response = cache_name_validator(cache_name=cache_name)
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+        else:
+            assert False
 
     def with_null_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = cache_name_validator(None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must be a string"
+        response = cache_name_validator(cache_name=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must be a string"
+        else:
+            assert False
 
     def with_empty_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = cache_name_validator("")
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must not be empty"
+        response = cache_name_validator(cache_name="")
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must not be empty"
+        else:
+            assert False
 
     def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = cache_name_validator(1)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must be a string"
+        response = cache_name_validator(cache_name=1)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must be a string"
+        else:
+            assert False
 
 
-TKeyValidator = Callable[[str, TScalarKey], CacheResponse]
+class TKeyValidator(Protocol):
+    def __call__(self, key: TScalarKey) -> CacheResponse:
+        ...
 
 
 def a_key_validator() -> None:
     def with_null_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
-        response = key_validator(cache_name, None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        response = key_validator(key=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        else:
+            assert False
 
     def with_bad_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
-        response = key_validator(cache_name, 1)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
+        response = key_validator(key=1)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
+        else:
+            assert False
 
 
-TConnectionValidator = Callable[[SimpleCacheClient, str], CacheResponse]
+class TConnectionValidator(Protocol):
+    def __call__(self, client: SimpleCacheClient) -> CacheResponse:
+        ...
 
 
 def a_connection_validator() -> None:
     def throws_authentication_exception_for_bad_token(
         bad_token_credential_provider: CredentialProvider,
         configuration: Configuration,
-        cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
         with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
-            response = connection_validator(client, cache_name)
-            assert isinstance(response, ErrorResponseMixin)
-            assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
+            response = connection_validator(client)
+            if isinstance(response, ErrorResponseMixin):
+                assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
+            else:
+                assert False
 
     def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
         credential_provider: CredentialProvider,
-        cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
         with SimpleCacheClient(configuration, credential_provider, default_ttl_seconds) as client:
-            response = connection_validator(client, cache_name)
-            assert isinstance(response, ErrorResponseMixin)
-            assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
+            response = connection_validator(client)
+            if isinstance(response, ErrorResponseMixin):
+                assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
+            else:
+                assert False

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import Awaitable
 
@@ -8,8 +10,8 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
-from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TScalarKey
+from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 
 
@@ -22,34 +24,31 @@ def a_cache_name_validator() -> None:
     async def with_non_existent_cache_name_it_throws_not_found(cache_name_validator: TCacheNameValidator) -> None:
         cache_name = uuid_str()
         response = await cache_name_validator(cache_name=cache_name)
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
-        else:
-            assert False
+        assert_response_is_error(response, error_code=MomentoErrorCode.NOT_FOUND_ERROR)
 
     async def with_null_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = await cache_name_validator(cache_name=None)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must be a string"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must be a string",
+        )
 
     async def with_empty_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = await cache_name_validator(cache_name="")
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must not be empty"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must not be empty",
+        )
 
     async def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
         response = await cache_name_validator(cache_name=1)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Cache name must be a string"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Cache name must be a string",
+        )
 
 
 class TKeyValidator(Protocol):
@@ -60,18 +59,15 @@ class TKeyValidator(Protocol):
 def a_key_validator() -> None:
     async def with_null_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
         response = await key_validator(key=None)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        else:
-            assert False
+        assert_response_is_error(response, error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR)
 
     async def with_bad_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
         response = await key_validator(key=1)  # type: ignore
-        if isinstance(response, ErrorResponseMixin):
-            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
-        else:
-            assert False
+        assert_response_is_error(
+            response,
+            error_code=MomentoErrorCode.INVALID_ARGUMENT_ERROR,
+            inner_exception_message="Unsupported type for key: <class 'int'>",
+        )
 
 
 class TConnectionValidator(Protocol):
@@ -90,10 +86,7 @@ def a_connection_validator() -> None:
             configuration, bad_token_credential_provider, default_ttl_seconds
         ) as client_async:
             response = await connection_validator(client_async)
-            if isinstance(response, ErrorResponseMixin):
-                assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
-            else:
-                assert False
+            assert_response_is_error(response, error_code=MomentoErrorCode.AUTHENTICATION_ERROR)
 
     async def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
@@ -104,7 +97,4 @@ def a_connection_validator() -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
         async with SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds) as client_async:
             response = await connection_validator(client_async)
-            if isinstance(response, ErrorResponseMixin):
-                assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
-            else:
-                assert False
+            assert_response_is_error(response, error_code=MomentoErrorCode.TIMEOUT_ERROR)

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
-from typing import Awaitable, Callable
+from typing import Awaitable
+
+from typing_extensions import Protocol
 
 from momento import SimpleCacheClientAsync
 from momento.auth import CredentialProvider
@@ -10,78 +12,99 @@ from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TScalarKey
 from tests.utils import uuid_str
 
-TCacheNameValidator = Callable[[TCacheName], Awaitable[CacheResponse]]
+
+class TCacheNameValidator(Protocol):
+    def __call__(self, cache_name: TCacheName) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_cache_name_validator() -> None:
     async def with_non_existent_cache_name_it_throws_not_found(cache_name_validator: TCacheNameValidator) -> None:
         cache_name = uuid_str()
-        response = await cache_name_validator(cache_name)
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+        response = await cache_name_validator(cache_name=cache_name)
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+        else:
+            assert False
 
     async def with_null_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = await cache_name_validator(None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must be a string"
+        response = await cache_name_validator(cache_name=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must be a string"
+        else:
+            assert False
 
     async def with_empty_cache_name_it_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = await cache_name_validator("")
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must not be empty"
+        response = await cache_name_validator(cache_name="")
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must not be empty"
+        else:
+            assert False
 
     async def with_bad_cache_name_throws_exception(cache_name_validator: TCacheNameValidator) -> None:
-        response = await cache_name_validator(1)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Cache name must be a string"
+        response = await cache_name_validator(cache_name=1)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Cache name must be a string"
+        else:
+            assert False
 
 
-TKeyValidator = Callable[[str, TScalarKey], Awaitable[CacheResponse]]
+class TKeyValidator(Protocol):
+    def __call__(self, key: TScalarKey) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_key_validator() -> None:
     async def with_null_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
-        response = await key_validator(cache_name, None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        response = await key_validator(key=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+        else:
+            assert False
 
     async def with_bad_key_throws_exception(cache_name: str, key_validator: TKeyValidator) -> None:
-        response = await key_validator(cache_name, 1)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
+        response = await key_validator(key=1)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Unsupported type for key: <class 'int'>"
+        else:
+            assert False
 
 
-TConnectionValidator = Callable[[SimpleCacheClientAsync, str], Awaitable[CacheResponse]]
+class TConnectionValidator(Protocol):
+    def __call__(self, client_async: SimpleCacheClientAsync) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_connection_validator() -> None:
     async def throws_authentication_exception_for_bad_token(
         bad_token_credential_provider: CredentialProvider,
         configuration: Configuration,
-        cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
         async with SimpleCacheClientAsync(
             configuration, bad_token_credential_provider, default_ttl_seconds
         ) as client_async:
-            response = await connection_validator(client_async, cache_name)
-            assert isinstance(response, ErrorResponseMixin)
-            assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
+            response = await connection_validator(client_async)
+            if isinstance(response, ErrorResponseMixin):
+                assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
+            else:
+                assert False
 
     async def throws_timeout_error_for_short_request_timeout(
         configuration: Configuration,
         credential_provider: CredentialProvider,
-        cache_name: str,
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
         async with SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds) as client_async:
-            response = await connection_validator(client_async, cache_name)
-            assert isinstance(response, ErrorResponseMixin)
-            assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
+            response = await connection_validator(client_async)
+            if isinstance(response, ErrorResponseMixin):
+                assert response.error_code == MomentoErrorCode.TIMEOUT_ERROR
+            else:
+                assert False

--- a/tests/momento/simple_cache_client/test_dictionary.py
+++ b/tests/momento/simple_cache_client/test_dictionary.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import timedelta
 from functools import partial
 from time import sleep
-from typing import Callable
 
 from pytest import fixture
 from pytest_describe import behaves_like
@@ -45,7 +44,10 @@ from .shared_behaviors import (
     a_connection_validator,
 )
 
-TDictionaryFieldValidator = Callable[[TDictionaryField], CacheResponse]
+
+class TDictionaryFieldValidator(Protocol):
+    def __call__(self, field: TDictionaryField) -> CacheResponse:
+        ...
 
 
 def a_dictionary_field_validator() -> None:
@@ -60,7 +62,9 @@ def a_dictionary_field_validator() -> None:
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-TDictionaryFieldsValidator = Callable[[TDictionaryFields], CacheResponse]
+class TDictionaryFieldsValidator(Protocol):
+    def __call__(fields: TDictionaryFields) -> CacheResponse:
+        ...
 
 
 def a_dictionary_fields_validator() -> None:
@@ -75,7 +79,9 @@ def a_dictionary_fields_validator() -> None:
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-TDictionaryItemsValidator = Callable[[TDictionaryItems], CacheResponse]
+class TDictionaryItemsValidator(Protocol):
+    def __call__(self, items: TDictionaryItems) -> CacheResponse:
+        ...
 
 
 def a_dictionary_items_validator() -> None:
@@ -90,7 +96,9 @@ def a_dictionary_items_validator() -> None:
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-TDictionaryNameValidator = Callable[[TDictionaryName], CacheResponse]
+class TDictionaryNameValidator(Protocol):
+    def __call__(self, dictionary_name: TDictionaryName) -> CacheResponse:
+        ...
 
 
 def a_dictionary_name_validator() -> None:
@@ -115,10 +123,11 @@ def a_dictionary_name_validator() -> None:
         assert response.inner_exception.message == "Dictionary name must be a string"
 
 
-TDictionaryGetter = Callable[
-    [TDictionaryName, TDictionaryField],
-    CacheDictionaryGetFieldResponse,
-]
+class TDictionaryGetter(Protocol):
+    def __call__(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheDictionaryGetFieldResponse:
+        ...
 
 
 def a_dictionary_getter() -> None:
@@ -135,7 +144,9 @@ def a_dictionary_getter() -> None:
         )
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
-        get_response = dictionary_getter(dictionary_name=dictionary_name, field=dictionary_field_bytes)  # type: ignore
+        get_response = dictionary_getter(
+            cache_name=cache_name, dictionary_name=dictionary_name, field=dictionary_field_bytes
+        )
         assert isinstance(get_response, CacheDictionaryGetField.Hit)
         assert get_response.field_bytes == dictionary_field_bytes
         assert get_response.value_bytes == dictionary_value_bytes
@@ -153,13 +164,19 @@ def a_dictionary_getter() -> None:
         )
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
-        get_response = dictionary_getter(dictionary_name=dictionary_name, field=dictionary_field_str)  # type: ignore
+        get_response = dictionary_getter(
+            cache_name=cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
+        )
         assert isinstance(get_response, CacheDictionaryGetField.Hit)
         assert get_response.field_string == dictionary_field_str
         assert get_response.value_string == dictionary_value_str
 
 
-TDictionaryRemover = Callable[[SimpleCacheClient, TDictionaryName, TDictionaryField], CacheResponse]
+class TDictionaryRemover(Protocol):
+    def __call__(
+        self, cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
+    ) -> CacheResponse:
+        ...
 
 
 def a_dictionary_remover() -> None:
@@ -176,26 +193,30 @@ def a_dictionary_remover() -> None:
         )
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
-        remove_response = dictionary_remover(client, dictionary_name, dictionary_field_str)
+        remove_response = dictionary_remover(
+            cache_name=cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
+        )
         assert not isinstance(remove_response, ErrorResponseMixin)
 
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Miss)
 
     def with_bytes_field_succeeds(
+        dictionary_remover: TDictionaryRemover,
         client: SimpleCacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
         dictionary_value_str: str,
-        dictionary_remover: TDictionaryRemover,
     ) -> None:
         set_response = client.dictionary_set_field(
             cache_name, dictionary_name, dictionary_field_bytes, dictionary_value_str
         )
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
-        remove_response = dictionary_remover(client, dictionary_name, dictionary_field_bytes)
+        remove_response = dictionary_remover(
+            cache_name=cache_name, dictionary_name=dictionary_name, field=dictionary_field_bytes
+        )
         assert not isinstance(remove_response, ErrorResponseMixin)
 
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
@@ -206,6 +227,7 @@ class TDictionarySetter(Protocol):
     def __call__(
         self,
         client: SimpleCacheClient,
+        cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         field: TDictionaryField,
         value: TDictionaryValue,
@@ -229,7 +251,7 @@ def a_dictionary_setter() -> None:
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
             for field, value in dictionary_items.items():
-                dictionary_setter(client, dictionary_name, field, value, ttl=ttl)
+                dictionary_setter(client, cache_name, dictionary_name, field, value, ttl=ttl)
 
             sleep(ttl_seconds * 2)
 
@@ -247,7 +269,7 @@ def a_dictionary_setter() -> None:
         items = dict([("one", "1"), ("two", "2"), ("three", "3"), ("four", "4")])
 
         for field, value in items.items():
-            dictionary_setter(client, dictionary_name, field, value, ttl=ttl)
+            dictionary_setter(client, cache_name, dictionary_name, field, value, ttl=ttl)
             sleep(ttl_seconds / 2)
 
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
@@ -267,7 +289,7 @@ def a_dictionary_setter() -> None:
         with SimpleCacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
-            dictionary_setter(client, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=ttl)
+            dictionary_setter(client, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=ttl)
 
             sleep(ttl_seconds / 2)
 
@@ -287,7 +309,14 @@ def a_dictionary_setter() -> None:
         dictionary_field_bytes: bytes,
         dictionary_value_bytes: TDictionaryValue,
     ) -> None:
-        dictionary_setter(client, dictionary_name, dictionary_field_bytes, dictionary_value_bytes, ttl=CollectionTtl())
+        dictionary_setter(
+            client,
+            cache_name,
+            dictionary_name,
+            dictionary_field_bytes,
+            dictionary_value_bytes,
+            ttl=CollectionTtl(),
+        )
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
         assert fetch_response.value_dictionary_bytes_bytes == {dictionary_field_bytes: dictionary_value_bytes}
@@ -300,7 +329,9 @@ def a_dictionary_setter() -> None:
         dictionary_field_str: str,
         dictionary_value_str: str,
     ) -> None:
-        dictionary_setter(client, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=CollectionTtl())
+        dictionary_setter(
+            client, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=CollectionTtl()
+        )
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
         assert fetch_response.value_dictionary_string_string == {dictionary_field_str: dictionary_value_str}
@@ -308,7 +339,6 @@ def a_dictionary_setter() -> None:
     def with_other_values_type_it_errors(
         dictionary_setter: TDictionarySetter,
         client: SimpleCacheClient,
-        cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> None:
         for field, value, bad_type in [
@@ -317,7 +347,10 @@ def a_dictionary_setter() -> None:
             (234, "value", "int"),
             ("field", 234, "int"),
         ]:
-            response = dictionary_setter(client, dictionary_name, field, value, ttl=CollectionTtl())  # type: ignore
+            cache_name = uuid_str()
+            response = dictionary_setter(
+                client, cache_name, dictionary_name, field, value, ttl=CollectionTtl()  # type:ignore[arg-type]
+            )
             assert isinstance(response, ErrorResponseMixin)
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert (
@@ -326,7 +359,9 @@ def a_dictionary_setter() -> None:
             )
 
 
-TDictionaryValueValidator = Callable[[TDictionaryValue], CacheResponse]
+class TDictionaryValueValidator(Protocol):
+    def __call__(self, value: TDictionaryValue) -> CacheResponse:
+        ...
 
 
 def a_dictionary_value_validator() -> None:
@@ -354,8 +389,10 @@ def describe_dictionary_get_field() -> None:
         return partial(client.dictionary_get_field, dictionary_name=dictionary_name, field=dictionary_field_str)
 
     @fixture
-    def connection_validator(dictionary_name: TDictionaryName, dictionary_field_str: str) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+    def connection_validator(
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
+    ) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_get_field(cache_name, dictionary_name=dictionary_name, field=dictionary_field_str)
 
         return _connection_validator
@@ -377,8 +414,8 @@ def describe_dictionary_get_field() -> None:
         return partial(client.dictionary_get_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client: SimpleCacheClient, cache_name: TCacheName) -> TDictionaryGetter:
-        return partial(client.dictionary_get_field, cache_name=cache_name)
+    def dictionary_getter(client: SimpleCacheClient) -> TDictionaryGetter:
+        return partial(client.dictionary_get_field)
 
     def misses_when_the_dictionary_does_not_exist(
         client: SimpleCacheClient,
@@ -404,9 +441,9 @@ def describe_dictionary_get_fields() -> None:
 
     @fixture
     def connection_validator(
-        dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_get_fields(cache_name, dictionary_name, dictionary_fields)
 
         return _connection_validator
@@ -428,9 +465,9 @@ def describe_dictionary_get_fields() -> None:
         return partial(client.dictionary_get_fields, cache_name=cache_name, fields=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client: SimpleCacheClient, cache_name: TCacheName) -> TDictionaryGetter:
+    def dictionary_getter(client: SimpleCacheClient) -> TDictionaryGetter:
         def _dictionary_getter(
-            dictionary_name: TDictionaryName, field: TDictionaryField
+            cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheDictionaryGetFieldResponse:
             response = client.dictionary_get_fields(cache_name, dictionary_name, [field])
             if isinstance(response, CacheDictionaryGetFields.Error):
@@ -504,8 +541,8 @@ def describe_dictionary_fetch() -> None:
         return partial(client.dictionary_fetch, dictionary_name=dictionary_name)
 
     @fixture
-    def connection_validator(dictionary_name: TDictionaryName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+    def connection_validator(cache_name: TCacheName, dictionary_name: TDictionaryName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_fetch(cache_name, dictionary_name=dictionary_name)
 
         return _connection_validator
@@ -543,11 +580,12 @@ def describe_dictionary_increment() -> None:
 
     @fixture
     def connection_validator(
+        cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
         increment_amount: int,
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_increment(
                 cache_name,
                 dictionary_name=dictionary_name,
@@ -659,8 +697,10 @@ def describe_dictionary_remove_field() -> None:
         return partial(client.dictionary_remove_field, dictionary_name=dictionary_name, field=dictionary_field_str)
 
     @fixture
-    def connection_validator(dictionary_name: TDictionaryName, dictionary_field_str: str) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+    def connection_validator(
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
+    ) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_remove_field(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
             )
@@ -684,15 +724,8 @@ def describe_dictionary_remove_field() -> None:
         return partial(client.dictionary_remove_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_remover(cache_name: TCacheName) -> TDictionaryRemover:
-        def _dictionary_remover(
-            client: SimpleCacheClient,
-            dictionary_name: TDictionaryName,
-            field: TDictionaryField,
-        ) -> CacheResponse:
-            return client.dictionary_remove_field(cache_name, dictionary_name, field)
-
-        return _dictionary_remover
+    def dictionary_remover(client: SimpleCacheClient) -> TDictionaryRemover:
+        return partial(client.dictionary_remove_field)
 
     def it_removes_a_field(
         client: SimpleCacheClient,
@@ -735,9 +768,9 @@ def describe_dictionary_remove_fields() -> None:
 
     @fixture
     def connection_validator(
-        dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_remove_fields(
                 cache_name, dictionary_name=dictionary_name, fields=dictionary_fields
             )
@@ -761,13 +794,13 @@ def describe_dictionary_remove_fields() -> None:
         return partial(client.dictionary_remove_fields, cache_name=cache_name, fields=dictionary_fields)
 
     @fixture
-    def dictionary_remover(cache_name: TCacheName) -> TDictionaryRemover:
+    def dictionary_remover(client: SimpleCacheClient) -> TDictionaryRemover:
         def _dictionary_remover(
-            client: SimpleCacheClient,
-            dictionary_name: TDictionaryName,
-            field: TDictionaryField,
+            cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheResponse:
-            return client.dictionary_remove_fields(cache_name, dictionary_name, [field])
+            return client.dictionary_remove_fields(
+                cache_name=cache_name, dictionary_name=dictionary_name, fields=[field]
+            )
 
         return _dictionary_remover
 
@@ -815,9 +848,9 @@ def describe_dictionary_set_field() -> None:
 
     @fixture
     def connection_validator(
-        dictionary_name: TDictionaryName, dictionary_field_str: str, dictionary_value_str: str
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str, dictionary_value_str: str
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_set_field(
                 cache_name,
                 dictionary_name=dictionary_name,
@@ -843,16 +876,23 @@ def describe_dictionary_set_field() -> None:
         )
 
     @fixture
-    def dictionary_setter(cache_name: TCacheName) -> TDictionarySetter:
+    def dictionary_setter() -> TDictionarySetter:
         def _dictionary_setter(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
             value: TDictionaryValue,
             *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.dictionary_set_field(cache_name, dictionary_name, field, value, ttl=ttl)
+            return client.dictionary_set_field(
+                cache_name=cache_name,
+                dictionary_name=dictionary_name,
+                field=field,
+                value=value,
+                ttl=ttl,
+            )
 
         return _dictionary_setter
 
@@ -868,7 +908,6 @@ def describe_dictionary_set_field() -> None:
             cache_name=cache_name,
             dictionary_name=dictionary_name,
             field=dictionary_field_str,
-            ttl=CollectionTtl(),
         )
 
 
@@ -888,9 +927,9 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def connection_validator(
-        dictionary_name: TDictionaryName, dictionary_items: TDictionaryItems
+        cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_items: TDictionaryItems
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> CacheResponse:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_set_fields(cache_name, dictionary_name=dictionary_name, items=dictionary_items)
 
         return _connection_validator
@@ -917,15 +956,22 @@ def describe_dictionary_set_fields() -> None:
         return partial(client.dictionary_set_fields, cache_name=cache_name, items=dictionary_items, ttl=CollectionTtl())
 
     @fixture
-    def dictionary_setter(cache_name: TCacheName) -> TDictionarySetter:
+    def dictionary_setter() -> TDictionarySetter:
         def _dictionary_setter(
             client: SimpleCacheClient,
+            cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
             value: TDictionaryValue,
+            *,
             ttl: CollectionTtl,
         ) -> CacheResponse:
-            return client.dictionary_set_fields(cache_name, dictionary_name, {field: value}, ttl=ttl)
+            return client.dictionary_set_fields(
+                cache_name=cache_name,
+                dictionary_name=dictionary_name,
+                items={field: value},
+                ttl=ttl,
+            )
 
         return _dictionary_setter
 
@@ -934,11 +980,13 @@ def describe_dictionary_set_fields() -> None:
         client: SimpleCacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
-        dictionary_field_str: str,
+        field: TDictionaryField,
     ) -> TDictionaryValueValidator:
-        def _value_validator(dictionary_value_str: str) -> CacheResponse:
+        def _value_validator(value: TDictionaryValue) -> CacheResponse:
             return client.dictionary_set_fields(
-                cache_name, dictionary_name, items={dictionary_field_str: dictionary_value_str}
+                cache_name=cache_name,
+                dictionary_name=dictionary_name,
+                items={field: value},
             )
 
         return _value_validator

--- a/tests/momento/simple_cache_client/test_dictionary.py
+++ b/tests/momento/simple_cache_client/test_dictionary.py
@@ -315,7 +315,6 @@ def a_dictionary_setter() -> None:
             dictionary_name,
             dictionary_field_bytes,
             dictionary_value_bytes,
-            ttl=CollectionTtl(),
         )
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
@@ -329,9 +328,7 @@ def a_dictionary_setter() -> None:
         dictionary_field_str: str,
         dictionary_value_str: str,
     ) -> None:
-        dictionary_setter(
-            client, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=CollectionTtl()
-        )
+        dictionary_setter(client, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str)
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
         assert fetch_response.value_dictionary_string_string == {dictionary_field_str: dictionary_value_str}
@@ -575,7 +572,6 @@ def describe_dictionary_increment() -> None:
             dictionary_name=dictionary_name,
             field=dictionary_field_str,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -587,11 +583,7 @@ def describe_dictionary_increment() -> None:
     ) -> TConnectionValidator:
         def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.dictionary_increment(
-                cache_name,
-                dictionary_name=dictionary_name,
-                field=dictionary_field_str,
-                amount=increment_amount,
-                ttl=CollectionTtl(),
+                cache_name, dictionary_name=dictionary_name, field=dictionary_field_str, amount=increment_amount
             )
 
         return _connection_validator
@@ -608,7 +600,6 @@ def describe_dictionary_increment() -> None:
             cache_name=cache_name,
             dictionary_name=dictionary_name,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -623,7 +614,6 @@ def describe_dictionary_increment() -> None:
             cache_name=cache_name,
             field=dictionary_field_str,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     def it_starts_at_zero(
@@ -872,7 +862,6 @@ def describe_dictionary_set_field() -> None:
             cache_name=cache_name,
             field=dictionary_field_str,
             value=dictionary_value_str,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -884,7 +873,7 @@ def describe_dictionary_set_field() -> None:
             field: TDictionaryField,
             value: TDictionaryValue,
             *,
-            ttl: CollectionTtl,
+            ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         ) -> CacheResponse:
             return client.dictionary_set_field(
                 cache_name=cache_name,
@@ -944,7 +933,6 @@ def describe_dictionary_set_fields() -> None:
             client.dictionary_set_fields,
             cache_name=cache_name,
             dictionary_name=dictionary_name,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -953,7 +941,7 @@ def describe_dictionary_set_fields() -> None:
         cache_name: TCacheName,
         dictionary_items: TDictionaryItems,
     ) -> TDictionaryNameValidator:
-        return partial(client.dictionary_set_fields, cache_name=cache_name, items=dictionary_items, ttl=CollectionTtl())
+        return partial(client.dictionary_set_fields, cache_name=cache_name, items=dictionary_items)
 
     @fixture
     def dictionary_setter() -> TDictionarySetter:
@@ -964,7 +952,7 @@ def describe_dictionary_set_fields() -> None:
             field: TDictionaryField,
             value: TDictionaryValue,
             *,
-            ttl: CollectionTtl,
+            ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         ) -> CacheResponse:
             return client.dictionary_set_fields(
                 cache_name=cache_name,
@@ -997,7 +985,7 @@ def describe_dictionary_set_fields() -> None:
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> None:
-        set_response = client.dictionary_set_fields(cache_name, dictionary_name, dictionary_items, ttl=CollectionTtl())
+        set_response = client.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)

--- a/tests/momento/simple_cache_client/test_dictionary_async.py
+++ b/tests/momento/simple_cache_client/test_dictionary_async.py
@@ -318,7 +318,6 @@ def a_dictionary_setter() -> None:
             dictionary_name,
             dictionary_field_bytes,
             dictionary_value_bytes,
-            ttl=CollectionTtl(),
         )
         fetch_response = await client_async.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
@@ -332,9 +331,7 @@ def a_dictionary_setter() -> None:
         dictionary_field_str: str,
         dictionary_value_str: str,
     ) -> None:
-        await dictionary_setter(
-            client_async, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=CollectionTtl()
-        )
+        await dictionary_setter(client_async, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str)
         fetch_response = await client_async.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Hit)
         assert fetch_response.value_dictionary_string_string == {dictionary_field_str: dictionary_value_str}
@@ -584,7 +581,6 @@ def describe_dictionary_increment() -> None:
             dictionary_name=dictionary_name,
             field=dictionary_field_str,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -596,11 +592,7 @@ def describe_dictionary_increment() -> None:
     ) -> TConnectionValidator:
         async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_increment(
-                cache_name,
-                dictionary_name=dictionary_name,
-                field=dictionary_field_str,
-                amount=increment_amount,
-                ttl=CollectionTtl(),
+                cache_name, dictionary_name=dictionary_name, field=dictionary_field_str, amount=increment_amount
             )
 
         return _connection_validator
@@ -617,7 +609,6 @@ def describe_dictionary_increment() -> None:
             cache_name=cache_name,
             dictionary_name=dictionary_name,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -632,7 +623,6 @@ def describe_dictionary_increment() -> None:
             cache_name=cache_name,
             field=dictionary_field_str,
             amount=increment_amount,
-            ttl=CollectionTtl(),
         )
 
     async def it_starts_at_zero(
@@ -891,7 +881,6 @@ def describe_dictionary_set_field() -> None:
             cache_name=cache_name,
             field=dictionary_field_str,
             value=dictionary_value_str,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -903,7 +892,7 @@ def describe_dictionary_set_field() -> None:
             field: TDictionaryField,
             value: TDictionaryValue,
             *,
-            ttl: CollectionTtl,
+            ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         ) -> CacheResponse:
             return await client_async.dictionary_set_field(
                 cache_name=cache_name,
@@ -965,7 +954,6 @@ def describe_dictionary_set_fields() -> None:
             client_async.dictionary_set_fields,
             cache_name=cache_name,
             dictionary_name=dictionary_name,
-            ttl=CollectionTtl(),
         )
 
     @fixture
@@ -974,9 +962,7 @@ def describe_dictionary_set_fields() -> None:
         cache_name: TCacheName,
         dictionary_items: TDictionaryItems,
     ) -> TDictionaryNameValidator:
-        return partial(
-            client_async.dictionary_set_fields, cache_name=cache_name, items=dictionary_items, ttl=CollectionTtl()
-        )
+        return partial(client_async.dictionary_set_fields, cache_name=cache_name, items=dictionary_items)
 
     @fixture
     def dictionary_setter() -> TDictionarySetter:
@@ -987,7 +973,7 @@ def describe_dictionary_set_fields() -> None:
             field: TDictionaryField,
             value: TDictionaryValue,
             *,
-            ttl: CollectionTtl,
+            ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
         ) -> CacheResponse:
             return await client_async.dictionary_set_fields(
                 cache_name=cache_name,
@@ -1020,9 +1006,7 @@ def describe_dictionary_set_fields() -> None:
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> None:
-        set_response = await client_async.dictionary_set_fields(
-            cache_name, dictionary_name, dictionary_items, ttl=CollectionTtl()
-        )
+        set_response = await client_async.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 
         fetch_response = await client_async.dictionary_fetch(cache_name, dictionary_name)

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -2,7 +2,6 @@ from collections import Counter
 from datetime import timedelta
 from functools import partial
 from time import sleep
-from typing import Callable
 
 import pytest
 from pytest import fixture
@@ -118,13 +117,14 @@ def a_list_adder() -> None:
             assert isinstance(fetch_resp, CacheListFetch.Miss)
 
 
-TListConcatenator = Callable[[TCacheName, TListName, TListValuesInput], CacheResponse]
+class TListConcatenator(Protocol):
+    def __call__(self, cache_name: TCacheName, list_name: TListName, values: TListValuesInput) -> CacheResponse:
+        ...
 
 
 def a_list_concatenator() -> None:
     def it_returns_the_new_list_length(
         list_concatenator: TListConcatenator,
-        client: SimpleCacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         values: TListValuesInput,
@@ -186,44 +186,47 @@ def a_list_concatenator() -> None:
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
-        resp = list_concatenator(cache_name, list_name, 234)
+        resp = list_concatenator(cache_name, list_name, 234)  # type:ignore[arg-type]
         assert isinstance(resp, ErrorResponseMixin)
         assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert resp.message == "Invalid argument passed to Momento client: Unsupported type for values: <class 'int'>"
 
 
-TListNameValidator = Callable[[TListName], CacheResponse]
+class TListNameValidator(Protocol):
+    def __call__(self, list_name: TListName) -> CacheResponse:
+        ...
 
 
 def a_list_name_validator() -> None:
-    def with_null_list_name_it_returns_invalid(list_name_validator: TListNameValidator, cache_name: TCacheName) -> None:
-        response = list_name_validator(cache_name, None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "List name must be a string"
+    def with_null_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
+        response = list_name_validator(list_name=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "List name must be a string"
+        else:
+            assert False
 
-    def with_empty_list_name_it_returns_invalid(
-        list_name_validator: TListNameValidator, cache_name: TCacheName
-    ) -> None:
-        response = list_name_validator(cache_name, "")
+    def with_empty_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
+        response = list_name_validator(list_name="")
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "List name must not be empty"
 
-    def with_bad_list_name_it_returns_invalid(list_name_validator: TCacheNameValidator, cache_name: TCacheName) -> None:
-        response = list_name_validator(cache_name, 1)  # type: ignore
+    def with_bad_list_name_it_returns_invalid(list_name_validator: TCacheNameValidator) -> None:
+        response = list_name_validator(list_name=1)  # type: ignore
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "List name must be a string"
 
 
-TListPusher = Callable[[TCacheName, TListName, TListValue], CacheResponse]
+class TListPusher(Protocol):
+    def __call__(self, cache_name: TCacheName, list_name: TListName, value: TListValue) -> CacheResponse:
+        ...
 
 
 def a_list_pusher() -> None:
     def it_returns_the_new_list_length(
         list_pusher: TListPusher,
-        client: SimpleCacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         values: TListValuesInput,
@@ -268,7 +271,7 @@ def a_list_pusher() -> None:
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
-        resp = list_pusher(cache_name, list_name, 234)
+        resp = list_pusher(cache_name, list_name, 234)  # type:ignore[arg-type]
         assert isinstance(resp, ErrorResponseMixin)
         assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert resp.message == "Invalid argument passed to Momento client: Unsupported type for value: <class 'int'>"
@@ -286,10 +289,11 @@ def describe_list_concatenate_back() -> None:
         return partial(client.list_concatenate_back, list_name=list_name, values=[uuid_str()])
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return client.list_concatenate_back(cache_name, list_name, [uuid_str()])
+    def connection_validator(
+        cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+    ) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+            return client.list_concatenate_back(cache_name, list_name, values)
 
         return _connection_validator
 
@@ -309,14 +313,12 @@ def describe_list_concatenate_back() -> None:
 
     @fixture
     def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+        client: SimpleCacheClient, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
-        return partial(client.list_concatenate_back, values=values)
+        return partial(client.list_concatenate_back, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
-    ) -> TListConcatenator:
+    def list_concatenator(client: SimpleCacheClient) -> TListConcatenator:
         return partial(client.list_concatenate_back)
 
     def it_truncates_the_front(
@@ -345,7 +347,10 @@ def describe_list_concatenate_back() -> None:
         assert concat_resp.list_length <= truncate_to
 
         fetch_resp = client.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["three", "four", "five", "six"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["three", "four", "five", "six"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -360,10 +365,12 @@ def describe_list_concatenate_front() -> None:
         return partial(client.list_concatenate_front, list_name=list_name, values=[uuid_str()])
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(
+        cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+    ) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             list_name = uuid_str()
-            return client.list_concatenate_front(cache_name, list_name, [uuid_str()])
+            return client.list_concatenate_front(cache_name, list_name, values)
 
         return _connection_validator
 
@@ -383,14 +390,12 @@ def describe_list_concatenate_front() -> None:
 
     @fixture
     def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+        client: SimpleCacheClient, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
-        return partial(client.list_concatenate_front, values=values)
+        return partial(client.list_concatenate_front, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
-    ) -> TListConcatenator:
+    def list_concatenator(client: SimpleCacheClient) -> TListConcatenator:
         return partial(client.list_concatenate_front)
 
     def it_truncates_the_back(
@@ -419,7 +424,10 @@ def describe_list_concatenate_front() -> None:
         assert concat_resp.list_length <= truncate_to
 
         fetch_resp = client.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["four", "five", "six", "one"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["four", "five", "six", "one"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -432,18 +440,15 @@ def describe_list_fetch() -> None:
         return partial(client.list_fetch, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client.list_fetch)
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client.list_fetch, cache_name=cache_name)
 
     def misses_when_the_list_does_not_exist(
         client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
@@ -462,18 +467,15 @@ def describe_list_length() -> None:
         return partial(client.list_length, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.list_length(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client.list_length)
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client.list_length, cache_name=cache_name)
 
     def it_returns_the_list_length(
         client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
@@ -501,18 +503,15 @@ def describe_list_pop_back() -> None:
         return partial(client.list_pop_back, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.list_pop_back(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client.list_pop_back)
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client.list_pop_back, cache_name=cache_name)
 
     def it_pops_the_back(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
@@ -540,18 +539,15 @@ def describe_list_pop_front() -> None:
         return partial(client.list_pop_front, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             return client.list_pop_front(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client.list_pop_front)
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client.list_pop_front, cache_name=cache_name)
 
     def it_pops_the_front(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
@@ -581,10 +577,9 @@ def describe_list_push_back() -> None:
         return partial(client.list_push_back, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return client.list_push_back(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+            return client.list_push_back(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
@@ -602,11 +597,9 @@ def describe_list_push_back() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client.list_push_back, value=value)
+        return partial(client.list_push_back, cache_name=cache_name, value=value)
 
     @fixture
     def list_pusher(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> TListPusher:
@@ -629,7 +622,10 @@ def describe_list_push_back() -> None:
             assert isinstance(concat_resp, CacheListPushBack.Success)
 
         fetch_resp = client.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["2", "3"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["2", "3"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -644,10 +640,9 @@ def describe_list_push_front() -> None:
         return partial(client.list_push_front, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return client.list_push_front(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+            return client.list_push_front(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
@@ -666,16 +661,12 @@ def describe_list_push_front() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client.list_push_front, value=value)
+        return partial(client.list_push_front, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListPusher:
+    def list_pusher(client: SimpleCacheClient) -> TListPusher:
         return partial(client.list_push_front)
 
     def it_truncates_the_back(
@@ -695,7 +686,10 @@ def describe_list_push_front() -> None:
             assert isinstance(concat_resp, CacheListPushFront.Success)
 
         fetch_resp = client.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["3", "2"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["3", "2"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -708,19 +702,16 @@ def describe_list_remove_value() -> None:
         return partial(client.list_remove_value, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return client.list_remove_value(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+            return client.list_remove_value(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client.list_remove_value, value=value)
+        return partial(client.list_remove_value, cache_name=cache_name, value=value)
 
     @pytest.mark.parametrize(
         "values, to_remove, expected_values",
@@ -745,4 +736,7 @@ def describe_list_remove_value() -> None:
         client.list_remove_value(cache_name, list_name, to_remove)
 
         fetch_resp = client.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == expected_values
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == expected_values
+        else:
+            assert False

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -2,7 +2,7 @@ from collections import Counter
 from datetime import timedelta
 from functools import partial
 from time import sleep
-from typing import Awaitable, Callable
+from typing import Awaitable
 
 import pytest
 from pytest import fixture
@@ -118,13 +118,16 @@ def a_list_adder() -> None:
             assert isinstance(fetch_resp, CacheListFetch.Miss)
 
 
-TListConcatenator = Callable[[TCacheName, TListName, TListValuesInput], Awaitable[CacheResponse]]
+class TListConcatenator(Protocol):
+    def __call__(
+        self, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+    ) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_list_concatenator() -> None:
     async def it_returns_the_new_list_length(
         list_concatenator: TListConcatenator,
-        client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         values: TListValuesInput,
@@ -186,48 +189,47 @@ def a_list_concatenator() -> None:
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
-        resp = await list_concatenator(cache_name, list_name, 234)
+        resp = await list_concatenator(cache_name, list_name, 234)  # type:ignore[arg-type]
         assert isinstance(resp, ErrorResponseMixin)
         assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert resp.message == "Invalid argument passed to Momento client: Unsupported type for values: <class 'int'>"
 
 
-TListNameValidator = Callable[[TListName], Awaitable[CacheResponse]]
+class TListNameValidator(Protocol):
+    def __call__(self, list_name: TListName) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_list_name_validator() -> None:
-    async def with_null_list_name_it_returns_invalid(
-        list_name_validator: TListNameValidator, cache_name: TCacheName
-    ) -> None:
-        response = await list_name_validator(cache_name, None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "List name must be a string"
+    async def with_null_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
+        response = await list_name_validator(list_name=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "List name must be a string"
+        else:
+            assert False
 
-    async def with_empty_list_name_it_returns_invalid(
-        list_name_validator: TListNameValidator, cache_name: TCacheName
-    ) -> None:
-        response = await list_name_validator(cache_name, "")
+    async def with_empty_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
+        response = await list_name_validator(list_name="")
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "List name must not be empty"
 
-    async def with_bad_list_name_it_returns_invalid(
-        list_name_validator: TCacheNameValidator, cache_name: TCacheName
-    ) -> None:
-        response = await list_name_validator(cache_name, 1)  # type: ignore
+    async def with_bad_list_name_it_returns_invalid(list_name_validator: TCacheNameValidator) -> None:
+        response = await list_name_validator(list_name=1)  # type: ignore
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "List name must be a string"
 
 
-TListPusher = Callable[[TCacheName, TListName, TListValue], Awaitable[CacheResponse]]
+class TListPusher(Protocol):
+    def __call__(self, cache_name: TCacheName, list_name: TListName, value: TListValue) -> Awaitable[CacheResponse]:
+        ...
 
 
 def a_list_pusher() -> None:
     async def it_returns_the_new_list_length(
         list_pusher: TListPusher,
-        client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         values: TListValuesInput,
@@ -272,7 +274,7 @@ def a_list_pusher() -> None:
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
-        resp = await list_pusher(cache_name, list_name, 234)
+        resp = await list_pusher(cache_name, list_name, 234)  # type:ignore[arg-type]
         assert isinstance(resp, ErrorResponseMixin)
         assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert resp.message == "Invalid argument passed to Momento client: Unsupported type for value: <class 'int'>"
@@ -290,12 +292,11 @@ def describe_list_concatenate_back() -> None:
         return partial(client_async.list_concatenate_back, list_name=list_name, values=[uuid_str()])
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return await client_async.list_concatenate_back(cache_name, list_name, [uuid_str()])
+    def connection_validator(
+        cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+    ) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+            return await client_async.list_concatenate_back(cache_name, list_name, values)
 
         return _connection_validator
 
@@ -315,14 +316,12 @@ def describe_list_concatenate_back() -> None:
 
     @fixture
     def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+        client_async: SimpleCacheClientAsync, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
-        return partial(client_async.list_concatenate_back, values=values)
+        return partial(client_async.list_concatenate_back, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
-    ) -> TListConcatenator:
+    def list_concatenator(client_async: SimpleCacheClientAsync) -> TListConcatenator:
         return partial(client_async.list_concatenate_back)
 
     async def it_truncates_the_front(
@@ -351,7 +350,10 @@ def describe_list_concatenate_back() -> None:
         assert concat_resp.list_length <= truncate_to
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["three", "four", "five", "six"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["three", "four", "five", "six"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -366,12 +368,12 @@ def describe_list_concatenate_front() -> None:
         return partial(client_async.list_concatenate_front, list_name=list_name, values=[uuid_str()])
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
+    def connection_validator(
+        cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+    ) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             list_name = uuid_str()
-            return await client_async.list_concatenate_front(cache_name, list_name, [uuid_str()])
+            return await client_async.list_concatenate_front(cache_name, list_name, values)
 
         return _connection_validator
 
@@ -391,14 +393,12 @@ def describe_list_concatenate_front() -> None:
 
     @fixture
     def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
+        client_async: SimpleCacheClientAsync, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
-        return partial(client_async.list_concatenate_front, values=values)
+        return partial(client_async.list_concatenate_front, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
-    ) -> TListConcatenator:
+    def list_concatenator(client_async: SimpleCacheClientAsync) -> TListConcatenator:
         return partial(client_async.list_concatenate_front)
 
     async def it_truncates_the_back(
@@ -427,7 +427,10 @@ def describe_list_concatenate_front() -> None:
         assert concat_resp.list_length <= truncate_to
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["four", "five", "six", "one"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["four", "five", "six", "one"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -440,20 +443,15 @@ def describe_list_fetch() -> None:
         return partial(client_async.list_fetch, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             return await client_async.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client_async.list_fetch)
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client_async.list_fetch, cache_name=cache_name)
 
     async def misses_when_the_list_does_not_exist(
         client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
@@ -472,20 +470,15 @@ def describe_list_length() -> None:
         return partial(client_async.list_length, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             return await client_async.list_length(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client_async.list_length)
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client_async.list_length, cache_name=cache_name)
 
     async def it_returns_the_list_length(
         client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: TListValuesInput
@@ -513,20 +506,15 @@ def describe_list_pop_back() -> None:
         return partial(client_async.list_pop_back, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             return await client_async.list_pop_back(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client_async.list_pop_back)
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client_async.list_pop_back, cache_name=cache_name)
 
     async def it_pops_the_back(
         client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
@@ -556,20 +544,15 @@ def describe_list_pop_front() -> None:
         return partial(client_async.list_pop_front, list_name=list_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
+    def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
             return await client_async.list_pop_front(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
-        return partial(client_async.list_pop_front)
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+        return partial(client_async.list_pop_front, cache_name=cache_name)
 
     async def it_pops_the_front(
         client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
@@ -601,12 +584,9 @@ def describe_list_push_back() -> None:
         return partial(client_async.list_push_back, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return await client_async.list_push_back(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+            return await client_async.list_push_back(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
@@ -624,11 +604,9 @@ def describe_list_push_back() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client_async.list_push_back, value=value)
+        return partial(client_async.list_push_back, cache_name=cache_name, value=value)
 
     @fixture
     def list_pusher(client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName) -> TListPusher:
@@ -651,7 +629,10 @@ def describe_list_push_back() -> None:
             assert isinstance(concat_resp, CacheListPushBack.Success)
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["2", "3"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["2", "3"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -666,12 +647,9 @@ def describe_list_push_front() -> None:
         return partial(client_async.list_push_front, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return await client_async.list_push_front(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+            return await client_async.list_push_front(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
@@ -690,16 +668,12 @@ def describe_list_push_front() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client_async.list_push_front, value=value)
+        return partial(client_async.list_push_front, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, list_value: TListValue
-    ) -> TListPusher:
+    def list_pusher(client_async: SimpleCacheClientAsync) -> TListPusher:
         return partial(client_async.list_push_front)
 
     async def it_truncates_the_back(
@@ -719,7 +693,10 @@ def describe_list_push_front() -> None:
             assert isinstance(concat_resp, CacheListPushFront.Success)
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == ["3", "2"]
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == ["3", "2"]
+        else:
+            assert False
 
 
 @behaves_like(a_cache_name_validator)
@@ -732,21 +709,16 @@ def describe_list_remove_value() -> None:
         return partial(client_async.list_remove_value, list_name=list_name, value=uuid_str())
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        async def _connection_validator(
-            client_async: SimpleCacheClientAsync, cache_name: TCacheName
-        ) -> ErrorResponseMixin:
-            list_name = uuid_str()
-            return await client_async.list_remove_value(cache_name=cache_name, list_name=list_name, value=uuid_str())
+    def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
+        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+            return await client_async.list_remove_value(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> TListNameValidator:
+    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
-        return partial(client_async.list_remove_value, value=value)
+        return partial(client_async.list_remove_value, cache_name=cache_name, value=value)
 
     @pytest.mark.parametrize(
         "values, to_remove, expected_values",
@@ -771,4 +743,7 @@ def describe_list_remove_value() -> None:
         await client_async.list_remove_value(cache_name, list_name, to_remove)
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
-        assert fetch_resp.values_string == expected_values
+        if isinstance(fetch_resp, CacheListFetch.Hit):
+            assert fetch_resp.values_string == expected_values
+        else:
+            assert False

--- a/tests/momento/simple_cache_client/test_set.py
+++ b/tests/momento/simple_cache_client/test_set.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from functools import partial
 from time import sleep
-from typing import Callable
 
 from pytest import fixture
 from pytest_describe import behaves_like
@@ -114,20 +113,17 @@ def a_set_adder() -> None:
 
 
 class TSetWhichTakesAnElement(Protocol):
-    def __call__(
-        self, client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName, element: TSetElement
-    ) -> CacheResponse:
+    def __call__(self, cache_name: TCacheName, set_name: TSetName, element: TSetElement) -> CacheResponse:
         ...
 
 
 def a_set_which_takes_an_element() -> None:
     def it_errors_with_the_wrong_type(
         set_which_takes_an_element: TSetWhichTakesAnElement,
-        client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
-        resp = set_which_takes_an_element(client, cache_name, set_name, 1)  # type:ignore[arg-type]
+        resp = set_which_takes_an_element(cache_name, set_name, 1)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
@@ -138,11 +134,10 @@ def a_set_which_takes_an_element() -> None:
 
     def it_errors_with_none(
         set_which_takes_an_element: TSetWhichTakesAnElement,
-        client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
-        resp = set_which_takes_an_element(client, cache_name, set_name, None)  # type:ignore[arg-type]
+        resp = set_which_takes_an_element(cache_name, set_name, None)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
@@ -152,24 +147,28 @@ def a_set_which_takes_an_element() -> None:
             assert False
 
 
-TSetNameValidator = Callable[[TCacheName, TSetName], CacheResponse]
+class TSetNameValidator(Protocol):
+    def __call__(self, set_name: TSetName) -> CacheResponse:
+        ...
 
 
 def a_set_name_validator() -> None:
-    def with_null_set_name_it_returns_invalid(set_name_validator: TSetNameValidator, cache_name: TCacheName) -> None:
-        response = set_name_validator(cache_name, None)  # type: ignore
-        assert isinstance(response, ErrorResponseMixin)
-        assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-        assert response.inner_exception.message == "Set name must be a string"
+    def with_null_set_name_it_returns_invalid(set_name_validator: TSetNameValidator) -> None:
+        response = set_name_validator(set_name=None)  # type: ignore
+        if isinstance(response, ErrorResponseMixin):
+            assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+            assert response.inner_exception.message == "Set name must be a string"
+        else:
+            assert False
 
-    def with_empty_set_name_it_returns_invalid(set_name_validator: TSetNameValidator, cache_name: TCacheName) -> None:
-        response = set_name_validator(cache_name, "")
+    def with_empty_set_name_it_returns_invalid(set_name_validator: TSetNameValidator) -> None:
+        response = set_name_validator(set_name="")
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "Set name must not be empty"
 
-    def with_bad_set_name_it_returns_invalid(set_name_validator: TCacheNameValidator, cache_name: TCacheName) -> None:
-        response = set_name_validator(cache_name, 1)  # type: ignore
+    def with_bad_set_name_it_returns_invalid(set_name_validator: TCacheNameValidator) -> None:
+        response = set_name_validator(set_name=1)  # type: ignore
         assert isinstance(response, ErrorResponseMixin)
         assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         assert response.inner_exception.message == "Set name must be a string"
@@ -188,8 +187,8 @@ def describe_set_add_element() -> None:
         return partial(client.set_add_element, set_name=set_name, element=element)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return client.set_add_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -211,13 +210,15 @@ def describe_set_add_element() -> None:
         return _set_adder
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient, element: TSetElement) -> TSetNameValidator:
-        return partial(client.set_add_element, element=element)
+    def set_name_validator(
+        client: SimpleCacheClient, cache_name: TCacheName, element: TSetElement
+    ) -> TSetNameValidator:
+        return partial(client.set_add_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element() -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
-            client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName, element: TSetElement
+            cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
             return client.set_add_element(cache_name, set_name, element)
 
@@ -277,8 +278,8 @@ def describe_set_add_elements() -> None:
         return partial(client.set_add_elements, set_name=set_name, elements=elements)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return client.set_add_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -300,13 +301,15 @@ def describe_set_add_elements() -> None:
         return _set_adder
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient, elements: TSetElementsInput) -> TSetNameValidator:
-        return partial(client.set_add_elements, elements=elements)
+    def set_name_validator(
+        client: SimpleCacheClient, cache_name: TCacheName, elements: TSetElementsInput
+    ) -> TSetNameValidator:
+        return partial(client.set_add_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element() -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
-            client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName, element: TSetElement
+            cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
             return client.set_add_elements(cache_name, set_name, {element})
 
@@ -365,16 +368,16 @@ def describe_set_fetch() -> None:
         return partial(client.set_fetch, set_name=set_name)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             set_name = uuid_str()
             return client.set_fetch(cache_name=cache_name, set_name=set_name)
 
         return _connection_validator
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient) -> TSetNameValidator:
-        return partial(client.set_fetch)
+    def set_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TSetNameValidator:
+        return partial(client.set_fetch, cache_name=cache_name)
 
     def when_the_set_exists_it_fetches(client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
         elements = {"one", "two"}
@@ -404,8 +407,8 @@ def describe_set_remove_element() -> None:
         return partial(client.set_remove_element, set_name=set_name, element=element)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return client.set_remove_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -413,13 +416,15 @@ def describe_set_remove_element() -> None:
         return _connection_validator
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient, element: TSetElement) -> TSetNameValidator:
-        return partial(client.set_remove_element, element=element)
+    def set_name_validator(
+        client: SimpleCacheClient, cache_name: TCacheName, element: TSetElement
+    ) -> TSetNameValidator:
+        return partial(client.set_remove_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element() -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
-            client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName, element: TSetElement
+            cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
             return client.set_remove_element(cache_name, set_name, element)
 
@@ -488,8 +493,8 @@ def describe_set_remove_elements() -> None:
         return partial(client.set_remove_elements, set_name=set_name, elements=elements)
 
     @fixture
-    def connection_validator() -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient, cache_name: TCacheName) -> ErrorResponseMixin:
+    def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
+        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return client.set_remove_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -497,13 +502,15 @@ def describe_set_remove_elements() -> None:
         return _connection_validator
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient, elements: TSetElementsInput) -> TSetNameValidator:
-        return partial(client.set_remove_elements, elements=elements)
+    def set_name_validator(
+        client: SimpleCacheClient, cache_name: TCacheName, elements: TSetElementsInput
+    ) -> TSetNameValidator:
+        return partial(client.set_remove_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element() -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
-            client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName, element: TSetElement
+            cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
             return client.set_add_elements(cache_name, set_name, {element})
 


### PR DESCRIPTION
* Switch to a style that supports named arguments and is easier to understand.
* Only pass the necessary arguments to fixtures.
* For any test which needs to use the same cache, the fixture gets the cache name.

Also: other misc type issues in the tests.

Closes #254 