### PR TITLE
feat: make the retry logic configurable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ module = [
   "momento.internal.aio._scs_data_client",
   "momento.internal.aio._scs_grpc_manager",
   "momento.internal.aio._utilities",
-  "momento.responses.control.signing_key.*"
+  "momento.responses.control.signing_key.*",
 ]
 disallow_any_expr           = false
 

--- a/src/momento/config/configuration.py
+++ b/src/momento/config/configuration.py
@@ -3,12 +3,21 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import timedelta
 
+from momento.retry import RetryStrategy
+
 from .transport.transport_strategy import TransportStrategy
 
 
 class ConfigurationBase(ABC):
 
-    # TODO: RetryStrategy and Middlewares
+    # TODO: Middlewares
+    @abstractmethod
+    def get_retry_strategy(self) -> RetryStrategy:
+        pass
+
+    @abstractmethod
+    def with_retry_strategy(self, retry_strategy: RetryStrategy) -> Configuration:
+        pass
 
     @abstractmethod
     def get_transport_strategy(self) -> TransportStrategy:
@@ -26,14 +35,35 @@ class ConfigurationBase(ABC):
 class Configuration(ConfigurationBase):
     """Configuration options for Momento Simple Cache Client."""
 
-    def __init__(self, transport_strategy: TransportStrategy):
+    def __init__(self, transport_strategy: TransportStrategy, retry_strategy: RetryStrategy):
         """Instantiate a Configuration.
 
         Args:
             transport_strategy (TransportStrategy): Configuration options for networking with
             the Momento service.
+            retry_strategy (RetryStrategy): the strategy to use when determining whether to retry a grpc call.
         """
         self._transport_strategy = transport_strategy
+        self._retry_strategy = retry_strategy
+
+    def get_retry_strategy(self) -> RetryStrategy:
+        """Access the retry strategy.
+
+        Returns:
+            RetryStrategy: the strategy to use when determining whether to retry a grpc call.
+        """
+        return self._retry_strategy
+
+    def with_retry_strategy(self, retry_strategy: RetryStrategy) -> Configuration:
+        """Copy constructor for overriding RetryStrategy.
+
+        Args:
+            retry_strategy (RetryStrategy): the new RetryStrategy.
+
+        Returns:
+            Configuration: the new Configuration with the specified RetryStrategy.
+        """
+        return Configuration(self._transport_strategy, retry_strategy)
 
     def get_transport_strategy(self) -> TransportStrategy:
         """Access the transport strategy.
@@ -52,7 +82,7 @@ class Configuration(ConfigurationBase):
         Returns:
             Configuration: the new Configuration with the specified TransportStrategy.
         """
-        return Configuration(transport_strategy)
+        return Configuration(transport_strategy, self._retry_strategy)
 
     def with_client_timeout(self, client_timeout: timedelta) -> Configuration:
         """Copies the Configuration and sets the new client-side timeout in the copy's TransportStrategy.
@@ -63,4 +93,4 @@ class Configuration(ConfigurationBase):
         Return:
             Configuration: the new Configuration.
         """
-        return Configuration(self._transport_strategy.with_client_timeout(client_timeout))
+        return Configuration(self._transport_strategy.with_client_timeout(client_timeout), self._retry_strategy)

--- a/src/momento/config/configurations.py
+++ b/src/momento/config/configurations.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from momento.retry import FixedCountRetryStrategy
+
 from .configuration import Configuration
 from .transport.transport_strategy import (
     StaticGrpcConfiguration,
@@ -20,7 +22,10 @@ class Configurations:
 
         @staticmethod
         def latest() -> Configurations.Laptop:
-            return Configurations.Laptop(StaticTransportStrategy(StaticGrpcConfiguration(timedelta(seconds=15))))
+            return Configurations.Laptop(
+                StaticTransportStrategy(StaticGrpcConfiguration(timedelta(seconds=15))),
+                FixedCountRetryStrategy(max_attempts=3),
+            )
 
     class InRegion:
         """Default for application running in the same region as the Momento service.
@@ -38,7 +43,8 @@ class Configurations:
             @staticmethod
             def latest() -> Configurations.InRegion.Default:
                 return Configurations.InRegion.Default(
-                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=1100)))
+                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=1100))),
+                    FixedCountRetryStrategy(max_attempts=3),
                 )
 
         class LowLatency(Configuration):
@@ -52,5 +58,6 @@ class Configurations:
             @staticmethod
             def latest() -> Configurations.InRegion.LowLatency:
                 return Configurations.InRegion.LowLatency(
-                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=500)))
+                    StaticTransportStrategy(StaticGrpcConfiguration(timedelta(milliseconds=500))),
+                    FixedCountRetryStrategy(max_attempts=3),
                 )

--- a/src/momento/internal/aio/_retry_interceptor.py
+++ b/src/momento/internal/aio/_retry_interceptor.py
@@ -1,47 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Callable
 
 import grpc
 
-import momento.errors
+from momento.retry import RetryableProps, RetryStrategy
 
 # TODO: This is very duplicative of the synchronous retry interceptor; we need to
 # DRY these up, but for now I am prioritizing getting a fix out for a customer.
 
-# TODO: Retry interceptor behavior should be configurable, but we need to
-# add the configuration API first.
-# For now, for convenience during development, you can toggle this hard-coded
-# variable to enable/disable it.
-
-RETRIES_ENABLED = True
-MAX_ATTEMPTS = 3
-
-
-RETRYABLE_STATUS_CODES: list[grpc.StatusCode] = [
-    # # including all the status codes for reference, but
-    # # commenting out the ones we don't want to retry on for now.
-    # grpc.StatusCode.OK,
-    # grpc.StatusCode.CANCELLED,
-    # grpc.StatusCode.UNKNOWN,
-    # grpc.StatusCode.INVALID_ARGUMENT,
-    # grpc.StatusCode.DEADLINE_EXCEEDED,
-    # grpc.StatusCode.NOT_FOUND,
-    # grpc.StatusCode.ALREADY_EXISTS,
-    # grpc.StatusCode.PERMISSION_DENIED,
-    # grpc.StatusCode.RESOURCE_EXHAUSTED,
-    # grpc.StatusCode.FAILED_PRECONDITION,
-    # grpc.StatusCode.ABORTED,
-    # grpc.StatusCode.OUT_OF_RANGE,
-    # grpc.StatusCode.UNIMPLEMENTED,
-    grpc.StatusCode.INTERNAL,
-    grpc.StatusCode.UNAVAILABLE,
-    # grpc.StatusCode.DATA_LOSS,
-    # grpc.StatusCode.UNAUTHENTICATED,
-]
-
-LOGGER = logging.getLogger("retry-interceptor")
+logger = logging.getLogger("retry-interceptor")
 
 
 # TODO: We need to send retry count information to the server so that we
@@ -49,14 +19,12 @@ LOGGER = logging.getLogger("retry-interceptor")
 # https://github.com/momentohq/client-sdk-javascript/issues/80
 # TODO: we need to add backoff/jitter for the retries:
 # https://github.com/momentohq/client-sdk-javascript/issues/81
-def get_retry_interceptor_if_enabled() -> list[grpc.aio.UnaryUnaryClientInterceptor]:
-    if not RETRIES_ENABLED:
-        return []
-
-    return [RetryInterceptor()]
 
 
 class RetryInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
+    def __init__(self, retry_strategy: RetryStrategy):
+        self._retry_strategy = retry_strategy
+
     async def intercept_unary_unary(
         self,
         continuation: Callable[
@@ -66,36 +34,17 @@ class RetryInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
         client_call_details: grpc.aio._interceptor.ClientCallDetails,
         request: grpc.aio._typing.RequestType,
     ) -> grpc.aio._call.UnaryUnaryCall | grpc.aio._typing.ResponseType:
-        for try_i in range(MAX_ATTEMPTS):
+        attempt_number = 1
+        while True:
             call = await continuation(client_call_details, request)
             response_code = await call.code()
 
-            if response_code == grpc.StatusCode.OK:
-                return call
-
-            # Return if it was last attempt
-            if try_i == (MAX_ATTEMPTS - 1):
-                LOGGER.debug(
-                    "Request path: %s; retryable status code: %s; number of retries (%i) "
-                    "has exceeded max (%i), not retrying.",
-                    client_call_details.method.decode("utf-8"),
-                    response_code,
-                    try_i,
-                    MAX_ATTEMPTS,
-                )
-                return call
-
-            # If status code is not in retryable status codes
-            if response_code not in RETRYABLE_STATUS_CODES:
-                return call
-
-            LOGGER.debug(
-                "Request path: %s; retryable status code: %s; number of retries (%i) "
-                "is less than max (%i), retrying.",
-                client_call_details.method.decode("utf-8"),
-                response_code,
-                try_i,
-                MAX_ATTEMPTS,
+            retryTime = self._retry_strategy.determine_when_to_retry(
+                RetryableProps(response_code, client_call_details.method.decode("utf-8"), attempt_number)
             )
 
-        raise momento.errors.UnknownException("Failed to return from RetryInterceptor!  This is a bug.")
+            if retryTime is None:
+                return call
+
+            attempt_number += 1
+            await asyncio.sleep(retryTime)

--- a/src/momento/internal/aio/_scs_control_client.py
+++ b/src/momento/internal/aio/_scs_control_client.py
@@ -13,6 +13,7 @@ from momento_wire_types.controlclient_pb2_grpc import ScsControlStub
 
 from momento import logs
 from momento.auth import CredentialProvider
+from momento.config import Configuration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_cache_name, _validate_ttl
 from momento.internal.aio._scs_grpc_manager import _ControlGrpcManager
@@ -37,11 +38,11 @@ _DEADLINE_SECONDS = 60.0  # 1 minute
 class _ScsControlClient:
     """Momento Internal."""
 
-    def __init__(self, credential_provider: CredentialProvider):
+    def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         endpoint = credential_provider.control_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache control client instantiated with endpoint: %s", endpoint)
-        self._grpc_manager = _ControlGrpcManager(credential_provider)
+        self._grpc_manager = _ControlGrpcManager(configuration, credential_provider)
         self._endpoint = endpoint
 
     @property

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -138,7 +138,7 @@ class _ScsDataClient:
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
         self._default_deadline_seconds = int(default_deadline.total_seconds())
 
-        self._grpc_manager = _DataGrpcManager(credential_provider)
+        self._grpc_manager = _DataGrpcManager(configuration, credential_provider)
 
         _validate_ttl(default_ttl)
         self._default_ttl = default_ttl

--- a/src/momento/internal/synchronous/_retry_interceptor.py
+++ b/src/momento/internal/synchronous/_retry_interceptor.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Callable, TypeVar
 
 import grpc
 
-import momento.errors
+from momento.retry import RetryableProps, RetryStrategy
 
 RequestType = TypeVar("RequestType")
 InterceptorCall = TypeVar("InterceptorCall")
@@ -14,37 +15,7 @@ ResponseType = TypeVar("ResponseType")
 # TODO: This is very duplicative of the asyncio retry interceptor; we need to
 # DRY these up, but for now I am prioritizing getting a fix out for a customer.
 
-# TODO: Retry interceptor behavior should be configurable, but we need to
-# add the configuration API first.
-# For now, for convenience during development, you can toggle this hard-coded
-# variable to enable/disable it.
-
-RETRIES_ENABLED = True
-MAX_ATTEMPTS = 3
-
-RETRYABLE_STATUS_CODES: list[grpc.StatusCode] = [
-    # # including all the status codes for reference, but
-    # # commenting out the ones we don't want to retry on for now.
-    # grpc.StatusCode.OK,
-    # grpc.StatusCode.CANCELLED,
-    # grpc.StatusCode.UNKNOWN,
-    # grpc.StatusCode.INVALID_ARGUMENT,
-    # grpc.StatusCode.DEADLINE_EXCEEDED,
-    # grpc.StatusCode.NOT_FOUND,
-    # grpc.StatusCode.ALREADY_EXISTS,
-    # grpc.StatusCode.PERMISSION_DENIED,
-    # grpc.StatusCode.RESOURCE_EXHAUSTED,
-    # grpc.StatusCode.FAILED_PRECONDITION,
-    # grpc.StatusCode.ABORTED,
-    # grpc.StatusCode.OUT_OF_RANGE,
-    # grpc.StatusCode.UNIMPLEMENTED,
-    grpc.StatusCode.INTERNAL,
-    grpc.StatusCode.UNAVAILABLE,
-    # grpc.StatusCode.DATA_LOSS,
-    # grpc.StatusCode.UNAUTHENTICATED,
-]
-
-LOGGER = logging.getLogger("retry-interceptor")
+logger = logging.getLogger("retry-interceptor")
 
 
 # TODO: We need to send retry count information to the server so that we
@@ -52,50 +23,29 @@ LOGGER = logging.getLogger("retry-interceptor")
 # https://github.com/momentohq/client-sdk-javascript/issues/80
 # TODO: we need to add backoff/jitter for the retries:
 # https://github.com/momentohq/client-sdk-javascript/issues/81
-def get_retry_interceptor_if_enabled() -> list[grpc.UnaryUnaryClientInterceptor]:
-    if not RETRIES_ENABLED:
-        return []
-
-    return [RetryInterceptor()]
 
 
 class RetryInterceptor(grpc.UnaryUnaryClientInterceptor):
+    def __init__(self, retry_strategy: RetryStrategy):
+        self._retry_strategy = retry_strategy
+
     def intercept_unary_unary(
         self,
         continuation: Callable[[grpc.ClientCallDetails, RequestType], InterceptorCall],
         client_call_details: grpc.ClientCallDetails,
         request: RequestType,
     ) -> InterceptorCall | ResponseType:
-        for try_i in range(MAX_ATTEMPTS):
+        attempt_number = 1
+        while True:
             call = continuation(client_call_details, request)
             response_code = call.code()  # type: ignore[attr-defined]  # noqa: F401
 
-            if response_code == grpc.StatusCode.OK:
-                return call
-
-            # Return if it was last attempt
-            if try_i == (MAX_ATTEMPTS - 1):
-                LOGGER.debug(
-                    "Request path: %s; retryable status code: %s; number of retries (%i) "
-                    "has exceeded max (%i), not retrying.",
-                    client_call_details.method,
-                    response_code,
-                    try_i,
-                    MAX_ATTEMPTS,
-                )
-                return call
-
-            # If status code is not in retryable status codes
-            if response_code not in RETRYABLE_STATUS_CODES:
-                return call
-
-            LOGGER.debug(
-                "Request path: %s; retryable status code: %s; number of retries (%i) "
-                "is less than max (%i), retrying.",
-                client_call_details.method,
-                response_code,
-                try_i,
-                MAX_ATTEMPTS,
+            retryTime = self._retry_strategy.determine_when_to_retry(
+                RetryableProps(response_code, client_call_details.method, attempt_number)
             )
 
-        raise momento.errors.UnknownException("Failed to return from RetryInterceptor!  This is a bug.")
+            if retryTime is None:
+                return call
+
+            attempt_number += 1
+            time.sleep(retryTime)

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -13,6 +13,7 @@ from momento_wire_types.controlclient_pb2_grpc import ScsControlStub
 
 from momento import logs
 from momento.auth import CredentialProvider
+from momento.config import Configuration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_cache_name, _validate_ttl
 from momento.internal.synchronous._scs_grpc_manager import _ControlGrpcManager
@@ -37,11 +38,11 @@ _DEADLINE_SECONDS = 60.0  # 1 minute
 class _ScsControlClient:
     """Momento Internal."""
 
-    def __init__(self, credential_provider: CredentialProvider):
+    def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         endpoint = credential_provider.control_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache control client instantiated with endpoint: %s", endpoint)
-        self._grpc_manager = _ControlGrpcManager(credential_provider)
+        self._grpc_manager = _ControlGrpcManager(credential_provider, configuration)
         self._endpoint = endpoint
 
     @property

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -138,7 +138,7 @@ class _ScsDataClient:
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
         self._default_deadline_seconds = int(default_deadline.total_seconds())
 
-        self._grpc_manager = _DataGrpcManager(credential_provider)
+        self._grpc_manager = _DataGrpcManager(configuration, credential_provider)
 
         _validate_ttl(default_ttl)
         self._default_ttl = default_ttl

--- a/src/momento/retry/__init__.py
+++ b/src/momento/retry/__init__.py
@@ -3,3 +3,11 @@ from .eligibility_strategy import EligibilityStrategy
 from .fixed_count_retry_strategy import FixedCountRetryStrategy
 from .retry_strategy import RetryStrategy
 from .retryable_props import RetryableProps
+
+__all__ = [
+    "DefaultEligibilityStrategy",
+    "EligibilityStrategy",
+    "FixedCountRetryStrategy",
+    "RetryStrategy",
+    "RetryableProps",
+]

--- a/src/momento/retry/__init__.py
+++ b/src/momento/retry/__init__.py
@@ -1,0 +1,5 @@
+from .default_eligibility_strategy import DefaultEligibilityStrategy
+from .eligibility_strategy import EligibilityStrategy
+from .fixed_count_retry_strategy import FixedCountRetryStrategy
+from .retry_strategy import RetryStrategy
+from .retryable_props import RetryableProps

--- a/src/momento/retry/default_eligibility_strategy.py
+++ b/src/momento/retry/default_eligibility_strategy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import grpc
+
+from .eligibility_strategy import EligibilityStrategy
+from .retryable_props import RetryableProps
+
+RETRYABLE_STATUS_CODES: list[grpc.StatusCode] = [
+    # # including all the status codes for reference, but
+    # # commenting out the ones we don't want to retry on for now.
+    # grpc.StatusCode.OK,
+    # grpc.StatusCode.CANCELLED,
+    # grpc.StatusCode.UNKNOWN,
+    # grpc.StatusCode.INVALID_ARGUMENT,
+    # grpc.StatusCode.DEADLINE_EXCEEDED,
+    # grpc.StatusCode.NOT_FOUND,
+    # grpc.StatusCode.ALREADY_EXISTS,
+    # grpc.StatusCode.PERMISSION_DENIED,
+    # grpc.StatusCode.RESOURCE_EXHAUSTED,
+    # grpc.StatusCode.FAILED_PRECONDITION,
+    # grpc.StatusCode.ABORTED,
+    # grpc.StatusCode.OUT_OF_RANGE,
+    # grpc.StatusCode.UNIMPLEMENTED,
+    grpc.StatusCode.INTERNAL,  # type: ignore[misc]
+    grpc.StatusCode.UNAVAILABLE,  # type: ignore[misc]
+    # grpc.StatusCode.DATA_LOSS,
+    # grpc.StatusCode.UNAUTHENTICATED,
+]
+
+RETRYABLE_REQUEST_TYPES: list[str] = [
+    "/cache_client.Scs/Set",
+    "/cache_client.Scs/Get",
+    "/cache_client.Scs/Delete",
+    "/cache_client.Scs/DictionarySet",
+    # not idempotent: '/cache_client.Scs/DictionaryIncrement',
+    "/cache_client.Scs/DictionaryGet",
+    "/cache_client.Scs/DictionaryFetch",
+    "/cache_client.Scs/DictionaryDelete",
+    "/cache_client.Scs/SetUnion",
+    "/cache_client.Scs/SetDifference",
+    "/cache_client.Scs/SetFetch",
+    # not idempotent: '/cache_client.Scs/ListPushFront',
+    # not idempotent: '/cache_client.Scs/ListPushBack',
+    # not idempotent: '/cache_client.Scs/ListPopFront',
+    # not idempotent: '/cache_client.Scs/ListPopBack',
+    "/cache_client.Scs/ListFetch",
+    # Warning: in the future, this may not be idempotent
+    # Currently it supports removing all occurrences of a value.
+    # In the future, we may also add "the first/last N occurrences of a value".
+    # In the latter case it is not idempotent.
+    "/cache_client.Scs/ListRemove",
+    "/cache_client.Scs/ListLength",
+    # not idempotent: '/cache_client.Scs/ListConcatenateFront',
+    # not idempotent: '/cache_client.Scs/ListConcatenateBack'
+]
+
+
+class DefaultEligibilityStrategy(EligibilityStrategy):
+    def is_eligible_for_retry(self, props: RetryableProps) -> bool:
+        """Determines whether a grpc call can safely be retried based on the result of the last invocation of the call
+           and whether the call is idempotent.
+
+        Args:
+            props (RetryableProps): Information about the grpc call and its last invocation.
+        """
+        if props.grpc_status not in RETRYABLE_STATUS_CODES:  # type: ignore[misc]
+            return False
+
+        if props.grpc_method not in RETRYABLE_REQUEST_TYPES:
+            return False
+
+        return True

--- a/src/momento/retry/default_eligibility_strategy.py
+++ b/src/momento/retry/default_eligibility_strategy.py
@@ -31,18 +31,20 @@ RETRYABLE_REQUEST_TYPES: list[str] = [
     "/cache_client.Scs/Set",
     "/cache_client.Scs/Get",
     "/cache_client.Scs/Delete",
+    # not idempotent: "/cache_client.Scs/Increment"
     "/cache_client.Scs/DictionarySet",
-    # not idempotent: '/cache_client.Scs/DictionaryIncrement',
+    # not idempotent: "/cache_client.Scs/DictionaryIncrement",
     "/cache_client.Scs/DictionaryGet",
     "/cache_client.Scs/DictionaryFetch",
     "/cache_client.Scs/DictionaryDelete",
     "/cache_client.Scs/SetUnion",
     "/cache_client.Scs/SetDifference",
     "/cache_client.Scs/SetFetch",
-    # not idempotent: '/cache_client.Scs/ListPushFront',
-    # not idempotent: '/cache_client.Scs/ListPushBack',
-    # not idempotent: '/cache_client.Scs/ListPopFront',
-    # not idempotent: '/cache_client.Scs/ListPopBack',
+    # not idempotent: "/cache_client.Scs/SetIfNotExists"
+    # not idempotent: "/cache_client.Scs/ListPushFront",
+    # not idempotent: "/cache_client.Scs/ListPushBack",
+    # not idempotent: "/cache_client.Scs/ListPopFront",
+    # not idempotent: "/cache_client.Scs/ListPopBack",
     "/cache_client.Scs/ListFetch",
     # Warning: in the future, this may not be idempotent
     # Currently it supports removing all occurrences of a value.
@@ -50,8 +52,8 @@ RETRYABLE_REQUEST_TYPES: list[str] = [
     # In the latter case it is not idempotent.
     "/cache_client.Scs/ListRemove",
     "/cache_client.Scs/ListLength",
-    # not idempotent: '/cache_client.Scs/ListConcatenateFront',
-    # not idempotent: '/cache_client.Scs/ListConcatenateBack'
+    # not idempotent: "/cache_client.Scs/ListConcatenateFront",
+    # not idempotent: "/cache_client.Scs/ListConcatenateBack"
 ]
 
 

--- a/src/momento/retry/default_eligibility_strategy.py
+++ b/src/momento/retry/default_eligibility_strategy.py
@@ -57,8 +57,9 @@ RETRYABLE_REQUEST_TYPES: list[str] = [
 
 class DefaultEligibilityStrategy(EligibilityStrategy):
     def is_eligible_for_retry(self, props: RetryableProps) -> bool:
-        """Determines whether a grpc call can safely be retried based on the result of the last invocation of the call
-           and whether the call is idempotent.
+        """Determines whether a grpc call is able to be retried.
+
+        The determination is based on the result of the last invocation of the call and whether the call is idempotent.
 
         Args:
             props (RetryableProps): Information about the grpc call and its last invocation.

--- a/src/momento/retry/eligibility_strategy.py
+++ b/src/momento/retry/eligibility_strategy.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from .retryable_props import RetryableProps
+
+
+class EligibilityStrategy(ABC):
+    @abstractmethod
+    def is_eligible_for_retry(self, props: RetryableProps) -> bool:
+        pass

--- a/src/momento/retry/fixed_count_retry_strategy.py
+++ b/src/momento/retry/fixed_count_retry_strategy.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Optional
+
+from .default_eligibility_strategy import DefaultEligibilityStrategy
+from .eligibility_strategy import EligibilityStrategy
+from .retry_strategy import RetryStrategy
+from .retryable_props import RetryableProps
+
+logger = logging.getLogger("fixed-count-retry-strategy")
+
+
+class FixedCountRetryStrategy(RetryStrategy):
+    def __init__(
+        self, *, max_attempts: int = 3, eligibility_strategy: DefaultEligibilityStrategy = DefaultEligibilityStrategy()
+    ):
+        self._eligibility_strategy: EligibilityStrategy = eligibility_strategy
+        self._max_attempts: int = max_attempts
+
+    def determine_when_to_retry(self, props: RetryableProps) -> Optional[float]:
+        """Determines whether a grpc call can be retried and how long to wait before that retry.
+
+        Args:
+            props (RetryableProps): Information about the grpc call, its last invocation, and how many times the call
+            has been made.
+
+        :Returns
+            The time in seconds before the next retry should occur or None if no retry should be attempted.
+        """
+        if self._eligibility_strategy.is_eligible_for_retry(props) is False:
+            logger.debug(
+                "Request path: %s; retryable status code: %s. Request is not retryable.",
+                props.grpc_method,
+                props.grpc_status,  # type: ignore[misc]
+            )
+            return None
+
+        if props.attempt_number > self._max_attempts:
+            logger.debug(
+                "Request path: %s; retryable status code: %s; number of attempts (%i) "
+                "has exceeded max (%i); not retrying.",
+                props.grpc_method,
+                props.grpc_status,  # type: ignore[misc]
+                props.attempt_number,
+                self._max_attempts,
+            )
+            return None
+
+        logger.debug(
+            "Request path: %s; retryable status code: %s; number of attempts (%i) " "is not above max (%i); retrying.",
+            props.grpc_method,
+            props.grpc_status,  # type: ignore[misc]
+            props.attempt_number,
+            self._max_attempts,
+        )
+        return 0.0

--- a/src/momento/retry/retry_strategy.py
+++ b/src/momento/retry/retry_strategy.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from .retryable_props import RetryableProps
+
+
+class RetryStrategy(ABC):
+    @abstractmethod
+    def determine_when_to_retry(self, props: RetryableProps) -> Optional[float]:
+        pass

--- a/src/momento/retry/retryable_props.py
+++ b/src/momento/retry/retryable_props.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+import grpc
+
+
+# The lack of type hints in the grpc code causes a lint failure in combination with the dataclass annotation
+@dataclass  # type: ignore[misc]
+class RetryableProps:
+    grpc_status: grpc.StatusCode
+    grpc_method: str
+    attempt_number: int

--- a/src/momento/simple_cache_client.py
+++ b/src/momento/simple_cache_client.py
@@ -149,7 +149,7 @@ class SimpleCacheClient:
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger
         self._next_client_index = 0
-        self._control_client = _ScsControlClient(credential_provider)
+        self._control_client = _ScsControlClient(configuration, credential_provider)
         self._cache_endpoint = credential_provider.cache_endpoint
         self._data_clients = [
             _ScsDataClient(configuration, credential_provider, default_ttl)

--- a/src/momento/simple_cache_client_async.py
+++ b/src/momento/simple_cache_client_async.py
@@ -149,7 +149,7 @@ class SimpleCacheClientAsync:
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger
         self._next_client_index = 0
-        self._control_client = _ScsControlClient(credential_provider)
+        self._control_client = _ScsControlClient(configuration, credential_provider)
         self._cache_endpoint = credential_provider.cache_endpoint
         self._data_clients = [
             _ScsDataClient(configuration, credential_provider, default_ttl)


### PR DESCRIPTION
Add abstract EligibilityStrategy class that determines whether a grpc call can be retried based on the type of call and the error encountered.

Add abstract RetryStrategy class that uses an EligibilityStrategy to determine if a call can be retried and outputs a time to wait before retrying.

Add default implementations of the retry and eligibility strategies that have no wait time.

Update the configurations to take a retry strategy and set the number of retries to 3 by default. That is, 1 initial call and up to 3 retries on top of that.