### PR TITLE
chore: fix as-bytes error messages

### DIFF
--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -13,11 +13,11 @@ from momento.typing import (
     TSetElementsInputBytes,
 )
 
-DEFAULT_STRING_CONVERSION_ERROR = "Could not decode bytes to UTF-8"
-DEFAULT_LIST_CONVERSION_ERROR = "Could not decode List[bytes] to UTF-8"
-DEFAULT_DICTIONARY_CONVERSION_ERROR = "Could not decode Mapping[bytes, bytes] to UTF-8"
-DEFAULT_DICTIONARY_FIELDS_CONVERSION_ERROR = "Could not decode Iterable[bytes, bytes] to UTF-8"
-DEFAULT_SET_CONVERSION_ERROR = "Could not decode Set[bytes] to UTF-8"
+DEFAULT_BYTES_CONVERSION_ERROR = "Could not convert the given type to bytes: "
+DEFAULT_LIST_CONVERSION_ERROR = "The given type is not List[bytes] or List[str]: "
+DEFAULT_DICTIONARY_CONVERSION_ERROR = "The given type is not a valid Mapping: "
+DEFAULT_DICTIONARY_FIELDS_CONVERSION_ERROR = "The given type is not Iterable[TDictionaryField]: "
+DEFAULT_SET_CONVERSION_ERROR = "The given type is not Set[bytes] or Set[str]: "
 
 
 def _validate_name(name: str, field_name: str) -> None:
@@ -45,7 +45,7 @@ def _validate_set_name(set_name: str) -> None:
 
 def _as_bytes(
     data: str | bytes,
-    error_message: Optional[str] = DEFAULT_STRING_CONVERSION_ERROR,
+    error_message: Optional[str] = DEFAULT_BYTES_CONVERSION_ERROR,
 ) -> bytes:
     if isinstance(data, str):
         return data.encode("utf-8")

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -14,10 +14,10 @@ from momento.typing import (
 )
 
 DEFAULT_BYTES_CONVERSION_ERROR = "Could not convert the given type to bytes: "
-DEFAULT_LIST_CONVERSION_ERROR = "The given type is not List[bytes] or List[str]: "
+DEFAULT_LIST_CONVERSION_ERROR = "The given type is not list[str | bytes]: "
 DEFAULT_DICTIONARY_CONVERSION_ERROR = "The given type is not a valid Mapping: "
-DEFAULT_DICTIONARY_FIELDS_CONVERSION_ERROR = "The given type is not Iterable[TDictionaryField]: "
-DEFAULT_SET_CONVERSION_ERROR = "The given type is not Set[bytes] or Set[str]: "
+DEFAULT_DICTIONARY_FIELDS_CONVERSION_ERROR = "The given type is not Iterable[str | bytes]: "
+DEFAULT_SET_CONVERSION_ERROR = "The given type is not set[str | bytes]: "
 
 
 def _validate_name(name: str, field_name: str) -> None:

--- a/tests/momento/simple_cache_client/test_dictionary.py
+++ b/tests/momento/simple_cache_client/test_dictionary.py
@@ -353,7 +353,8 @@ def a_dictionary_setter() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert (
                 response.message
-                == f"Invalid argument passed to Momento client: Could not decode bytes to UTF-8<class '{bad_type}'>"
+                == f"Invalid argument passed to Momento client: Could not convert the given type to bytes: "
+                f"<class '{bad_type}'>"
             )
 
 

--- a/tests/momento/simple_cache_client/test_dictionary_async.py
+++ b/tests/momento/simple_cache_client/test_dictionary_async.py
@@ -355,7 +355,8 @@ def a_dictionary_setter() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert (
                 response.message
-                == f"Invalid argument passed to Momento client: Could not decode bytes to UTF-8<class '{bad_type}'>"
+                == f"Invalid argument passed to Momento client: Could not convert the given type to bytes: "
+                f"<class '{bad_type}'>"
             )
 
 

--- a/tests/momento/simple_cache_client/test_set.py
+++ b/tests/momento/simple_cache_client/test_set.py
@@ -121,9 +121,7 @@ def a_set_which_takes_an_element() -> None:
         resp = set_which_takes_an_element(cache_name, set_name, 1)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
-            # Should be "Could not convert an int to bytes"
-            assert resp.inner_exception.message == "Could not decode bytes to UTF-8<class 'int'>"
+            assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'int'>"
         else:
             assert False
 
@@ -135,9 +133,7 @@ def a_set_which_takes_an_element() -> None:
         resp = set_which_takes_an_element(cache_name, set_name, None)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
-            # Should be "Could not convert an int to bytes"
-            assert resp.inner_exception.message == "Could not decode bytes to UTF-8<class 'NoneType'>"
+            assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'NoneType'>"
         else:
             assert False
 

--- a/tests/momento/simple_cache_client/test_set_async.py
+++ b/tests/momento/simple_cache_client/test_set_async.py
@@ -122,9 +122,7 @@ def a_set_which_takes_an_element() -> None:
         resp = await set_which_takes_an_element(cache_name, set_name, 1)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
-            # Should be "Could not convert an int to bytes"
-            assert resp.inner_exception.message == "Could not decode bytes to UTF-8<class 'int'>"
+            assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'int'>"
         else:
             assert False
 
@@ -136,9 +134,7 @@ def a_set_which_takes_an_element() -> None:
         resp = await set_which_takes_an_element(cache_name, set_name, None)  # type:ignore[arg-type]
         if isinstance(resp, ErrorResponseMixin):
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
-            # This error is wrong. See https://github.com/momentohq/client-sdk-python/issues/242
-            # Should be "Could not convert an int to bytes"
-            assert resp.inner_exception.message == "Could not decode bytes to UTF-8<class 'NoneType'>"
+            assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'NoneType'>"
         else:
             assert False
 


### PR DESCRIPTION
Align the default error messages in _data_validation.py with what the errors represent.