### PR TITLE
chore: add client instantiation example to docs

### DIFF
--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -131,7 +131,11 @@ name_replacements = NameReplacement(
 )
 
 simple_string_replacements = SimpleStringReplacement(
-    [(r"(.*?)Async(\s+Simple\s+Cache\s+Client.*?)", "\\1Synchronous\\2"), (r"(.*?)\bawait\s+(.*?)", "\\1\\2")]
+    [
+        ("(SimpleCacheClient)Async", "\\1"),
+        (r"(.*?)Async(\s+Simple\s+Cache\s+Client.*?)", "\\1Synchronous\\2"),
+        (r"(.*?)\bawait\s+(.*?)", "\\1\\2"),
+    ]
 )
 
 canonical_pipeline = Pipeline([AsyncToSyncTransformer(), name_replacements, simple_string_replacements])

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -135,8 +135,8 @@ class SimpleCacheClient:
                 It is possible to override this setting when calling the set method.
         Raises:
             IllegalArgumentException: If method arguments fail validations.
-        Example:
-        ::
+        Example::
+
             configuration = Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -135,6 +135,12 @@ class SimpleCacheClient:
                 It is possible to override this setting when calling the set method.
         Raises:
             IllegalArgumentException: If method arguments fail validations.
+        Example:
+        ::
+            configuration = Laptop.latest()
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            ttl_seconds = timedelta(seconds=60)
+            SimpleCacheClient(configuration, credential_provider, ttl_seconds)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -135,8 +135,8 @@ class SimpleCacheClientAsync:
                 It is possible to override this setting when calling the set method.
         Raises:
             IllegalArgumentException: If method arguments fail validations.
-        Example:
-        ::
+        Example::
+
             configuration = Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -135,6 +135,12 @@ class SimpleCacheClientAsync:
                 It is possible to override this setting when calling the set method.
         Raises:
             IllegalArgumentException: If method arguments fail validations.
+        Example:
+        ::
+            configuration = Laptop.latest()
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            ttl_seconds = timedelta(seconds=60)
+            SimpleCacheClientAsync(configuration, credential_provider, ttl_seconds)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger


### PR DESCRIPTION
Add an example of how to instantiate a client to the simple cache client docs.

Add a new string replacement to the code generation to replace any instance of 'SimpleCacheClientAsync' with 'SimpleCacheClient' to let the example doc be translated correctly.