### PR TITLE
chore: remove pagination from list caches and list signing keys

### DIFF
--- a/src/momento/internal/aio/_scs_control_client.py
+++ b/src/momento/internal/aio/_scs_control_client.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Optional
 
 import grpc
 from momento_wire_types.controlclient_pb2 import (
@@ -72,10 +71,10 @@ class _ScsControlClient:
             return DeleteCache.Error(convert_error(e))
         return DeleteCache.Success()
 
-    async def list_caches(self, next_token: Optional[str] = None) -> ListCachesResponse:
+    async def list_caches(self) -> ListCachesResponse:
         try:
             list_caches_request = _ListCachesRequest()
-            list_caches_request.next_token = next_token if next_token is not None else ""
+            list_caches_request.next_token = ""
             response = await self._build_stub().ListCaches(list_caches_request, timeout=_DEADLINE_SECONDS)
             return ListCaches.Success.from_grpc_response(response)
         except Exception as e:
@@ -107,10 +106,10 @@ class _ScsControlClient:
             self._logger.warning(f"Failed to revoke signing key with key_id {key_id} exception: {e}")
             raise convert_error(e)
 
-    async def list_signing_keys(self, endpoint: str, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    async def list_signing_keys(self, endpoint: str) -> ListSigningKeysResponse:
         try:
             list_signing_keys_request = _ListSigningKeysRequest()
-            list_signing_keys_request.next_token = next_token if next_token is not None else ""
+            list_signing_keys_request.next_token = ""
             return ListSigningKeysResponse.from_grpc_response(
                 await self._build_stub().ListSigningKeys(list_signing_keys_request, timeout=_DEADLINE_SECONDS),
                 endpoint,

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Optional
 
 import grpc
 from momento_wire_types.controlclient_pb2 import (
@@ -72,10 +71,10 @@ class _ScsControlClient:
             return DeleteCache.Error(convert_error(e))
         return DeleteCache.Success()
 
-    def list_caches(self, next_token: Optional[str] = None) -> ListCachesResponse:
+    def list_caches(self) -> ListCachesResponse:
         try:
             list_caches_request = _ListCachesRequest()
-            list_caches_request.next_token = next_token if next_token is not None else ""
+            list_caches_request.next_token = ""
             response = self._build_stub().ListCaches(list_caches_request, timeout=_DEADLINE_SECONDS)
             return ListCaches.Success.from_grpc_response(response)
         except Exception as e:
@@ -107,10 +106,10 @@ class _ScsControlClient:
             self._logger.warning(f"Failed to revoke signing key with key_id {key_id} exception: {e}")
             raise convert_error(e)
 
-    def list_signing_keys(self, endpoint: str, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    def list_signing_keys(self, endpoint: str) -> ListSigningKeysResponse:
         try:
             list_signing_keys_request = _ListSigningKeysRequest()
-            list_signing_keys_request.next_token = next_token if next_token is not None else ""
+            list_signing_keys_request.next_token = ""
             return ListSigningKeysResponse.from_grpc_response(
                 self._build_stub().ListSigningKeys(list_signing_keys_request, timeout=_DEADLINE_SECONDS),
                 endpoint,

--- a/src/momento/responses/control/list_caches.py
+++ b/src/momento/responses/control/list_caches.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 from momento_wire_types.controlclient_pb2 import _ListCachesResponse
 
@@ -58,8 +58,6 @@ class ListCaches(ABC):
 
         caches: List[CacheInfo]
         """The list of caches available to the user."""
-        next_token: Optional[str]
-        """A token to specify where to start paging. This is the `NextToken` from a previous response."""
 
         @staticmethod
         def from_grpc_response(grpc_list_cache_response: _ListCachesResponse) -> ListCaches.Success:  # type: ignore[misc] # noqa: E501
@@ -68,13 +66,8 @@ class ListCaches(ABC):
             Args:
                 grpc_list_cache_response: Protobuf based response returned by Scs.
             """
-            next_token: Optional[str] = (
-                grpc_list_cache_response.next_token  # type: ignore[misc]
-                if grpc_list_cache_response.next_token != ""  # type: ignore[misc]
-                else None
-            )
             caches = [CacheInfo(cache.cache_name) for cache in grpc_list_cache_response.cache]  # type: ignore[misc]
-            return ListCaches.Success(caches=caches, next_token=next_token)
+            return ListCaches.Success(caches=caches)
 
     class Error(ListCachesResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request:

--- a/src/momento/responses/control/signing_keys.py
+++ b/src/momento/responses/control/signing_keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import google
 
@@ -68,11 +68,9 @@ class ListSigningKeysResponse(ControlResponse):
     Responses are paginated.
 
     Args:
-        next_token: Optional[str] - the token to get the next page
         signing_keys: list[SigningKey] - all signing keys in this page
     """
 
-    next_token: Optional[str]
     signing_keys: list[SigningKey]
 
     @staticmethod
@@ -85,11 +83,8 @@ class ListSigningKeysResponse(ControlResponse):
             grpc_list_signing_keys_response: google.protobuf.message.Message
         """
         print(f"Name: {grpc_list_signing_keys_response.__class__.__bases__}")
-        next_token: Optional[str] = (
-            grpc_list_signing_keys_response.next_token if grpc_list_signing_keys_response.next_token != "" else None
-        )
         signing_keys: list[SigningKey] = [
             SigningKey.from_grpc_response(signing_key, endpoint)
             for signing_key in grpc_list_signing_keys_response.signing_key
         ]
-        return ListSigningKeysResponse(next_token, signing_keys)
+        return ListSigningKeysResponse(signing_keys)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -181,17 +181,13 @@ class SimpleCacheClient:
         """
         return self._control_client.delete_cache(cache_name)
 
-    def list_caches(self, *, next_token: Optional[str] = None) -> ListCachesResponse:
+    def list_caches(self) -> ListCachesResponse:
         """Lists all caches.
-
-        Args:
-            next_token (Optional[str], optional): A token to specify where to start paginating.
-            This is the NextToken from a previous response. Defaults to None.
 
         Returns:
             ListCachesResponse:
         """
-        return self._control_client.list_caches(next_token)
+        return self._control_client.list_caches()
 
     def create_signing_key(self, ttl: timedelta) -> CreateSigningKeyResponse:
         """Creates a Momento signing key
@@ -221,12 +217,8 @@ class SimpleCacheClient:
         """
         return self._control_client.revoke_signing_key(key_id)
 
-    def list_signing_keys(self, *, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    def list_signing_keys(self) -> ListSigningKeysResponse:
         """Lists all Momento signing keys for the provided auth token.
-
-        Args:
-            next_token (Optional[str], optional) Token to continue paginating through the list.
-            It's used to handle large paginated lists. Defaults to None.
 
         Returns:
             ListSigningKeysResponse
@@ -234,7 +226,7 @@ class SimpleCacheClient:
         Raises:
             SdkException: validation, server-side, or other runtime error
         """
-        return self._control_client.list_signing_keys(self._cache_endpoint, next_token)
+        return self._control_client.list_signing_keys(self._cache_endpoint)
 
     def increment(
         self,

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -181,17 +181,13 @@ class SimpleCacheClientAsync:
         """
         return await self._control_client.delete_cache(cache_name)
 
-    async def list_caches(self, *, next_token: Optional[str] = None) -> ListCachesResponse:
+    async def list_caches(self) -> ListCachesResponse:
         """Lists all caches.
-
-        Args:
-            next_token (Optional[str], optional): A token to specify where to start paginating.
-            This is the NextToken from a previous response. Defaults to None.
 
         Returns:
             ListCachesResponse:
         """
-        return await self._control_client.list_caches(next_token)
+        return await self._control_client.list_caches()
 
     async def create_signing_key(self, ttl: timedelta) -> CreateSigningKeyResponse:
         """Creates a Momento signing key
@@ -221,12 +217,8 @@ class SimpleCacheClientAsync:
         """
         return await self._control_client.revoke_signing_key(key_id)
 
-    async def list_signing_keys(self, *, next_token: Optional[str] = None) -> ListSigningKeysResponse:
+    async def list_signing_keys(self) -> ListSigningKeysResponse:
         """Lists all Momento signing keys for the provided auth token.
-
-        Args:
-            next_token (Optional[str], optional) Token to continue paginating through the list.
-            It's used to handle large paginated lists. Defaults to None.
 
         Returns:
             ListSigningKeysResponse
@@ -234,7 +226,7 @@ class SimpleCacheClientAsync:
         Raises:
             SdkException: validation, server-side, or other runtime error
         """
-        return await self._control_client.list_signing_keys(self._cache_endpoint, next_token)
+        return await self._control_client.list_signing_keys(self._cache_endpoint)
 
     async def increment(
         self,

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -151,7 +151,6 @@ def test_list_caches_succeeds(client: SimpleCacheClient, cache_name: str) -> Non
 
         cache_names = [cache.name for cache in list_cache_resp.caches]
         assert cache_name in cache_names
-        assert list_cache_resp.next_token is None
     finally:
         delete_response = client.delete_cache(cache_name)
         assert isinstance(delete_response, DeleteCache.Success)

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -166,12 +166,6 @@ def test_list_caches_throws_authentication_exception_for_bad_token(
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
-def test_list_caches_with_next_token_works() -> None:
-    """skip until pagination is actually implemented, see
-    https://github.com/momentohq/control-plane-service/issues/83"""
-    pass
-
-
 def test_create_list_revoke_signing_keys(client: SimpleCacheClient) -> None:
     create_resp = client.create_signing_key(timedelta(minutes=30))
     list_resp = client.list_signing_keys()

--- a/tests/momento/simple_cache_client/test_control_async.py
+++ b/tests/momento/simple_cache_client/test_control_async.py
@@ -157,7 +157,6 @@ async def test_list_caches_succeeds(client_async: SimpleCacheClientAsync, cache_
 
         cache_names = [cache.name for cache in list_cache_resp.caches]
         assert cache_name in cache_names
-        assert list_cache_resp.next_token is None
     finally:
         delete_response = await client_async.delete_cache(cache_name)
         assert isinstance(delete_response, DeleteCache.Success)

--- a/tests/momento/simple_cache_client/test_control_async.py
+++ b/tests/momento/simple_cache_client/test_control_async.py
@@ -174,12 +174,6 @@ async def test_list_caches_throws_authentication_exception_for_bad_token(
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
-async def test_list_caches_with_next_token_works() -> None:
-    """skip until pagination is actually implemented, see
-    https://github.com/momentohq/control-plane-service/issues/83"""
-    pass
-
-
 async def test_create_list_revoke_signing_keys(client_async: SimpleCacheClientAsync) -> None:
     create_resp = await client_async.create_signing_key(timedelta(minutes=30))
     list_resp = await client_async.list_signing_keys()


### PR DESCRIPTION
Remove the page token from the list caches and list signing keys methods. The paging functionality is currently unimplemented and the paging logic could potentially be hidden from the user after it is.