### PR TITLE
chore: add trace level logging

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -127,6 +127,17 @@ if __name__ == "__main__":
     _print_end_banner()
 ```
 
+### Logging
+To avoid cluttering DEBUG logging with per-method logs the Momento SDK adds a TRACE logging level. This will only happen
+if the TRACE level does not already exist.
+
+To enable TRACE level logging you can call logging.basicConfig() before making any log statements:
+```agsl
+import logging
+
+logging.basicConfig(level='TRACE')
+```
+
 ### Error Handling
 
 Coming Soon!

--- a/README.template.md
+++ b/README.template.md
@@ -134,7 +134,7 @@ if the TRACE level does not already exist.
 
 To enable TRACE level logging you can call logging.basicConfig() before making any log statements:
 
-```agsl
+```python
 import logging
 
 logging.basicConfig(level='TRACE')

--- a/README.template.md
+++ b/README.template.md
@@ -128,10 +128,12 @@ if __name__ == "__main__":
 ```
 
 ### Logging
+
 To avoid cluttering DEBUG logging with per-method logs the Momento SDK adds a TRACE logging level. This will only happen
 if the TRACE level does not already exist.
 
 To enable TRACE level logging you can call logging.basicConfig() before making any log statements:
+
 ```agsl
 import logging
 

--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -1,10 +1,13 @@
 import logging
 
+from momento import logs
+
 from .auth import CredentialProvider
 from .config import Configurations
 from .simple_cache_client import SimpleCacheClient
 from .simple_cache_client_async import SimpleCacheClientAsync
 
 logging.getLogger("momentosdk").addHandler(logging.NullHandler())
+logs.initialize_momento_logging()
 
 __all__ = ["CredentialProvider", "Configurations", "SimpleCacheClient", "SimpleCacheClientAsync"]

--- a/src/momento/logs.py
+++ b/src/momento/logs.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Optional
 
 logger = logging.getLogger("momentosdk")
@@ -41,6 +42,11 @@ def add_logging_level(level_name: str, level_num: int, method_name: Optional[str
     if hasattr(logging, level_name) or hasattr(logging, method_name) or hasattr(logging.getLoggerClass(), method_name):
         # Do nothing if the logging level already exists. Since this affects logging globally we can't know if the user
         # or another dependency has already added the same level.
+        warnings.warn(
+            "Logging level {level} or logging method {method} already defined. Skipping.".format(
+                level=level_name, method=method_name
+            )
+        )
         return False
 
     # This method was inspired by the answers to Stack Overflow post

--- a/src/momento/logs.py
+++ b/src/momento/logs.py
@@ -12,7 +12,7 @@ info = logger.info
 debug = logger.debug
 
 
-def add_logging_level(level_name: str, level_num: int, method_name: Optional[str] = None) -> None:
+def add_logging_level(level_name: str, level_num: int, method_name: Optional[str] = None) -> bool:
     """Comprehensively adds a new logging level to the `logging` module and the currently configured logging class.
 
     `level_name` becomes an attribute of the `logging` module with the value
@@ -38,12 +38,10 @@ def add_logging_level(level_name: str, level_num: int, method_name: Optional[str
     if not method_name:
         method_name = level_name.lower()
 
-    if hasattr(logging, level_name):
-        raise AttributeError("{} already defined in logging module".format(level_name))
-    if hasattr(logging, method_name):
-        raise AttributeError("{} already defined in logging module".format(method_name))
-    if hasattr(logging.getLoggerClass(), method_name):
-        raise AttributeError("{} already defined in logger class".format(method_name))
+    if hasattr(logging, level_name) or hasattr(logging, method_name) or hasattr(logging.getLoggerClass(), method_name):
+        # Do nothing if the logging level already exists. Since this affects logging globally we can't know if the user
+        # or another dependency has already added the same level.
+        return False
 
     # This method was inspired by the answers to Stack Overflow post
     # http://stackoverflow.com/q/2183233/2988730, especially
@@ -59,6 +57,8 @@ def add_logging_level(level_name: str, level_num: int, method_name: Optional[str
     setattr(logging, level_name, level_num)
     setattr(logging.getLoggerClass(), method_name, logForLevel)  # type: ignore[misc]
     setattr(logging, method_name, logToRoot)  # type: ignore[misc]
+
+    return True
 
 
 TRACE = logging.DEBUG - 5


### PR DESCRIPTION
Do nothing instead of raising an error if a log method is already defined in the add_logging_level method.

Call initialize_momento_logging in __init__.py to add trace logging.

Add a section to the readme that explains the trace logging and has an example of how to enable it.