### PR TITLE
chore: enable linting on tests

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator
         if: matrix.python-version == '3.7'
-        run: poetry run mypy src/
+        run: poetry run mypy src tests
 
       - name: Run flake8
-        run: poetry run flake8 src/
+        run: poetry run flake8 src tests
 
       - name: Run black
         run: poetry run black src tests --check --diff

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator
         if: matrix.python-version == '3.7'
-        run: poetry run mypy src/
+        run: poetry run mypy src tests
 
       - name: Run flake8
-        run: poetry run flake8 src/
+        run: poetry run flake8 src tests
 
       - name: Run black
         run: poetry run black src tests --check --diff

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ format:
 .PHONY: lint
 ## Lint the code using mypy and flake8
 lint:
-	@poetry run mypy src
-	@poetry run flake8 src
+	@poetry run mypy src tests
+	@poetry run flake8 src tests
 
 .PHONY: do-gen-sync
 do-gen-sync:

--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -123,6 +123,7 @@ name_replacements = NameReplacement(
         ("(.*?)_async_(.*)", "\\1_\\2"),
         ("(.*?)_async$", "\\1"),
         ("^(SimpleCacheClient)Async$", "\\1"),
+        ("^(TUniqueCacheName)Async$", "\\1"),
         ("__aenter__", "__enter__"),
         ("__aexit__", "__exit__"),
         ("^aio$", "synchronous"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import os
 import random
 from datetime import timedelta
-from typing import Optional, cast
+from typing import AsyncIterator, Callable, Iterator, List, Optional, Union, cast
 
 import pytest
 import pytest_asyncio
@@ -16,18 +18,12 @@ from momento.typing import (
     TDictionaryFields,
     TDictionaryItems,
     TDictionaryName,
-    TDictionaryValue,
     TListName,
     TListValue,
-    TListValuesInput,
-    TListValuesInputBytes,
-    TListValuesInputStr,
     TScalarKey,
     TScalarValue,
     TSetElement,
     TSetElementsInput,
-    TSetElementsInputBytes,
-    TSetElementsInputStr,
     TSetName,
 )
 from tests.utils import unique_test_cache_name, uuid_bytes, uuid_str
@@ -81,31 +77,32 @@ def list_name() -> TListName:
 
 @pytest.fixture
 def list_value() -> TListValue:
-    return random.choice((uuid_bytes(), uuid_str()))
+    return cast(TListValue, random.choice((uuid_bytes(), uuid_str())))
 
 
 @pytest.fixture
 def key() -> TScalarKey:
-    return random.choice((uuid_bytes(), uuid_str()))
+    return cast(TScalarKey, random.choice((uuid_bytes(), uuid_str())))
 
 
 @pytest.fixture
 def value() -> TScalarValue:
-    return random.choice((uuid_bytes(), uuid_str()))
+    return cast(TScalarValue, random.choice((uuid_bytes(), uuid_str())))
 
 
 @pytest.fixture
-def values_bytes() -> TListValuesInputBytes:
+def values_bytes() -> list[bytes]:
     return [uuid_bytes(), uuid_bytes(), uuid_bytes()]
 
 
 @pytest.fixture()
-def values() -> TListValuesInput:
-    return random.choice(([uuid_bytes(), uuid_bytes(), uuid_bytes()], [uuid_str(), uuid_str(), uuid_str()]))
+def values() -> list[str | bytes]:
+    val = random.choice(([uuid_bytes(), uuid_bytes(), uuid_bytes()], [uuid_str(), uuid_str(), uuid_str()]))
+    return cast(List[Union[str, bytes]], val)
 
 
 @pytest.fixture
-def values_str() -> TListValuesInputStr:
+def values_str() -> list[str]:
     return [uuid_str(), uuid_str(), uuid_str()]
 
 
@@ -116,7 +113,7 @@ def dictionary_name() -> TDictionaryName:
 
 @pytest.fixture
 def dictionary_field() -> TDictionaryField:
-    return random.choice((uuid_bytes(), uuid_str()))
+    return cast(TDictionaryField, random.choice((uuid_bytes(), uuid_str())))
 
 
 @pytest.fixture
@@ -146,7 +143,7 @@ def dictionary_fields() -> TDictionaryFields:
 
 @pytest.fixture
 def dictionary_items() -> TDictionaryItems:
-    return dict([(uuid_str(), uuid_str()), (uuid_bytes(), uuid_bytes())])
+    return cast(TDictionaryItems, dict([(uuid_str(), uuid_str()), (uuid_bytes(), uuid_bytes())]))
 
 
 @pytest.fixture
@@ -161,25 +158,28 @@ def set_name() -> TSetName:
 
 @pytest.fixture
 def element() -> TSetElement:
-    return random.choice((uuid_bytes(), uuid_str()))
+    return cast(TSetElement, random.choice((uuid_bytes(), uuid_str())))
 
 
 @pytest.fixture
 def elements() -> TSetElementsInput:
-    return {
-        random.choice((uuid_bytes(), uuid_str())),
-        random.choice((uuid_bytes(), uuid_str())),
-        random.choice((uuid_bytes(), uuid_str())),
-    }
+    return cast(
+        TSetElementsInput,
+        {
+            random.choice((uuid_bytes(), uuid_str())),
+            random.choice((uuid_bytes(), uuid_str())),
+            random.choice((uuid_bytes(), uuid_str())),
+        },
+    )
 
 
 @pytest.fixture
-def elements_str() -> TSetElementsInputStr:
+def elements_str() -> set[str]:
     return {uuid_str(), uuid_str(), uuid_str()}
 
 
 @pytest.fixture
-def elements_bytes() -> TSetElementsInputBytes:
+def elements_bytes() -> set[bytes]:
     return {uuid_bytes(), uuid_bytes(), uuid_bytes()}
 
 
@@ -194,7 +194,7 @@ def bad_auth_token() -> str:
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> asyncio.AbstractEventLoop:  # type: ignore
+def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     """cf https://github.com/pytest-dev/pytest-asyncio#event_loop"""
     policy = asyncio.get_event_loop_policy()
     loop = policy.new_event_loop()
@@ -203,34 +203,37 @@ def event_loop() -> asyncio.AbstractEventLoop:  # type: ignore
 
 
 @pytest.fixture(scope="session")
-def client() -> SimpleCacheClient:
+def client() -> Iterator[SimpleCacheClient]:
     configuration = Laptop.latest()
     credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
     with SimpleCacheClient(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
-        _client.create_cache(TEST_CACHE_NAME)
+        _client.create_cache(cast(str, TEST_CACHE_NAME))
         try:
             yield _client
         finally:
-            _client.delete_cache(TEST_CACHE_NAME)
+            _client.delete_cache(cast(str, TEST_CACHE_NAME))
 
 
 @pytest_asyncio.fixture(scope="session")
-async def client_async() -> SimpleCacheClientAsync:
+async def client_async() -> AsyncIterator[SimpleCacheClientAsync]:
     configuration = Laptop.latest()
     credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
     async with SimpleCacheClientAsync(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         # TODO consider deleting cache on when test runner shuts down
-        await _client.create_cache(TEST_CACHE_NAME)
+        await _client.create_cache(cast(str, TEST_CACHE_NAME))
         try:
             yield _client
         finally:
-            await _client.delete_cache(TEST_CACHE_NAME)
+            await _client.delete_cache(cast(str, TEST_CACHE_NAME))
+
+
+TUniqueCacheName = Callable[[SimpleCacheClient], str]
 
 
 @pytest.fixture
-def unique_cache_name(client: SimpleCacheClient) -> str:
+def unique_cache_name(client: SimpleCacheClient) -> Iterator[Callable[[SimpleCacheClient], str]]:
     """Synchronous version of unique_cache_name_async"""
 
     cache_names = []
@@ -247,9 +250,13 @@ def unique_cache_name(client: SimpleCacheClient) -> str:
             client.delete_cache(cache_name)
 
 
-#
+TUniqueCacheNameAsync = Callable[[SimpleCacheClientAsync], str]
+
+
 @pytest_asyncio.fixture
-async def unique_cache_name_async(client_async: SimpleCacheClientAsync) -> str:
+async def unique_cache_name_async(
+    client_async: SimpleCacheClientAsync,
+) -> AsyncIterator[Callable[[SimpleCacheClientAsync], str]]:
     """Returns unique cache name for testing, and ensures the cache is deleted after the test,
     even if the test fails.
 

--- a/tests/momento/aio/client_interceptor_test.py
+++ b/tests/momento/aio/client_interceptor_test.py
@@ -73,7 +73,8 @@ def test_sanitize_client_grpc_request() -> None:
             # Test with unknown generic dict passed as metadata
             client_input=build_test_client_request(metadata_to_set={}),
             expected_output=None,
-            expected_err=InvalidArgumentException,  # type: ignore[arg-type] # Make sure we throw on unkown metadata input
+            # Make sure we throw on unkown metadata input
+            expected_err=InvalidArgumentException,  # type: ignore[arg-type]
         ),
     ]
 

--- a/tests/momento/aio/client_interceptor_test.py
+++ b/tests/momento/aio/client_interceptor_test.py
@@ -73,7 +73,7 @@ def test_sanitize_client_grpc_request() -> None:
             # Test with unknown generic dict passed as metadata
             client_input=build_test_client_request(metadata_to_set={}),
             expected_output=None,
-            expected_err=InvalidArgumentException,  # Make sure we throw on unkown metadata input
+            expected_err=InvalidArgumentException,  # type: ignore[arg-type] # Make sure we throw on unkown metadata input
         ),
     ]
 

--- a/tests/momento/auth/test_credential_provider.py
+++ b/tests/momento/auth/test_credential_provider.py
@@ -47,7 +47,7 @@ os.environ[test_env_var_name] = test_token
         ),
     ],
 )
-def test_endpoints(provider, auth_token, control_endpoint, cache_endpoint) -> None:
+def test_endpoints(provider: CredentialProvider, auth_token: str, control_endpoint: str, cache_endpoint: str) -> None:
     assert provider.auth_token == auth_token
     assert provider.control_endpoint == control_endpoint
     assert provider.cache_endpoint == cache_endpoint

--- a/tests/momento/config/test_config.py
+++ b/tests/momento/config/test_config.py
@@ -5,7 +5,7 @@ from momento.config import Configuration
 
 def test_configuration_client_timeout_copy_constructor(configuration: Configuration) -> None:
     def snag_deadline(config: Configuration) -> timedelta:
-        return config.get_transport_strategy().get_grpc_configuration().get_deadline()  # type: ignore
+        return config.get_transport_strategy().get_grpc_configuration().get_deadline()
 
     original_deadline: timedelta = snag_deadline(configuration)
     assert original_deadline.total_seconds() == 15

--- a/tests/momento/requests/test_collection_ttl.py
+++ b/tests/momento/requests/test_collection_ttl.py
@@ -60,4 +60,4 @@ def describe_collection_ttl() -> None:
 
     def test_int_ttl() -> None:
         with pytest.raises(InvalidArgumentException, match=r"ttl must be a timedelta."):
-            CollectionTtl(ttl=23)
+            CollectionTtl(ttl=23)  # type: ignore[arg-type]

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -6,22 +6,25 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheGet, CacheSet, CreateCache, DeleteCache, ListCaches
+from tests.conftest import TUniqueCacheName
 from tests.utils import uuid_str
 
 
 def test_create_cache_get_set_values_and_delete_cache(
-    client: SimpleCacheClient, cache_name: str, unique_cache_name
+    client: SimpleCacheClient,
+    cache_name: str,
+    unique_cache_name: TUniqueCacheName,
 ) -> None:
     key = uuid_str()
     value = uuid_str()
-    unique_cache_name = unique_cache_name(client)
+    new_cache_name = unique_cache_name(client)
 
-    client.create_cache(unique_cache_name)
+    client.create_cache(new_cache_name)
 
-    set_resp = client.set(unique_cache_name, key, value)
+    set_resp = client.set(new_cache_name, key, value)
     assert isinstance(set_resp, CacheSet.Success)
 
-    get_resp = client.get(unique_cache_name, key)
+    get_resp = client.get(new_cache_name, key)
     assert isinstance(get_resp, CacheGet.Hit)
     assert get_resp.value_string == value
 
@@ -45,7 +48,7 @@ def test_create_cache_throws_exception_for_empty_cache_name(
 def test_create_cache_throws_validation_exception_for_null_cache_name(
     client: SimpleCacheClient,
 ) -> None:
-    response = client.create_cache(None)
+    response = client.create_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert response.inner_exception.message == "Cache name must be a string"
@@ -54,7 +57,7 @@ def test_create_cache_throws_validation_exception_for_null_cache_name(
 def test_create_cache_with_bad_cache_name_throws_exception(
     client: SimpleCacheClient,
 ) -> None:
-    response = client.create_cache(1)
+    response = client.create_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert response.inner_exception.message == "Cache name must be a string"
@@ -64,11 +67,11 @@ def test_create_cache_throws_authentication_exception_for_bad_token(
     bad_token_credential_provider: CredentialProvider,
     configuration: Configuration,
     default_ttl_seconds: timedelta,
-    unique_cache_name,
+    unique_cache_name: TUniqueCacheName,
 ) -> None:
     with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
-        unique_cache_name = unique_cache_name(client)
-        response = client.create_cache(unique_cache_name)
+        new_cache_name = unique_cache_name(client)
+        response = client.create_cache(new_cache_name)
         assert isinstance(response, CreateCache.Error)
         assert response.error_code == errors.MomentoErrorCode.AUTHENTICATION_ERROR
 
@@ -80,12 +83,12 @@ def test_delete_cache_succeeds(client: SimpleCacheClient, cache_name: str) -> No
     response = client.create_cache(cache_name)
     assert isinstance(response, CreateCache.Success)
 
-    response = client.delete_cache(cache_name)
-    assert isinstance(response, DeleteCache.Success)
+    delete_response = client.delete_cache(cache_name)
+    assert isinstance(delete_response, DeleteCache.Success)
 
-    response = client.delete_cache(cache_name)
-    assert isinstance(response, DeleteCache.Error)
-    assert response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+    delete_response = client.delete_cache(cache_name)
+    assert isinstance(delete_response, DeleteCache.Error)
+    assert delete_response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
 
 
 def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
@@ -100,7 +103,7 @@ def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
 def test_delete_cache_throws_invalid_input_for_null_cache_name(
     client: SimpleCacheClient,
 ) -> None:
-    response = client.delete_cache(None)
+    response = client.delete_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
@@ -113,8 +116,8 @@ def test_delete_cache_throws_exception_for_empty_cache_name(
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-def test_delete_with_bad_cache_name_throws_exception(client: SimpleCacheClient, cache_name: str) -> None:
-    response = client.delete_cache(1)
+def test_delete_with_bad_cache_name_throws_exception(client: SimpleCacheClient) -> None:
+    response = client.delete_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert response.inner_exception.message == "Cache name must be a string"
@@ -163,7 +166,7 @@ def test_list_caches_throws_authentication_exception_for_bad_token(
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
-def test_list_caches_with_next_token_works(client: SimpleCacheClient, cache_name: str) -> None:
+def test_list_caches_with_next_token_works() -> None:
     """skip until pagination is actually implemented, see
     https://github.com/momentohq/control-plane-service/issues/83"""
     pass

--- a/tests/momento/simple_cache_client/test_dictionary.py
+++ b/tests/momento/simple_cache_client/test_dictionary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from functools import partial
 from time import sleep
+from typing import Union, cast
 
 from pytest import fixture
 from pytest_describe import behaves_like
@@ -232,7 +233,7 @@ class TDictionarySetter(Protocol):
         field: TDictionaryField,
         value: TDictionaryValue,
         *,
-        ttl: CollectionTtl,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> CacheResponse:
         ...
 
@@ -730,6 +731,7 @@ def describe_dictionary_remove_field() -> None:
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
         for field in [dictionary_field_str, dictionary_field_bytes]:
+            field = cast(Union[str, bytes], field)
             set_response = client.dictionary_set_field(cache_name, dictionary_name, field, dictionary_value_str)
             assert isinstance(set_response, CacheDictionarySetField.Success)
 

--- a/tests/momento/simple_cache_client/test_dictionary_async.py
+++ b/tests/momento/simple_cache_client/test_dictionary_async.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from functools import partial
 from time import sleep
-from typing import Awaitable
+from typing import Awaitable, Union, cast
 
 from pytest import fixture
 from pytest_describe import behaves_like
@@ -233,7 +233,7 @@ class TDictionarySetter(Protocol):
         field: TDictionaryField,
         value: TDictionaryValue,
         *,
-        ttl: CollectionTtl,
+        ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
     ) -> Awaitable[CacheResponse]:
         ...
 
@@ -745,6 +745,7 @@ def describe_dictionary_remove_field() -> None:
         assert isinstance(set_response, CacheDictionarySetField.Success)
 
         for field in [dictionary_field_str, dictionary_field_bytes]:
+            field = cast(Union[str, bytes], field)
             set_response = await client_async.dictionary_set_field(
                 cache_name, dictionary_name, field, dictionary_value_str
             )

--- a/tests/momento/simple_cache_client/test_init.py
+++ b/tests/momento/simple_cache_client/test_init.py
@@ -27,7 +27,7 @@ def test_init_throws_exception_when_client_uses_integer_request_timeout_ms(
     configuration: Configuration, credential_provider: CredentialProvider, default_ttl_seconds: int
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a timedelta."):
-        configuration.with_client_timeout(-1)
+        configuration.with_client_timeout(-1)  # type: ignore[arg-type]
 
 
 def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(

--- a/tests/momento/simple_cache_client/test_init_async.py
+++ b/tests/momento/simple_cache_client/test_init_async.py
@@ -29,7 +29,7 @@ async def test_init_throws_exception_when_client_uses_integer_request_timeout_ms
     configuration: Configuration, credential_provider: CredentialProvider, default_ttl_seconds: int
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a timedelta."):
-        configuration.with_client_timeout(-1)
+        configuration.with_client_timeout(-1)  # type: ignore[arg-type]
 
 
 async def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(

--- a/tests/momento/simple_cache_client/test_set.py
+++ b/tests/momento/simple_cache_client/test_set.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 from time import sleep
@@ -20,14 +22,7 @@ from momento.responses import (
     CacheSetRemoveElements,
 )
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import (
-    TCacheName,
-    TSetElement,
-    TSetElementsInput,
-    TSetElementsInputBytes,
-    TSetElementsInputStr,
-    TSetName,
-)
+from momento.typing import TCacheName, TSetElement, TSetElementsInput, TSetName
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors import (
@@ -319,7 +314,7 @@ def describe_set_add_elements() -> None:
         client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_str: TSetElementsInputStr,
+        elements_str: set[str],
     ) -> None:
         add_resp = client.set_add_elements(cache_name, set_name, elements_str)
         assert isinstance(add_resp, CacheSetAddElements.Success)
@@ -340,7 +335,7 @@ def describe_set_add_elements() -> None:
         client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_bytes: TSetElementsInputBytes,
+        elements_bytes: set[bytes],
     ) -> None:
         add_resp = client.set_add_elements(cache_name, set_name, elements_bytes)
         assert isinstance(add_resp, CacheSetAddElements.Success)
@@ -520,7 +515,7 @@ def describe_set_remove_elements() -> None:
         client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_str: TSetElementsInputStr,
+        elements_str: set[str],
     ) -> None:
         remove_resp = client.set_remove_elements(cache_name, set_name, elements_str)
         assert isinstance(remove_resp, CacheSetRemoveElements.Success)
@@ -543,7 +538,7 @@ def describe_set_remove_elements() -> None:
         client: SimpleCacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_bytes: TSetElementsInputStr,
+        elements_bytes: set[bytes],
     ) -> None:
         remove_resp = client.set_remove_elements(cache_name, set_name, elements_bytes)
         assert isinstance(remove_resp, CacheSetRemoveElements.Success)

--- a/tests/momento/simple_cache_client/test_set_async.py
+++ b/tests/momento/simple_cache_client/test_set_async.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 from time import sleep
@@ -21,14 +23,7 @@ from momento.responses import (
     CacheSetRemoveElements,
 )
 from momento.responses.mixins import ErrorResponseMixin
-from momento.typing import (
-    TCacheName,
-    TSetElement,
-    TSetElementsInput,
-    TSetElementsInputBytes,
-    TSetElementsInputStr,
-    TSetName,
-)
+from momento.typing import TCacheName, TSetElement, TSetElementsInput, TSetName
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (
@@ -324,7 +319,7 @@ def describe_set_add_elements() -> None:
         client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_str: TSetElementsInputStr,
+        elements_str: set[str],
     ) -> None:
         add_resp = await client_async.set_add_elements(cache_name, set_name, elements_str)
         assert isinstance(add_resp, CacheSetAddElements.Success)
@@ -345,7 +340,7 @@ def describe_set_add_elements() -> None:
         client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_bytes: TSetElementsInputBytes,
+        elements_bytes: set[bytes],
     ) -> None:
         add_resp = await client_async.set_add_elements(cache_name, set_name, elements_bytes)
         assert isinstance(add_resp, CacheSetAddElements.Success)
@@ -527,7 +522,7 @@ def describe_set_remove_elements() -> None:
         client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_str: TSetElementsInputStr,
+        elements_str: set[str],
     ) -> None:
         remove_resp = await client_async.set_remove_elements(cache_name, set_name, elements_str)
         assert isinstance(remove_resp, CacheSetRemoveElements.Success)
@@ -550,7 +545,7 @@ def describe_set_remove_elements() -> None:
         client_async: SimpleCacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
-        elements_bytes: TSetElementsInputStr,
+        elements_bytes: set[bytes],
     ) -> None:
         remove_resp = await client_async.set_remove_elements(cache_name, set_name, elements_bytes)
         assert isinstance(remove_resp, CacheSetRemoveElements.Success)


### PR DESCRIPTION
This PR fixes the type hint errors throughout the tests and enables `mypy` and `flake8` on the tests in the Makefile and CI.

- chore: fix mypy errors on tests
- chore: enable mypy and flake8 on tests in Makefile
- chore: run mypy and flake8 on tests in CI

Closes #236 