### PR TITLE
chore: improve imports for configurations and CredentialProvider

### DIFF
--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from .auth import CredentialProvider
-from .config import configurations
+from .config import Configurations
 from .simple_cache_client import SimpleCacheClient
 from .simple_cache_client_async import SimpleCacheClientAsync
 

--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from .auth import CredentialProvider
+from .config import configurations
 from .simple_cache_client import SimpleCacheClient
 from .simple_cache_client_async import SimpleCacheClientAsync
 

--- a/src/momento/config/__init__.py
+++ b/src/momento/config/__init__.py
@@ -1,2 +1,2 @@
 from .configuration import Configuration
-from .configurations import InRegion, Laptop
+from .configurations import Configurations

--- a/src/momento/config/configurations.py
+++ b/src/momento/config/configurations.py
@@ -9,42 +9,48 @@ from .transport.transport_strategy import (
 )
 
 
-class Laptop(Configuration):
-    """Laptop config provides defaults suitable for a medium-to-high-latency dev environment.
+class Configurations:
+    """Container class for pre-built configurations."""
 
-    Permissive timeouts, retries, and relaxed latency and throughput targets.
-    """
+    class Laptop(Configuration):
+        """Laptop config provides defaults suitable for a medium-to-high-latency dev environment.
 
-    @staticmethod
-    def latest() -> Laptop:
-        return Laptop(StaticTransportStrategy(StaticGrpcConfiguration(timedelta(seconds=15))))
-
-
-class InRegion:
-    """Default for application running in the same region as the Momento service.
-
-    InRegion provides defaults suitable for an environment where your client is running in the same region as the
-    Momento service.  It has more aggressive timeouts and retry behavior than the Laptop config.
-    """
-
-    class Default(Configuration):
-        """Prioritizes throughput and client resource utilization.
-
-        It has a slightly relaxed client-side timeout setting to maximize throughput.
+        Permissive timeouts, retries, and relaxed latency and throughput targets.
         """
 
         @staticmethod
-        def latest() -> InRegion.Default:
-            return InRegion.Default(StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=1100))))
+        def latest() -> Configurations.Laptop:
+            return Configurations.Laptop(StaticTransportStrategy(StaticGrpcConfiguration(timedelta(seconds=15))))
 
-    class LowLatency(Configuration):
-        """Prioritizes keeping p99.9 latencies as low as possible.
+    class InRegion:
+        """Default for application running in the same region as the Momento service.
 
-        It potentially sacrifices some throughput to achieve this.  It has a very aggressive client-side timeout.
-        Use this configuration if the most important factor is to ensure that cache unavailability doesn't
-        force unacceptably high latencies for your application.
+        InRegion provides defaults suitable for an environment where your client is running in the same region as the
+        Momento service.  It has more aggressive timeouts and retry behavior than the Laptop config.
         """
 
-        @staticmethod
-        def latest() -> InRegion.LowLatency:
-            return InRegion.LowLatency(StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=500))))
+        class Default(Configuration):
+            """Prioritizes throughput and client resource utilization.
+
+            It has a slightly relaxed client-side timeout setting to maximize throughput.
+            """
+
+            @staticmethod
+            def latest() -> Configurations.InRegion.Default:
+                return Configurations.InRegion.Default(
+                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=1100)))
+                )
+
+        class LowLatency(Configuration):
+            """Prioritizes keeping p99.9 latencies as low as possible.
+
+            It potentially sacrifices some throughput to achieve this.  It has a very aggressive client-side timeout.
+            Use this configuration if the most important factor is to ensure that cache unavailability doesn't
+            force unacceptably high latencies for your application.
+            """
+
+            @staticmethod
+            def latest() -> Configurations.InRegion.LowLatency:
+                return Configurations.InRegion.LowLatency(
+                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=500)))
+                )

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -138,7 +138,10 @@ class SimpleCacheClient:
             IllegalArgumentException: If method arguments fail validations.
         Example::
 
-            configuration = Laptop.latest()
+            from datetime import timedelta
+            from momento import configurations, CredentialProvider, SimpleCacheClient
+
+            configuration = configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
             client = SimpleCacheClient(configuration, credential_provider, ttl_seconds)

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -139,9 +139,9 @@ class SimpleCacheClient:
         Example::
 
             from datetime import timedelta
-            from momento import configurations, CredentialProvider, SimpleCacheClient
+            from momento import Configurations, CredentialProvider, SimpleCacheClient
 
-            configuration = configurations.Laptop.latest()
+            configuration = Configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
             client = SimpleCacheClient(configuration, credential_provider, ttl_seconds)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -138,7 +138,10 @@ class SimpleCacheClientAsync:
             IllegalArgumentException: If method arguments fail validations.
         Example::
 
-            configuration = Laptop.latest()
+            from datetime import timedelta
+            from momento import configurations, CredentialProvider, SimpleCacheClientAsync
+
+            configuration = configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
             client = SimpleCacheClientAsync(configuration, credential_provider, ttl_seconds)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -139,9 +139,9 @@ class SimpleCacheClientAsync:
         Example::
 
             from datetime import timedelta
-            from momento import configurations, CredentialProvider, SimpleCacheClientAsync
+            from momento import Configurations, CredentialProvider, SimpleCacheClientAsync
 
-            configuration = configurations.Laptop.latest()
+            configuration = Configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
             client = SimpleCacheClientAsync(configuration, credential_provider, ttl_seconds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,10 @@ import pytest
 import pytest_asyncio
 
 from momento import (
+    Configurations,
     CredentialProvider,
     SimpleCacheClient,
     SimpleCacheClientAsync,
-    configurations,
 )
 from momento.config import Configuration
 from momento.typing import (
@@ -36,7 +36,7 @@ from tests.utils import unique_test_cache_name, uuid_bytes, uuid_str
 # Integration test data
 #######################
 
-TEST_CONFIGURATION = configurations.Laptop.latest()
+TEST_CONFIGURATION = Configurations.Laptop.latest()
 
 TEST_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,13 @@ from typing import AsyncIterator, Callable, Iterator, List, Optional, Union, cas
 import pytest
 import pytest_asyncio
 
-from momento import SimpleCacheClient, SimpleCacheClientAsync
-from momento.auth import CredentialProvider
-from momento.config import Configuration, Laptop
+from momento import (
+    CredentialProvider,
+    SimpleCacheClient,
+    SimpleCacheClientAsync,
+    configurations,
+)
+from momento.config import Configuration
 from momento.typing import (
     TCacheName,
     TDictionaryField,
@@ -32,7 +36,7 @@ from tests.utils import unique_test_cache_name, uuid_bytes, uuid_str
 # Integration test data
 #######################
 
-TEST_CONFIGURATION = Laptop.latest()
+TEST_CONFIGURATION = configurations.Laptop.latest()
 
 TEST_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
 
@@ -204,9 +208,7 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 @pytest.fixture(scope="session")
 def client() -> Iterator[SimpleCacheClient]:
-    configuration = Laptop.latest()
-    credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
-    with SimpleCacheClient(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
+    with SimpleCacheClient(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         _client.create_cache(cast(str, TEST_CACHE_NAME))
         try:
@@ -217,9 +219,7 @@ def client() -> Iterator[SimpleCacheClient]:
 
 @pytest_asyncio.fixture(scope="session")
 async def client_async() -> AsyncIterator[SimpleCacheClientAsync]:
-    configuration = Laptop.latest()
-    credential_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
-    async with SimpleCacheClientAsync(configuration, credential_provider, DEFAULT_TTL_SECONDS) as _client:
+    async with SimpleCacheClientAsync(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         # TODO consider deleting cache on when test runner shuts down
         await _client.create_cache(cast(str, TEST_CACHE_NAME))


### PR DESCRIPTION
Rolls up configurations and CredentialProvider to top level `momento`
package. Updates documentation of inline examples.

Closes #284 