### PR TITLE
chore: refine str and repr for collections

### DIFF
--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -487,7 +487,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheListFetch.Miss()
             elif type == "found":
-                return CacheListFetch.Hit(response.found.values)
+                return CacheListFetch.Hit(list(response.found.values))
             else:
                 raise UnknownException("Unknown list field")
         except Exception as e:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -485,7 +485,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheListFetch.Miss()
             elif type == "found":
-                return CacheListFetch.Hit(response.found.values)
+                return CacheListFetch.Hit(list(response.found.values))
             else:
                 raise UnknownException("Unknown list field")
         except Exception as e:

--- a/src/momento/responses/control/list_caches.py
+++ b/src/momento/responses/control/list_caches.py
@@ -52,7 +52,7 @@ class CacheInfo:
 class ListCaches(ABC):
     """Groups all `ListCachesResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(ListCachesResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/control/signing_keys.py
+++ b/src/momento/responses/control/signing_keys.py
@@ -10,7 +10,7 @@ import google
 from momento.responses.response import ControlResponse
 
 
-@dataclass(repr=False)
+@dataclass
 class CreateSigningKeyResponse(ControlResponse):
     """The response from creating a signing key.
 
@@ -61,7 +61,7 @@ class SigningKey:
         return SigningKey(key_id, expires_at, endpoint)
 
 
-@dataclass(repr=False)
+@dataclass
 class ListSigningKeysResponse(ControlResponse):
     """A list signing keys response.
 

--- a/src/momento/responses/dictionary_data/dictionary_fetch.py
+++ b/src/momento/responses/dictionary_data/dictionary_fetch.py
@@ -21,7 +21,7 @@ class CacheDictionaryFetchResponse(CacheResponse):
 class CacheDictionaryFetch(ABC):
     """Groups all `CacheDictionaryFetchResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheDictionaryFetchResponse):
         """Indicates the dictionary exists and its items were fetched."""
 

--- a/src/momento/responses/dictionary_data/dictionary_get_field.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_field.py
@@ -19,7 +19,7 @@ class CacheDictionaryGetFieldResponse(CacheResponse):
 class CacheDictionaryGetField(ABC):
     """Groups all `CacheDictionaryGetFieldResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheDictionaryGetFieldResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 

--- a/src/momento/responses/dictionary_data/dictionary_get_fields.py
+++ b/src/momento/responses/dictionary_data/dictionary_get_fields.py
@@ -25,7 +25,7 @@ class CacheDictionaryGetFieldsResponse(CacheResponse):
 class CacheDictionaryGetFields(ABC):
     """Groups all `CacheDictionaryGetFieldsResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheDictionaryGetFieldsResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 

--- a/src/momento/responses/dictionary_data/dictionary_increment.py
+++ b/src/momento/responses/dictionary_data/dictionary_increment.py
@@ -18,7 +18,7 @@ class CacheDictionaryIncrementResponse(CacheResponse):
 class CacheDictionaryIncrement(ABC):
     """Groups all `CacheDictionaryIncrementResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(CacheDictionaryIncrementResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/list_data/list_concatenate_back.py
+++ b/src/momento/responses/list_data/list_concatenate_back.py
@@ -18,7 +18,7 @@ class CacheListConcatenateBackResponse(CacheResponse):
 class CacheListConcatenateBack(ABC):
     """Groups all `CacheListConcatenateBackResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(CacheListConcatenateBackResponse):
         """Indicates the concatenation was successful."""
 

--- a/src/momento/responses/list_data/list_concatenate_front.py
+++ b/src/momento/responses/list_data/list_concatenate_front.py
@@ -18,7 +18,7 @@ class CacheListConcatenateFrontResponse(CacheResponse):
 class CacheListConcatenateFront(ABC):
     """Groups all `CacheListConcatenateFrontResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(CacheListConcatenateFrontResponse):
         """Indicates the concatenation was successful."""
 

--- a/src/momento/responses/list_data/list_fetch.py
+++ b/src/momento/responses/list_data/list_fetch.py
@@ -21,7 +21,7 @@ class CacheListFetchResponse(CacheResponse):
 class CacheListFetch(ABC):
     """Groups all `CacheListFetchResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheListFetchResponse):
         """Indicates the list exists and its values were fetched."""
 

--- a/src/momento/responses/list_data/list_length.py
+++ b/src/momento/responses/list_data/list_length.py
@@ -19,7 +19,7 @@ class CacheListLengthResponse(CacheResponse):
 class CacheListLength(ABC):
     """Groups all `CacheListLengthResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheListLengthResponse):
         """Indicates the list exists and its length was fetched."""
 

--- a/src/momento/responses/list_data/list_pop_back.py
+++ b/src/momento/responses/list_data/list_pop_back.py
@@ -19,7 +19,7 @@ class CacheListPopBackResponse(CacheResponse):
 class CacheListPopBack(ABC):
     """Groups all `CacheListPopBack` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheListPopBackResponse, ValueStringMixin):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/list_data/list_pop_front.py
+++ b/src/momento/responses/list_data/list_pop_front.py
@@ -19,7 +19,7 @@ class CacheListPopFrontResponse(CacheResponse):
 class CacheListPopFront(ABC):
     """Groups all `CacheListPopFront` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheListPopFrontResponse, ValueStringMixin):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/list_data/list_push_back.py
+++ b/src/momento/responses/list_data/list_push_back.py
@@ -18,7 +18,7 @@ class CacheListPushBackResponse(CacheResponse):
 class CacheListPushBack(ABC):
     """Groups all `CacheListPushBackResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(CacheListPushBackResponse):
         """Indicates the push was successful."""
 

--- a/src/momento/responses/list_data/list_push_front.py
+++ b/src/momento/responses/list_data/list_push_front.py
@@ -18,7 +18,7 @@ class CacheListPushFrontResponse(CacheResponse):
 class CacheListPushFront(ABC):
     """Groups all `CacheListPushFrontResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Success(CacheListPushFrontResponse):
         """Indicates the push was successful."""
 

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -42,6 +42,9 @@ class Response(ABC):
                         value = {
                             Response._truncate_value(k_i): Response._truncate_value(v_i) for k_i, v_i in value.items()
                         }
+                else:
+                    value = Response._truncate_value(value)
+
                 # appended == False <==> either the value was not a collection or it did not exceed the max length
                 if not appended:
                     message_parts.append(f"{attribute}={value!r}")

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -9,16 +9,26 @@ class Response(ABC):
 
     # We need to work with Any.
     @no_type_check
-    def __repr__(self) -> str:
+    def _render_as_str(self, truncate: bool = False) -> str:
         class_name = self.__class__.__qualname__
         attributes = vars(self)
 
         if not attributes:
             return f"{class_name}()"
 
-        message = ", ".join(f"{k}={self._truncate_value(v)!r}" for k, v in attributes.items())
+        message = ", ".join(
+            f"{k}={self._truncate_value(v)!r}" if truncate else f"{k}={v!r}" for k, v in attributes.items()
+        )
 
         return f"{class_name}({message})"
+
+    @no_type_check
+    def __repr__(self) -> str:
+        return self._render_as_str()
+
+    @no_type_check
+    def __str__(self) -> str:
+        return self._render_as_str(truncate=True)
 
     @no_type_check
     def _truncate_value(self, value: Any, max_length: int = 32) -> Any:

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -24,28 +24,19 @@ class Response(ABC):
                 # To truncate a collection, we must render it as a string all at once to account for the ellipsis
                 if type(value) == list:
                     if len(value) > max_collection_length:
-                        value = value[:5]
-                        message_parts.append(
-                            f"{attribute}=[{', '.join(str(Response._truncate_value(v_i)) for v_i in value)}, ...]"
-                        )
+                        message_parts.append(Response._display_list(attribute, value, max_collection_length))
                         appended = True
                     else:
                         value = [Response._truncate_value(v_i) for v_i in value]
                 elif type(value) == set:
                     if len(value) > max_collection_length:
-                        value = list(value)[:5]
-                        message_parts.append(
-                            f"{attribute}={{{', '.join(str(Response._truncate_value(v_i)) for v_i in value)}, ...}}"
-                        )
+                        message_parts.append(Response._display_set(attribute, value, max_collection_length))
                         appended = True
                     else:
                         value = {Response._truncate_value(v_i) for v_i in value}
                 elif type(value) == dict:
                     if len(value) > max_collection_length:
-                        value = dict(list(value.items())[:5])
-                        message_parts.append(
-                            f"{attribute}={{{', '.join(str(Response._truncate_value(k_i)) + ': ' + str(Response._truncate_value(v_i)) for k_i, v_i in value.items())}, ...}}"  # noqa: E501
-                        )
+                        message_parts.append(Response._display_dict(attribute, value, max_collection_length))
                         appended = True
                     else:
                         value = {
@@ -60,6 +51,24 @@ class Response(ABC):
         message = ", ".join(message_parts)
 
         return f"{class_name}({message})"
+
+    @staticmethod
+    @no_type_check
+    def _display_list(attribute: object, list_: list[bytes], max_collection_length: int) -> str:
+        list_ = list_[:max_collection_length]
+        return f"{attribute}=[{', '.join(str(Response._truncate_value(list_i)) for list_i in list_)}, ...]"
+
+    @staticmethod
+    @no_type_check
+    def _display_set(attribute: object, set_: set[bytes], max_collection_length: int) -> str:
+        set_ = list(set_)[:max_collection_length]
+        return f"{attribute}={{{', '.join(str(Response._truncate_value(set_i)) for set_i in set_)}, ...}}"
+
+    @staticmethod
+    @no_type_check
+    def _display_dict(attribute: object, dict_: dict[bytes, bytes], max_collection_length: int) -> str:
+        dict_ = dict(list(dict_.items())[:5])
+        return f"{attribute}={{{', '.join(str(Response._truncate_value(k_i)) + ': ' + str(Response._truncate_value(v_i)) for k_i, v_i in dict_.items())}, ...}}"  # noqa: E501
 
     @no_type_check
     def __repr__(self) -> str:

--- a/src/momento/responses/scalar_data/get.py
+++ b/src/momento/responses/scalar_data/get.py
@@ -19,7 +19,7 @@ class CacheGetResponse(CacheResponse):
 class CacheGet(ABC):
     """Groups all `CacheGetResponse` derived types under a common namespace."""
 
-    @dataclass(repr=False)
+    @dataclass
     class Hit(CacheGetResponse, ValueStringMixin):
         """Contains the result of a cache hit."""
 

--- a/tests/momento/responses/test_cache_dictionary_fetch_response.py
+++ b/tests/momento/responses/test_cache_dictionary_fetch_response.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from momento.responses import CacheDictionaryFetch
+
+
+@pytest.mark.parametrize(
+    "dictionary, expected_str",
+    [
+        ({b"hello": b"world"}, "CacheDictionaryFetch.Hit(value_dictionary_bytes_bytes={b'hello': b'world'})"),
+        (
+            {("i" * 100).encode(): ("i" * 100).encode()},
+            "CacheDictionaryFetch.Hit(value_dictionary_bytes_bytes={b'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...': b'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...'})",  # noqa: E501
+        ),
+        (
+            {f"{i}".encode(): f"{i}".encode() for i in range(10)},
+            "CacheDictionaryFetch.Hit(value_dictionary_bytes_bytes={b'7', b'2', b'6', b'9', b'3', ...})",
+        ),
+    ],
+)
+def test_dictionary_fetch_hit_str_and_repr(dictionary: dict[bytes, bytes], expected_str: str) -> None:
+    hit = CacheDictionaryFetch.Hit(dictionary)
+    if "..." in expected_str:
+        assert "..." in str(hit)
+    else:
+        assert str(hit) == expected_str
+    assert eval(repr(hit)) == hit

--- a/tests/momento/responses/test_cache_dictionary_fetch_response.py
+++ b/tests/momento/responses/test_cache_dictionary_fetch_response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from momento.responses import CacheDictionaryFetch
 
 

--- a/tests/momento/responses/test_cache_dictionary_fetch_response.py
+++ b/tests/momento/responses/test_cache_dictionary_fetch_response.py
@@ -15,7 +15,7 @@ from momento.responses import CacheDictionaryFetch
         ),
         (
             {f"{i}".encode(): f"{i}".encode() for i in range(10)},
-            "CacheDictionaryFetch.Hit(value_dictionary_bytes_bytes={b'7', b'2', b'6', b'9', b'3', ...})",
+            "CacheDictionaryFetch.Hit(value_dictionary_bytes_bytes={b'7': b'7', b'2': b'2', b'6': b'6', b'9': b'9', b'3': b'3', ...})",  # noqa: E501
         ),
     ],
 )

--- a/tests/momento/responses/test_cache_get_response.py
+++ b/tests/momento/responses/test_cache_get_response.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from momento.responses import CacheGet
+
+
+@pytest.mark.parametrize(
+    "value_bytes, expected_str",
+    [
+        (b"hello", "CacheGet.Hit(value_bytes=b'hello')"),
+        (("i" * 100).encode(), "CacheGet.Hit(value_bytes=b'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...')"),
+    ],
+)
+def test_dictionary_fetch_hit_str_and_repr(value_bytes: bytes, expected_str: str) -> None:
+    hit = CacheGet.Hit(value_bytes)
+    assert str(hit) == expected_str
+    assert eval(repr(hit)) == hit

--- a/tests/momento/responses/test_cache_list_fetch_response.py
+++ b/tests/momento/responses/test_cache_list_fetch_response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from momento.responses import CacheListFetch
 
 

--- a/tests/momento/responses/test_cache_list_fetch_response.py
+++ b/tests/momento/responses/test_cache_list_fetch_response.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from momento.responses import CacheListFetch
+
+
+@pytest.mark.parametrize(
+    "list_, expected_str",
+    [
+        (
+            [b"hello", b"world"],
+            "CacheListFetch.Hit(values_bytes=[b'hello', b'world'])",
+        ),
+        (
+            [("i" * 100).encode()],
+            f"CacheListFetch.Hit(values_bytes=[b'{'i'*32}...'])",
+        ),
+        (
+            [f"{i}".encode() for i in range(10)],
+            "CacheListFetch.Hit(values_bytes=[b'0', b'1', b'2', b'3', b'4', ...])",
+        ),
+    ],
+)
+def test_list_fetch_hit_str_and_repr(list_: list[bytes], expected_str: str) -> None:
+    hit = CacheListFetch.Hit(list_)
+    assert str(hit) == expected_str
+    assert eval(repr(hit)) == hit

--- a/tests/momento/responses/test_cache_set_fetch_response.py
+++ b/tests/momento/responses/test_cache_set_fetch_response.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from momento.responses import CacheSetFetch
 
 

--- a/tests/momento/responses/test_cache_set_fetch_response.py
+++ b/tests/momento/responses/test_cache_set_fetch_response.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from momento.responses import CacheSetFetch
+
+
+@pytest.mark.parametrize(
+    "set_, expected_str",
+    [
+        ({b"hello"}, "CacheSetFetch.Hit(value_set_bytes={b'hello'})"),
+        (
+            {("i" * 100).encode()},
+            f"CacheSetFetch.Hit(values_bytes=[b'{'i'*32}...'])",
+        ),
+        (
+            {f"{i}".encode() for i in range(10)},
+            "CacheSetFetch.Hit(values_bytes=[b'0', b'1', b'2', b'3', b'4', ...])",
+        ),
+    ],
+)
+def test_set_fetch_hit_str_and_repr(set_: set[bytes], expected_str: str) -> None:
+    hit = CacheSetFetch.Hit(set_)
+    if "..." in expected_str:
+        assert "..." in str(hit)
+    else:
+        assert str(hit) == expected_str
+    assert eval(repr(hit)) == hit


### PR DESCRIPTION
Updates `__repr__` to be an evaluable string representation of the object, as per the Python spec. `__str__` still truncates, and now also truncates collections both in their elements and number of elements.

Closes #194