### PR TITLE
fix: audit response hierarchy

### DIFF
--- a/src/momento/responses/data/dictionary/get_fields.py
+++ b/src/momento/responses/data/dictionary/get_fields.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 
-from ...mixins import ErrorResponseMixin, ValueStringMixin
+from ...mixins import ErrorResponseMixin
 from ...response import CacheResponse
 from .get_field import CacheDictionaryGetField, CacheDictionaryGetFieldResponse
 
@@ -24,7 +24,7 @@ class CacheDictionaryGetFields(ABC):
     """Groups all `CacheDictionaryGetFieldsResponse` derived types under a common namespace."""
 
     @dataclass
-    class Hit(CacheDictionaryGetFieldsResponse, ValueStringMixin):
+    class Hit(CacheDictionaryGetFieldsResponse):
         """Contains the result of a cache hit."""
 
         responses: list[CacheDictionaryGetFieldResponse]

--- a/src/momento/responses/data/list/fetch.py
+++ b/src/momento/responses/data/list/fetch.py
@@ -26,21 +26,17 @@ class CacheListFetch(ABC):
     class Hit(CacheListFetchResponse):
         """Indicates the list exists and its values were fetched."""
 
-        values_bytes: list[bytes]
-        """The values for the fetched list, as bytes.
-
-        Returns:
-            list[bytes]
-        """
+        value_list_bytes: list[bytes]
+        """The values for the fetched list, as bytes."""
 
         @property
-        def values_string(self) -> list[str]:
+        def value_list_string(self) -> list[str]:
             """The values for the fetched list, as utf-8 encoded strings.
 
             Returns:
                 list[str]
             """
-            return [v.decode("utf-8") for v in self.values_bytes]
+            return [v.decode("utf-8") for v in self.value_list_bytes]
 
     class Miss(CacheListFetchResponse):
         """Indicates the list does not exist."""

--- a/tests/momento/responses/test_cache_list_fetch_response.py
+++ b/tests/momento/responses/test_cache_list_fetch_response.py
@@ -10,15 +10,15 @@ from momento.responses import CacheListFetch
     [
         (
             [b"hello", b"world"],
-            "CacheListFetch.Hit(values_bytes=[b'hello', b'world'])",
+            "CacheListFetch.Hit(value_list_bytes=[b'hello', b'world'])",
         ),
         (
             [("i" * 100).encode()],
-            f"CacheListFetch.Hit(values_bytes=[b'{'i'*32}...'])",
+            f"CacheListFetch.Hit(value_list_bytes=[b'{'i'*32}...'])",
         ),
         (
             [f"{i}".encode() for i in range(10)],
-            "CacheListFetch.Hit(values_bytes=[b'0', b'1', b'2', b'3', b'4', ...])",
+            "CacheListFetch.Hit(value_list_bytes=[b'0', b'1', b'2', b'3', b'4', ...])",
         ),
     ],
 )

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -91,7 +91,7 @@ def a_list_adder() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert Counter(fetch_resp.values_string) == Counter(values)
+        assert Counter(fetch_resp.value_list_string) == Counter(values)
 
     def it_uses_the_default_ttl_when_the_collection_ttl_has_no_ttl(
         configuration: Configuration,
@@ -111,7 +111,7 @@ def a_list_adder() -> None:
 
             fetch_resp = client.list_fetch(cache_name, list_name)
             assert isinstance(fetch_resp, CacheListFetch.Hit)
-            assert fetch_resp.values_string == [value]
+            assert fetch_resp.value_list_string == [value]
 
             sleep(ttl_seconds / 2)
             fetch_resp = client.list_fetch(cache_name, list_name)
@@ -155,7 +155,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_bytes == values_bytes
+        assert fetch_resp.value_list_bytes == values_bytes
 
     def with_strings_it_succeeds(
         list_concatenator: TListConcatenator,
@@ -172,7 +172,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == values_str
+        assert fetch_resp.value_list_string == values_str
 
     def with_iterable_values_it_succeeds(
         list_concatenator: TListConcatenator,
@@ -190,7 +190,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == values_str
+        assert fetch_resp.value_list_string == values_str
 
     def with_other_values_type_it_errors(
         list_concatenator: TListConcatenator,
@@ -263,7 +263,7 @@ def a_list_pusher() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_bytes == [value]
+        assert fetch_resp.value_list_bytes == [value]
 
     def with_strings_it_succeeds(
         list_pusher: TListPusher,
@@ -278,7 +278,7 @@ def a_list_pusher() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == [value]
+        assert fetch_resp.value_list_string == [value]
 
     def with_other_value_type_it_errors(
         list_pusher: TListPusher,
@@ -363,7 +363,7 @@ def describe_list_concatenate_back() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["three", "four", "five", "six"]
+            assert fetch_resp.value_list_string == ["three", "four", "five", "six"]
         else:
             assert False
 
@@ -440,7 +440,7 @@ def describe_list_concatenate_front() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["four", "five", "six", "one"]
+            assert fetch_resp.value_list_string == ["four", "five", "six", "one"]
         else:
             assert False
 
@@ -638,7 +638,7 @@ def describe_list_push_back() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["2", "3"]
+            assert fetch_resp.value_list_string == ["2", "3"]
         else:
             assert False
 
@@ -702,7 +702,7 @@ def describe_list_push_front() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["3", "2"]
+            assert fetch_resp.value_list_string == ["3", "2"]
         else:
             assert False
 
@@ -752,6 +752,6 @@ def describe_list_remove_value() -> None:
 
         fetch_resp = client.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == expected_values
+            assert fetch_resp.value_list_string == expected_values
         else:
             assert False

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -92,7 +92,7 @@ def a_list_adder() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert Counter(fetch_resp.values_string) == Counter(values)
+        assert Counter(fetch_resp.value_list_string) == Counter(values)
 
     async def it_uses_the_default_ttl_when_the_collection_ttl_has_no_ttl(
         configuration: Configuration,
@@ -112,7 +112,7 @@ def a_list_adder() -> None:
 
             fetch_resp = await client.list_fetch(cache_name, list_name)
             assert isinstance(fetch_resp, CacheListFetch.Hit)
-            assert fetch_resp.values_string == [value]
+            assert fetch_resp.value_list_string == [value]
 
             sleep(ttl_seconds / 2)
             fetch_resp = await client.list_fetch(cache_name, list_name)
@@ -158,7 +158,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_bytes == values_bytes
+        assert fetch_resp.value_list_bytes == values_bytes
 
     async def with_strings_it_succeeds(
         list_concatenator: TListConcatenator,
@@ -175,7 +175,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == values_str
+        assert fetch_resp.value_list_string == values_str
 
     async def with_iterable_values_it_succeeds(
         list_concatenator: TListConcatenator,
@@ -193,7 +193,7 @@ def a_list_concatenator() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == values_str
+        assert fetch_resp.value_list_string == values_str
 
     async def with_other_values_type_it_errors(
         list_concatenator: TListConcatenator,
@@ -266,7 +266,7 @@ def a_list_pusher() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_bytes == [value]
+        assert fetch_resp.value_list_bytes == [value]
 
     async def with_strings_it_succeeds(
         list_pusher: TListPusher,
@@ -281,7 +281,7 @@ def a_list_pusher() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(fetch_resp, CacheListFetch.Hit)
-        assert fetch_resp.values_string == [value]
+        assert fetch_resp.value_list_string == [value]
 
     async def with_other_value_type_it_errors(
         list_pusher: TListPusher,
@@ -366,7 +366,7 @@ def describe_list_concatenate_back() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["three", "four", "five", "six"]
+            assert fetch_resp.value_list_string == ["three", "four", "five", "six"]
         else:
             assert False
 
@@ -443,7 +443,7 @@ def describe_list_concatenate_front() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["four", "five", "six", "one"]
+            assert fetch_resp.value_list_string == ["four", "five", "six", "one"]
         else:
             assert False
 
@@ -645,7 +645,7 @@ def describe_list_push_back() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["2", "3"]
+            assert fetch_resp.value_list_string == ["2", "3"]
         else:
             assert False
 
@@ -709,7 +709,7 @@ def describe_list_push_front() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == ["3", "2"]
+            assert fetch_resp.value_list_string == ["3", "2"]
         else:
             assert False
 
@@ -759,6 +759,6 @@ def describe_list_remove_value() -> None:
 
         fetch_resp = await client_async.list_fetch(cache_name, list_name)
         if isinstance(fetch_resp, CacheListFetch.Hit):
-            assert fetch_resp.values_string == expected_values
+            assert fetch_resp.value_list_string == expected_values
         else:
             assert False


### PR DESCRIPTION
Audit the response hierarchy checking for incorrect parent classes and
checking the class fields for consistency.

Closes #286 