### PR TITLE
feat: rename cache client from `SimpleCacheClient` to `CacheClient`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 do-gen-sync:
 	@poetry run python -m momento.internal.codegen src/momento/internal/aio/_scs_control_client.py src/momento/internal/synchronous/_scs_control_client.py
 	@poetry run python -m momento.internal.codegen src/momento/internal/aio/_scs_data_client.py src/momento/internal/synchronous/_scs_data_client.py
-	@poetry run python -m momento.internal.codegen src/momento/simple_cache_client_async.py src/momento/simple_cache_client.py
+	@poetry run python -m momento.internal.codegen src/momento/cache_client_async.py src/momento/cache_client.py
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/shared_behaviors_async.py tests/momento/simple_cache_client/shared_behaviors.py 
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_init_async.py tests/momento/simple_cache_client/test_init.py
 	@poetry run python -m momento.internal.codegen tests/momento/simple_cache_client/test_control_async.py tests/momento/simple_cache_client/test_control.py
@@ -55,7 +55,7 @@ precommit: gen-sync format lint test
 ## Remove intermediate files
 clean:
 	@rm -rf dist .mypy_cache .pytest_cache
-	@find -name "*__pycache__*" | xargs rm -rf
+	@find . -name "*__pycache__*" | xargs rm -rf
 
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -70,7 +70,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     match create_cache_response:
         case CreateCache.Success():
@@ -83,7 +83,7 @@ def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
             _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: SimpleCacheClient) -> None:
+def _list_caches(cache_client: CacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -106,7 +106,7 @@ def _list_caches(cache_client: SimpleCacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 
@@ -148,7 +148,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -174,7 +174,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -186,7 +186,7 @@ def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
         _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: SimpleCacheClient) -> None:
+def _list_caches(cache_client: CacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -208,7 +208,7 @@ def _list_caches(cache_client: SimpleCacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/README.template.md
+++ b/README.template.md
@@ -40,7 +40,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -66,7 +66,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -78,7 +78,7 @@ def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
         _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: SimpleCacheClient) -> None:
+def _list_caches(cache_client: CacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -100,7 +100,7 @@ def _list_caches(cache_client: SimpleCacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/examples/prepy310/example.py
+++ b/examples/prepy310/example.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -29,7 +29,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -41,7 +41,7 @@ def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
         _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: SimpleCacheClient) -> None:
+def _list_caches(cache_client: CacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -63,7 +63,7 @@ def _list_caches(cache_client: SimpleCacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/examples/prepy310/example.py
+++ b/examples/prepy310/example.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import CacheClient
+from momento import SimpleCacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -29,7 +29,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -41,7 +41,7 @@ def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
         _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: CacheClient) -> None:
+def _list_caches(cache_client: SimpleCacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -63,7 +63,7 @@ def _list_caches(cache_client: CacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import CacheClientAsync
+from momento import SimpleCacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -30,7 +30,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None:
+async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -> None:
     create_cache_response = await cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -42,7 +42,7 @@ async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None
         _logger.error("Unreachable")
 
 
-async def _list_caches(cache_client: CacheClientAsync) -> None:
+async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
     _logger.info("Listing caches:")
     list_caches_response = await cache_client.list_caches()
     while True:
@@ -64,7 +64,7 @@ async def _list_caches(cache_client: CacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with CacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with SimpleCacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -30,7 +30,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -> None:
+async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None:
     create_cache_response = await cache_client.create_cache(cache_name)
     if isinstance(create_cache_response, CreateCache.Success):
         pass
@@ -42,7 +42,7 @@ async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -
         _logger.error("Unreachable")
 
 
-async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
+async def _list_caches(cache_client: CacheClientAsync) -> None:
     _logger.info("Listing caches:")
     list_caches_response = await cache_client.list_caches()
     while True:
@@ -64,7 +64,7 @@ async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with SimpleCacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with CacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -29,7 +29,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     match create_cache_response:
         case CreateCache.Success():
@@ -42,7 +42,7 @@ def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
             _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: SimpleCacheClient) -> None:
+def _list_caches(cache_client: CacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -65,7 +65,7 @@ def _list_caches(cache_client: SimpleCacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import CacheClient
+from momento import SimpleCacheClient
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -29,7 +29,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
+def _create_cache(cache_client: SimpleCacheClient, cache_name: str) -> None:
     create_cache_response = cache_client.create_cache(cache_name)
     match create_cache_response:
         case CreateCache.Success():
@@ -42,7 +42,7 @@ def _create_cache(cache_client: CacheClient, cache_name: str) -> None:
             _logger.error("Unreachable")
 
 
-def _list_caches(cache_client: CacheClient) -> None:
+def _list_caches(cache_client: SimpleCacheClient) -> None:
     _logger.info("Listing caches:")
     list_caches_response = cache_client.list_caches()
     while True:
@@ -65,7 +65,7 @@ def _list_caches(cache_client: CacheClient) -> None:
 if __name__ == "__main__":
     initialize_logging()
     _print_start_banner()
-    with CacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    with SimpleCacheClient(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         _create_cache(cache_client, _CACHE_NAME)
         _list_caches(cache_client)
 

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -30,7 +30,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -> None:
+async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None:
     create_cache_response = await cache_client.create_cache(cache_name)
     match create_cache_response:
         case CreateCache.Success():
@@ -43,7 +43,7 @@ async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -
             _logger.error("Unreachable")
 
 
-async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
+async def _list_caches(cache_client: CacheClientAsync) -> None:
     _logger.info("Listing caches:")
     list_caches_response = await cache_client.list_caches()
     while True:
@@ -66,7 +66,7 @@ async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with SimpleCacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with CacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from example_utils.example_logging import initialize_logging
 
-from momento import CacheClientAsync
+from momento import SimpleCacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
@@ -30,7 +30,7 @@ def _print_end_banner() -> None:
     _logger.info("******************************************************************")
 
 
-async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None:
+async def _create_cache(cache_client: SimpleCacheClientAsync, cache_name: str) -> None:
     create_cache_response = await cache_client.create_cache(cache_name)
     match create_cache_response:
         case CreateCache.Success():
@@ -43,7 +43,7 @@ async def _create_cache(cache_client: CacheClientAsync, cache_name: str) -> None
             _logger.error("Unreachable")
 
 
-async def _list_caches(cache_client: CacheClientAsync) -> None:
+async def _list_caches(cache_client: SimpleCacheClientAsync) -> None:
     _logger.info("Listing caches:")
     list_caches_response = await cache_client.list_caches()
     while True:
@@ -66,7 +66,7 @@ async def _list_caches(cache_client: CacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with CacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with SimpleCacheClientAsync(Laptop.latest(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -11,7 +11,7 @@ import colorlog  # type: ignore
 from hdrh.histogram import HdrHistogram
 
 import momento.errors
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.logs import initialize_momento_logging
@@ -85,7 +85,7 @@ class BasicPythonLoadGen:
     async def run(self) -> None:
         cache_item_ttl_seconds = timedelta(seconds=60)
         config = Laptop.latest().with_client_timeout(timedelta(milliseconds=self.options.request_timeout_ms))
-        async with SimpleCacheClientAsync(
+        async with CacheClientAsync(
             config, self.auth_provider, cache_item_ttl_seconds
         ) as cache_client:
             create_cache_response = await cache_client.create_cache(BasicPythonLoadGen.cache_name)
@@ -132,7 +132,7 @@ class BasicPythonLoadGen:
 
     async def start(
         self,
-        cache_client: SimpleCacheClientAsync,
+        cache_client: CacheClientAsync,
     ) -> None:
         async_get_set_results = (
             self.launch_and_run_worker(
@@ -164,7 +164,7 @@ class BasicPythonLoadGen:
 
     async def launch_and_run_worker(
         self,
-        client: SimpleCacheClientAsync,
+        client: CacheClientAsync,
         worker_id: int,
     ) -> None:
         operation_id = 1
@@ -179,7 +179,7 @@ class BasicPythonLoadGen:
 
     async def issue_async_set_get(
         self,
-        client: SimpleCacheClientAsync,
+        client: CacheClientAsync,
         worker_id: int,
         operation_id: int,
     ) -> None:

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -11,7 +11,7 @@ import colorlog  # type: ignore
 from hdrh.histogram import HdrHistogram
 
 import momento.errors
-from momento import CacheClientAsync
+from momento import SimpleCacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Laptop
 from momento.logs import initialize_momento_logging
@@ -85,7 +85,7 @@ class BasicPythonLoadGen:
     async def run(self) -> None:
         cache_item_ttl_seconds = timedelta(seconds=60)
         config = Laptop.latest().with_client_timeout(timedelta(milliseconds=self.options.request_timeout_ms))
-        async with CacheClientAsync(
+        async with SimpleCacheClientAsync(
             config, self.auth_provider, cache_item_ttl_seconds
         ) as cache_client:
             create_cache_response = await cache_client.create_cache(BasicPythonLoadGen.cache_name)
@@ -132,7 +132,7 @@ class BasicPythonLoadGen:
 
     async def start(
         self,
-        cache_client: CacheClientAsync,
+        cache_client: SimpleCacheClientAsync,
     ) -> None:
         async_get_set_results = (
             self.launch_and_run_worker(
@@ -164,7 +164,7 @@ class BasicPythonLoadGen:
 
     async def launch_and_run_worker(
         self,
-        client: CacheClientAsync,
+        client: SimpleCacheClientAsync,
         worker_id: int,
     ) -> None:
         operation_id = 1
@@ -179,7 +179,7 @@ class BasicPythonLoadGen:
 
     async def issue_async_set_get(
         self,
-        client: CacheClientAsync,
+        client: SimpleCacheClientAsync,
         worker_id: int,
         operation_id: int,
     ) -> None:

--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -1,10 +1,10 @@
 import logging
 
 from .auth import CredentialProvider
+from .cache_client import CacheClient
+from .cache_client_async import CacheClientAsync
 from .config import Configurations
-from .simple_cache_client import SimpleCacheClient
-from .simple_cache_client_async import SimpleCacheClientAsync
 
 logging.getLogger("momentosdk").addHandler(logging.NullHandler())
 
-__all__ = ["CredentialProvider", "Configurations", "SimpleCacheClient", "SimpleCacheClientAsync"]
+__all__ = ["CredentialProvider", "Configurations", "CacheClient", "CacheClientAsync"]

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -9,7 +9,7 @@ from . import momento_endpoint_resolver
 
 @dataclass
 class CredentialProvider:
-    """Information the SimpleCacheClient needs to connect to and authenticate with the Momento service."""
+    """Information the CacheClient needs to connect to and authenticate with the Momento service."""
 
     auth_token: str
     control_endpoint: str

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -139,12 +139,12 @@ class CacheClient:
         Example::
 
             from datetime import timedelta
-            from momento import Configurations, CredentialProvider, SimpleCacheClient
+            from momento import Configurations, CredentialProvider, CacheClient
 
             configuration = Configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
-            client = SimpleCacheClient(configuration, credential_provider, ttl_seconds)
+            client = CacheClient(configuration, credential_provider, ttl_seconds)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -12,8 +12,8 @@ from momento.requests import CollectionTtl
 
 try:
     from momento.internal._utilities import _validate_request_timeout
-    from momento.internal.aio._scs_control_client import _ScsControlClient
-    from momento.internal.aio._scs_data_client import _ScsDataClient
+    from momento.internal.synchronous._scs_control_client import _ScsControlClient
+    from momento.internal.synchronous._scs_data_client import _ScsDataClient
 except ImportError as e:
     if e.name == "cygrpc":
         import sys
@@ -83,8 +83,8 @@ from momento.responses import (
 from momento.typing import TDictionaryItems
 
 
-class SimpleCacheClientAsync:
-    """Async Simple Cache Client.
+class CacheClient:
+    """Synchronous Cache Client.
 
     Cache and control methods return a response object unique to each request.
     The response object is resolved to a type-safe object of one of several
@@ -93,7 +93,7 @@ class SimpleCacheClientAsync:
     Pattern matching can be used to operate on the appropriate subtype.
     For example, in python 3.10+ if you're deleting a key::
 
-        response = await client.delete(cache_name, key)
+        response = client.delete(cache_name, key)
         match response:
             case CacheDelete.Success():
                 ...they key was deleted or not found...
@@ -102,7 +102,7 @@ class SimpleCacheClientAsync:
 
     or equivalently in earlier versions of python::
 
-        response = await client.delete(cache_name, key)
+        response = client.delete(cache_name, key)
         if isinstance(response, CacheDelete.Success):
             ...
         elif isinstance(response, CacheDelete.Error):
@@ -139,12 +139,12 @@ class SimpleCacheClientAsync:
         Example::
 
             from datetime import timedelta
-            from momento import Configurations, CredentialProvider, SimpleCacheClientAsync
+            from momento import Configurations, CredentialProvider, SimpleCacheClient
 
             configuration = Configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
-            client = SimpleCacheClientAsync(configuration, credential_provider, ttl_seconds)
+            client = SimpleCacheClient(configuration, credential_provider, ttl_seconds)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger
@@ -152,24 +152,23 @@ class SimpleCacheClientAsync:
         self._control_client = _ScsControlClient(configuration, credential_provider)
         self._cache_endpoint = credential_provider.cache_endpoint
         self._data_clients = [
-            _ScsDataClient(configuration, credential_provider, default_ttl)
-            for _ in range(SimpleCacheClientAsync._NUM_CLIENTS)
+            _ScsDataClient(configuration, credential_provider, default_ttl) for _ in range(CacheClient._NUM_CLIENTS)
         ]
 
-    async def __aenter__(self) -> SimpleCacheClientAsync:
+    def __enter__(self) -> CacheClient:
         return self
 
-    async def __aexit__(
+    def __exit__(
         self,
         exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        await self._control_client.close()
+        self._control_client.close()
         for data_client in self._data_clients:
-            await data_client.close()
+            data_client.close()
 
-    async def create_cache(self, cache_name: str) -> CreateCacheResponse:
+    def create_cache(self, cache_name: str) -> CreateCacheResponse:
         """Creates a cache if it doesn't exist.
 
         Args:
@@ -178,9 +177,9 @@ class SimpleCacheClientAsync:
         Returns:
             CreateCacheResponse:
         """
-        return await self._control_client.create_cache(cache_name)
+        return self._control_client.create_cache(cache_name)
 
-    async def delete_cache(self, cache_name: str) -> DeleteCacheResponse:
+    def delete_cache(self, cache_name: str) -> DeleteCacheResponse:
         """Deletes a cache and all of the items within it.
 
         Args:
@@ -189,17 +188,17 @@ class SimpleCacheClientAsync:
         Returns:
             DeleteCacheResponse:
         """
-        return await self._control_client.delete_cache(cache_name)
+        return self._control_client.delete_cache(cache_name)
 
-    async def list_caches(self) -> ListCachesResponse:
+    def list_caches(self) -> ListCachesResponse:
         """Lists all caches.
 
         Returns:
             ListCachesResponse:
         """
-        return await self._control_client.list_caches()
+        return self._control_client.list_caches()
 
-    async def create_signing_key(self, ttl: timedelta) -> CreateSigningKeyResponse:
+    def create_signing_key(self, ttl: timedelta) -> CreateSigningKeyResponse:
         """Creates a Momento signing key.
 
         Args:
@@ -208,9 +207,9 @@ class SimpleCacheClientAsync:
         Returns:
             CreateSigningKeyResponse
         """
-        return await self._control_client.create_signing_key(ttl, self._cache_endpoint)
+        return self._control_client.create_signing_key(ttl, self._cache_endpoint)
 
-    async def revoke_signing_key(self, key_id: str) -> RevokeSigningKeyResponse:
+    def revoke_signing_key(self, key_id: str) -> RevokeSigningKeyResponse:
         """Revokes a Momento signing key, all tokens signed by which will be invalid.
 
         Args:
@@ -219,17 +218,17 @@ class SimpleCacheClientAsync:
         Returns:
             RevokeSigningKeyResponse
         """
-        return await self._control_client.revoke_signing_key(key_id)
+        return self._control_client.revoke_signing_key(key_id)
 
-    async def list_signing_keys(self) -> ListSigningKeysResponse:
+    def list_signing_keys(self) -> ListSigningKeysResponse:
         """Lists all Momento signing keys for the provided auth token.
 
         Returns:
             ListSigningKeysResponse
         """
-        return await self._control_client.list_signing_keys(self._cache_endpoint)
+        return self._control_client.list_signing_keys(self._cache_endpoint)
 
-    async def increment(
+    def increment(
         self,
         cache_name: str,
         key: str | bytes,
@@ -249,9 +248,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheIncrementResponse
         """
-        return await self._data_client.increment(cache_name, key, amount, ttl)
+        return self._data_client.increment(cache_name, key, amount, ttl)
 
-    async def set(
+    def set(
         self,
         cache_name: str,
         key: str | bytes,
@@ -271,9 +270,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetResponse:
         """
-        return await self._data_client.set(cache_name, key, value, ttl)
+        return self._data_client.set(cache_name, key, value, ttl)
 
-    async def set_if_not_exists(
+    def set_if_not_exists(
         self,
         cache_name: str,
         key: str | bytes,
@@ -293,9 +292,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetIfNotExistsResponse:
         """
-        return await self._data_client.set_if_not_exists(cache_name, key, value, ttl)
+        return self._data_client.set_if_not_exists(cache_name, key, value, ttl)
 
-    async def get(self, cache_name: str, key: str | bytes) -> CacheGetResponse:
+    def get(self, cache_name: str, key: str | bytes) -> CacheGetResponse:
         """Get the cache value stored for the given key.
 
         Args:
@@ -305,9 +304,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheGetResponse:
         """
-        return await self._data_client.get(cache_name, key)
+        return self._data_client.get(cache_name, key)
 
-    async def delete(self, cache_name: str, key: str | bytes) -> CacheDeleteResponse:
+    def delete(self, cache_name: str, key: str | bytes) -> CacheDeleteResponse:
         """Remove the key from the cache.
 
         Args:
@@ -317,10 +316,10 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDeleteResponse:
         """
-        return await self._data_client.delete(cache_name, key)
+        return self._data_client.delete(cache_name, key)
 
     # DICTIONARY COLLECTION METHODS
-    async def dictionary_fetch(self, cache_name: str, dictionary_name: str) -> CacheDictionaryFetchResponse:
+    def dictionary_fetch(self, cache_name: str, dictionary_name: str) -> CacheDictionaryFetchResponse:
         """Fetch the entire dictionary from the cache.
 
         Args:
@@ -330,9 +329,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryFetchResponse: result of the fetch operation and the associated dictionary.
         """
-        return await self._data_client.dictionary_fetch(cache_name, dictionary_name)
+        return self._data_client.dictionary_fetch(cache_name, dictionary_name)
 
-    async def dictionary_get_field(
+    def dictionary_get_field(
         self, cache_name: str, dictionary_name: str, field: str | bytes
     ) -> CacheDictionaryGetFieldResponse:
         """Get the cache value stored for the given dictionary and field.
@@ -345,7 +344,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryGetFieldResponse: the status and value for the field.
         """
-        get_fields_response = await self.dictionary_get_fields(cache_name, dictionary_name, [field])
+        get_fields_response = self.dictionary_get_fields(cache_name, dictionary_name, [field])
         if isinstance(get_fields_response, CacheDictionaryGetFields.Hit):
             if len(get_fields_response.responses) == 0:
                 return CacheDictionaryGetField.Error(UnknownException("Unknown get fields response had no data"))
@@ -357,7 +356,7 @@ class SimpleCacheClientAsync:
         else:
             return CacheDictionaryGetField.Error(UnknownException(f"Unknown get field response: {get_fields_response}"))
 
-    async def dictionary_get_fields(
+    def dictionary_get_fields(
         self, cache_name: str, dictionary_name: str, fields: Iterable[str | bytes]
     ) -> CacheDictionaryGetFieldsResponse:
         """Get several values from a dictionary.
@@ -370,9 +369,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryGetFieldsResponse: the status and associated value for each field.
         """
-        return await self._data_client.dictionary_get_fields(cache_name, dictionary_name, fields)
+        return self._data_client.dictionary_get_fields(cache_name, dictionary_name, fields)
 
-    async def dictionary_increment(
+    def dictionary_increment(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -395,9 +394,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryIncrementResponse: result of the increment operation.
         """
-        return await self._data_client.dictionary_increment(cache_name, dictionary_name, field, amount, ttl)
+        return self._data_client.dictionary_increment(cache_name, dictionary_name, field, amount, ttl)
 
-    async def dictionary_remove_field(
+    def dictionary_remove_field(
         self, cache_name: str, dictionary_name: str, field: str | bytes
     ) -> CacheDictionaryRemoveFieldResponse:
         """Remove a field from a dictionary.
@@ -412,7 +411,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryRemoveFieldResponse: result of the remove operation.
         """
-        remove_fields_response = await self.dictionary_remove_fields(cache_name, dictionary_name, fields=[field])
+        remove_fields_response = self.dictionary_remove_fields(cache_name, dictionary_name, fields=[field])
         if isinstance(remove_fields_response, CacheDictionaryRemoveFields.Success):
             return CacheDictionaryRemoveField.Success()
         elif isinstance(remove_fields_response, CacheDictionaryRemoveFields.Error):
@@ -422,7 +421,7 @@ class SimpleCacheClientAsync:
                 UnknownException(f"Unknown remove fields response: {remove_fields_response}")
             )
 
-    async def dictionary_remove_fields(
+    def dictionary_remove_fields(
         self, cache_name: str, dictionary_name: str, fields: Iterable[str | bytes]
     ) -> CacheDictionaryRemoveFieldsResponse:
         """Remove fields from a dictionary.
@@ -437,9 +436,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionaryRemoveFieldsResponse: result of the remove fields operation.
         """
-        return await self._data_client.dictionary_remove_fields(cache_name, dictionary_name, fields)
+        return self._data_client.dictionary_remove_fields(cache_name, dictionary_name, fields)
 
-    async def dictionary_set_field(
+    def dictionary_set_field(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -462,9 +461,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionarySetFieldResponse: result of the set operation.
         """
-        set_fields_response = await self.dictionary_set_fields(
-            cache_name, dictionary_name, items={field: value}, ttl=ttl
-        )
+        set_fields_response = self.dictionary_set_fields(cache_name, dictionary_name, items={field: value}, ttl=ttl)
         if isinstance(set_fields_response, CacheDictionarySetFields.Success):
             return CacheDictionarySetField.Success()
         elif isinstance(set_fields_response, CacheDictionarySetFields.Error):
@@ -474,7 +471,7 @@ class SimpleCacheClientAsync:
                 UnknownException(f"Unknown set fields response: {set_fields_response}")
             )
 
-    async def dictionary_set_fields(
+    def dictionary_set_fields(
         self,
         cache_name: str,
         dictionary_name: str,
@@ -495,10 +492,10 @@ class SimpleCacheClientAsync:
         Returns:
             CacheDictionarySetFieldsResponse: result of the set fields operation.
         """
-        return await self._data_client.dictionary_set_fields(cache_name, dictionary_name, items, ttl)
+        return self._data_client.dictionary_set_fields(cache_name, dictionary_name, items, ttl)
 
     # LIST COLLECTION METHODS
-    async def list_concatenate_back(
+    def list_concatenate_back(
         self,
         cache_name: str,
         list_name: str,
@@ -520,9 +517,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListConcatenateBackResponse:
         """
-        return await self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
+        return self._data_client.list_concatenate_back(cache_name, list_name, values, ttl, truncate_front_to_size)
 
-    async def list_concatenate_front(
+    def list_concatenate_front(
         self,
         cache_name: str,
         list_name: str,
@@ -544,9 +541,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListConcatenateFrontResponse:
         """
-        return await self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
+        return self._data_client.list_concatenate_front(cache_name, list_name, values, ttl, truncate_back_to_size)
 
-    async def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
+    def list_fetch(self, cache_name: str, list_name: str) -> CacheListFetchResponse:
         """Gets all values from the list.
 
         Args:
@@ -556,9 +553,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListFetchResponse:
         """
-        return await self._data_client.list_fetch(cache_name, list_name)
+        return self._data_client.list_fetch(cache_name, list_name)
 
-    async def list_length(self, cache_name: str, list_name: str) -> CacheListLengthResponse:
+    def list_length(self, cache_name: str, list_name: str) -> CacheListLengthResponse:
         """Gets the number of values in the list.
 
         Args:
@@ -568,9 +565,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListLengthResponse:
         """
-        return await self._data_client.list_length(cache_name, list_name)
+        return self._data_client.list_length(cache_name, list_name)
 
-    async def list_pop_back(self, cache_name: str, list_name: str) -> CacheListPopBackResponse:
+    def list_pop_back(self, cache_name: str, list_name: str) -> CacheListPopBackResponse:
         """Gets, removes, and returns the last value from the list.
 
         Args:
@@ -580,9 +577,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListPopBackResponse:
         """
-        return await self._data_client.list_pop_back(cache_name, list_name)
+        return self._data_client.list_pop_back(cache_name, list_name)
 
-    async def list_pop_front(self, cache_name: str, list_name: str) -> CacheListPopFrontResponse:
+    def list_pop_front(self, cache_name: str, list_name: str) -> CacheListPopFrontResponse:
         """Gets, removes, and returns the first value from the list.
 
         Args:
@@ -592,9 +589,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListPopFrontResponse:
         """
-        return await self._data_client.list_pop_front(cache_name, list_name)
+        return self._data_client.list_pop_front(cache_name, list_name)
 
-    async def list_push_back(
+    def list_push_back(
         self,
         cache_name: str,
         list_name: str,
@@ -616,9 +613,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListPushBackResponse:
         """
-        return await self._data_client.list_push_back(cache_name, list_name, value, ttl, truncate_front_to_size)
+        return self._data_client.list_push_back(cache_name, list_name, value, ttl, truncate_front_to_size)
 
-    async def list_push_front(
+    def list_push_front(
         self,
         cache_name: str,
         list_name: str,
@@ -640,9 +637,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListPushFrontResponse:
         """
-        return await self._data_client.list_push_front(cache_name, list_name, value, ttl, truncate_back_to_size)
+        return self._data_client.list_push_front(cache_name, list_name, value, ttl, truncate_back_to_size)
 
-    async def list_remove_value(
+    def list_remove_value(
         self,
         cache_name: str,
         list_name: str,
@@ -651,8 +648,8 @@ class SimpleCacheClientAsync:
         """Removes all matching values from the list.
 
         Example:
-            await client.list_concatenate_front(cache_name, list_name, ['up', 'up', 'down', 'down', 'left', 'right'])
-            await client.list_remove_value(cache_name, list_name, 'up')
+            client.list_concatenate_front(cache_name, list_name, ['up', 'up', 'down', 'down', 'left', 'right'])
+            client.list_remove_value(cache_name, list_name, 'up')
             fetch_resp = client.list_fetch(cache_name, list_name)
 
             # ['down', 'down', 'left', 'right']
@@ -666,10 +663,10 @@ class SimpleCacheClientAsync:
         Returns:
             CacheListRemoveValueResponse
         """
-        return await self._data_client.list_remove_value(cache_name, list_name, value)
+        return self._data_client.list_remove_value(cache_name, list_name, value)
 
     # SET COLLECTION METHODS
-    async def set_add_element(
+    def set_add_element(
         self,
         cache_name: str,
         set_name: str,
@@ -688,7 +685,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetAddElementResponse
         """
-        resp = await self.set_add_elements(cache_name, set_name, (element,), ttl=ttl)
+        resp = self.set_add_elements(cache_name, set_name, (element,), ttl=ttl)
 
         if isinstance(resp, CacheSetAddElements.Success):
             return CacheSetAddElement.Success()
@@ -697,7 +694,7 @@ class SimpleCacheClientAsync:
         else:
             raise UnknownException(f"Unknown response type: {type(resp)}")
 
-    async def set_add_elements(
+    def set_add_elements(
         self,
         cache_name: str,
         set_name: str,
@@ -716,9 +713,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetAddElementsResponse
         """
-        return await self._data_client.set_add_elements(cache_name, set_name, elements, ttl)
+        return self._data_client.set_add_elements(cache_name, set_name, elements, ttl)
 
-    async def set_fetch(
+    def set_fetch(
         self,
         cache_name: str,
         set_name: str,
@@ -732,11 +729,9 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetFetchResponse
         """
-        return await self._data_client.set_fetch(cache_name, set_name)
+        return self._data_client.set_fetch(cache_name, set_name)
 
-    async def set_remove_element(
-        self, cache_name: str, set_name: str, element: str | bytes
-    ) -> CacheSetRemoveElementResponse:
+    def set_remove_element(self, cache_name: str, set_name: str, element: str | bytes) -> CacheSetRemoveElementResponse:
         """Remove an element from a set.
 
         Args:
@@ -747,7 +742,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetRemoveElementResponse
         """
-        resp = await self.set_remove_elements(cache_name, set_name, (element,))
+        resp = self.set_remove_elements(cache_name, set_name, (element,))
         if isinstance(resp, CacheSetRemoveElements.Success):
             return CacheSetRemoveElement.Success()
         elif isinstance(resp, CacheSetRemoveElements.Error):
@@ -755,7 +750,7 @@ class SimpleCacheClientAsync:
         else:
             raise UnknownException(f"Unknown response type: {type(resp)}")
 
-    async def set_remove_elements(
+    def set_remove_elements(
         self, cache_name: str, set_name: str, elements: Iterable[str | bytes]
     ) -> CacheSetRemoveElementsResponse:
         """Remove elements from a set.
@@ -768,7 +763,7 @@ class SimpleCacheClientAsync:
         Returns:
             CacheSetRemoveElementsResponse
         """
-        return await self._data_client.set_remove_elements(cache_name, set_name, elements)
+        return self._data_client.set_remove_elements(cache_name, set_name, elements)
 
     @property
     def _data_client(self) -> _ScsDataClient:

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -139,12 +139,12 @@ class CacheClientAsync:
         Example::
 
             from datetime import timedelta
-            from momento import Configurations, CredentialProvider, SimpleCacheClientAsync
+            from momento import Configurations, CredentialProvider, CacheClientAsync
 
             configuration = Configurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
             ttl_seconds = timedelta(seconds=60)
-            client = SimpleCacheClientAsync(configuration, credential_provider, ttl_seconds)
+            client = CacheClientAsync(configuration, credential_provider, ttl_seconds)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())
         self._logger = logs.logger

--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -122,7 +122,7 @@ name_replacements = NameReplacement(
         ("^async_(.*)", "\\1"),
         ("(.*?)_async_(.*)", "\\1_\\2"),
         ("(.*?)_async$", "\\1"),
-        ("^(SimpleCacheClient)Async$", "\\1"),
+        ("^(CacheClient)Async$", "\\1"),
         ("^(TUniqueCacheName)Async$", "\\1"),
         ("__aenter__", "__enter__"),
         ("__aexit__", "__exit__"),
@@ -132,8 +132,8 @@ name_replacements = NameReplacement(
 
 simple_string_replacements = SimpleStringReplacement(
     [
-        ("(SimpleCacheClient)Async", "\\1"),
-        (r"(.*?)Async(\s+Simple\s+Cache\s+Client.*?)", "\\1Synchronous\\2"),
+        ("(CacheClient)Async", "\\1"),
+        (r"(.*?)Async(\s+Cache\s+Client.*?)", "\\1Synchronous\\2"),
         (r"(.*?)\bawait\s+(.*?)", "\\1\\2"),
     ]
 )

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -42,7 +42,7 @@ class _ScsControlClient:
         endpoint = credential_provider.control_endpoint
         self._logger = logs.logger
         self._logger.debug("Simple cache control client instantiated with endpoint: %s", endpoint)
-        self._grpc_manager = _ControlGrpcManager(credential_provider, configuration)
+        self._grpc_manager = _ControlGrpcManager(configuration, credential_provider)
         self._endpoint = endpoint
 
     @property

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -20,7 +20,7 @@ class _ControlGrpcManager:
 
     version = pkg_resources.get_distribution("momento").version
 
-    def __init__(self, credential_provider: CredentialProvider, configuration: Configuration):
+    def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.control_endpoint, credentials=grpc.ssl_channel_credentials()
         )

--- a/src/momento/requests/collection_ttl.py
+++ b/src/momento/requests/collection_ttl.py
@@ -28,7 +28,7 @@ class CollectionTtl:
 
     ttl: Optional[timedelta] = None
     """The duration after which the cached collection should be expired from the cache.
-    If `null`, we use the default TTL that was passed to the `SimpleCacheClient` init method.
+    If `null`, we use the default TTL that was passed to the `CacheClient` init method.
     """
     refresh_ttl: bool = True
     """If `True`, the collection's TTL will be refreshed (to prolong the life of the collection)
@@ -46,7 +46,7 @@ class CollectionTtl:
         """The default way to handle TTLs for collections.
 
         The default TTL `timedelta` that was specified when instantiating the
-        `SimpleCacheClient` will be used, and the TTL for the collection will be
+        `CacheClient` will be used, and the TTL for the collection will be
         refreshed any time the collection is modified.
 
         Returns:

--- a/src/momento/responses/control/signing_key/create.py
+++ b/src/momento/responses/control/signing_key/create.py
@@ -18,7 +18,7 @@ class CreateSigningKeyResponse(ControlResponse):
     - `CreateSigningKey.Success`
     - `CreateSigningKey.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/control/signing_key/list.py
+++ b/src/momento/responses/control/signing_key/list.py
@@ -37,7 +37,7 @@ class ListSigningKeysResponse(ControlResponse):
     - `ListSigningKeys.Success`
     - `ListSigningKeys.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/control/signing_key/revoke.py
+++ b/src/momento/responses/control/signing_key/revoke.py
@@ -15,7 +15,7 @@ class RevokeSigningKeyResponse(ControlResponse):
     - `RevokeSigningKey.Success`
     - `RevokeSigningKey.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/fetch.py
+++ b/src/momento/responses/data/dictionary/fetch.py
@@ -15,7 +15,7 @@ class CacheDictionaryFetchResponse(CacheResponse):
     - `CacheDictionaryFetch.Miss`
     - `CacheDictionaryFetch.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/get_field.py
+++ b/src/momento/responses/data/dictionary/get_field.py
@@ -13,7 +13,7 @@ class CacheDictionaryGetFieldResponse(CacheResponse):
     - `CacheDictionaryGetField.Miss`
     - `CacheDictionaryGetField.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/get_fields.py
+++ b/src/momento/responses/data/dictionary/get_fields.py
@@ -16,7 +16,7 @@ class CacheDictionaryGetFieldsResponse(CacheResponse):
     - `CacheDictionaryGetFields.Miss`
     - `CacheDictionaryGetFields.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/increment.py
+++ b/src/momento/responses/data/dictionary/increment.py
@@ -12,7 +12,7 @@ class CacheDictionaryIncrementResponse(CacheResponse):
     - `CacheDictionaryIncrement.Success`
     - `CacheDictionaryIncrement.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/remove_field.py
+++ b/src/momento/responses/data/dictionary/remove_field.py
@@ -11,7 +11,7 @@ class CacheDictionaryRemoveFieldResponse(CacheResponse):
     - `CacheDictionaryRemoveField.Success`
     - `CacheDictionaryRemoveField.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/remove_fields.py
+++ b/src/momento/responses/data/dictionary/remove_fields.py
@@ -11,7 +11,7 @@ class CacheDictionaryRemoveFieldsResponse(CacheResponse):
     - `CacheDictionaryRemoveFields.Success`
     - `CacheDictionaryRemoveFields.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/set_field.py
+++ b/src/momento/responses/data/dictionary/set_field.py
@@ -11,7 +11,7 @@ class CacheDictionarySetFieldResponse(CacheResponse):
     - `CacheDictionarySetField.Success`
     - `CacheDictionarySetField.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/dictionary/set_fields.py
+++ b/src/momento/responses/data/dictionary/set_fields.py
@@ -11,7 +11,7 @@ class CacheDictionarySetFieldsResponse(CacheResponse):
     - `CacheDictionarySetFields.Success`
     - `CacheDictionarySetFields.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/concatenate_back.py
+++ b/src/momento/responses/data/list/concatenate_back.py
@@ -12,7 +12,7 @@ class CacheListConcatenateBackResponse(CacheResponse):
     - `CacheListConcatenateBack.Success`
     - `CacheListConcatenateBack.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/concatenate_front.py
+++ b/src/momento/responses/data/list/concatenate_front.py
@@ -12,7 +12,7 @@ class CacheListConcatenateFrontResponse(CacheResponse):
     - `CacheListConcatenateFront.Success`
     - `CacheListConcatenateFront.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/fetch.py
+++ b/src/momento/responses/data/list/fetch.py
@@ -15,7 +15,7 @@ class CacheListFetchResponse(CacheResponse):
     - `CacheListFetch.Miss`
     - `CacheListFetch.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/length.py
+++ b/src/momento/responses/data/list/length.py
@@ -13,7 +13,7 @@ class CacheListLengthResponse(CacheResponse):
     - `CacheListLength.Miss`
     - `CacheListLength.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/pop_back.py
+++ b/src/momento/responses/data/list/pop_back.py
@@ -13,7 +13,7 @@ class CacheListPopBackResponse(CacheResponse):
     - `CacheListPopBack.Miss`
     - `CacheListPopBack.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/pop_front.py
+++ b/src/momento/responses/data/list/pop_front.py
@@ -13,7 +13,7 @@ class CacheListPopFrontResponse(CacheResponse):
     - `CacheListPopFront.Miss`
     - `CacheListPopFront.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/push_back.py
+++ b/src/momento/responses/data/list/push_back.py
@@ -12,7 +12,7 @@ class CacheListPushBackResponse(CacheResponse):
     - `CacheListPushBack.Success`
     - `CacheListPushBack.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/push_front.py
+++ b/src/momento/responses/data/list/push_front.py
@@ -12,7 +12,7 @@ class CacheListPushFrontResponse(CacheResponse):
     - `CacheListPushFront.Success`
     - `CacheListPushFront.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/list/remove_value.py
+++ b/src/momento/responses/data/list/remove_value.py
@@ -11,7 +11,7 @@ class CacheListRemoveValueResponse(CacheResponse):
     - `CacheListRemoveValue.Success`
     - `CacheListRemoveValue.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/scalar/delete.py
+++ b/src/momento/responses/data/scalar/delete.py
@@ -11,7 +11,7 @@ class CacheDeleteResponse(CacheResponse):
     - `CacheDelete.Success`
     - `CacheDelete.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/scalar/get.py
+++ b/src/momento/responses/data/scalar/get.py
@@ -13,7 +13,7 @@ class CacheGetResponse(CacheResponse):
     - `CacheGet.Miss`
     - `CacheGet.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/scalar/increment.py
+++ b/src/momento/responses/data/scalar/increment.py
@@ -14,7 +14,7 @@ class CacheIncrementResponse(CacheResponse):
     - `CacheIncrement.Success`
     - `CacheIncrement.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/scalar/set.py
+++ b/src/momento/responses/data/scalar/set.py
@@ -11,7 +11,7 @@ class CacheSetResponse(CacheResponse):
     - `CacheSet.Success`
     - `CacheSet.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/scalar/set_if_not_exists.py
+++ b/src/momento/responses/data/scalar/set_if_not_exists.py
@@ -12,7 +12,7 @@ class CacheSetIfNotExistsResponse(CacheResponse):
     - `CacheSetIfNotExists.NotStored`
     - `CacheSetIfNotExists.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/set/add_element.py
+++ b/src/momento/responses/data/set/add_element.py
@@ -11,7 +11,7 @@ class CacheSetAddElementResponse(CacheResponse):
     - `CacheSetAddElement.Success`
     - `CacheSetAddElement.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/set/add_elements.py
+++ b/src/momento/responses/data/set/add_elements.py
@@ -11,7 +11,7 @@ class CacheSetAddElementsResponse(CacheResponse):
     - `CacheSetAddElements.Success`
     - `CacheSetAddElements.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/set/fetch.py
+++ b/src/momento/responses/data/set/fetch.py
@@ -15,7 +15,7 @@ class CacheSetFetchResponse(CacheResponse):
     - `CacheSetFetch.Miss`
     - `CacheSetFetch.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/set/remove_element.py
+++ b/src/momento/responses/data/set/remove_element.py
@@ -11,7 +11,7 @@ class CacheSetRemoveElementResponse(CacheResponse):
     - `CacheSetRemoveElement.Success`
     - `CacheSetRemoveElement.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/src/momento/responses/data/set/remove_elements.py
+++ b/src/momento/responses/data/set/remove_elements.py
@@ -11,7 +11,7 @@ class CacheSetRemoveElementsResponse(CacheResponse):
     - `CacheSetRemoveElements.Success`
     - `CacheSetRemoveElements.Error`
 
-    See `SimpleCacheClient` for how to work with responses.
+    See `CacheClient` for how to work with responses.
     """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,7 +258,7 @@ async def unique_cache_name_async(
     It does not create the cache for you.
 
     Args:
-        client_async (SimpleCacheClientAsync): The client to use to delete the cache.
+        client_async (CacheClientAsync): The client to use to delete the cache.
 
     Returns:
         str: the unique cache name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,7 @@ from typing import AsyncIterator, Callable, Iterator, List, Optional, Union, cas
 import pytest
 import pytest_asyncio
 
-from momento import (
-    Configurations,
-    CredentialProvider,
-    SimpleCacheClient,
-    SimpleCacheClientAsync,
-)
+from momento import CacheClient, CacheClientAsync, Configurations, CredentialProvider
 from momento.config import Configuration
 from momento.typing import (
     TCacheName,
@@ -207,8 +202,8 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.fixture(scope="session")
-def client() -> Iterator[SimpleCacheClient]:
-    with SimpleCacheClient(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
+def client() -> Iterator[CacheClient]:
+    with CacheClient(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         _client.create_cache(cast(str, TEST_CACHE_NAME))
         try:
@@ -218,8 +213,8 @@ def client() -> Iterator[SimpleCacheClient]:
 
 
 @pytest_asyncio.fixture(scope="session")
-async def client_async() -> AsyncIterator[SimpleCacheClientAsync]:
-    async with SimpleCacheClientAsync(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
+async def client_async() -> AsyncIterator[CacheClientAsync]:
+    async with CacheClientAsync(TEST_CONFIGURATION, TEST_AUTH_PROVIDER, DEFAULT_TTL_SECONDS) as _client:
         # Ensure test cache exists
         # TODO consider deleting cache on when test runner shuts down
         await _client.create_cache(cast(str, TEST_CACHE_NAME))
@@ -229,15 +224,15 @@ async def client_async() -> AsyncIterator[SimpleCacheClientAsync]:
             await _client.delete_cache(cast(str, TEST_CACHE_NAME))
 
 
-TUniqueCacheName = Callable[[SimpleCacheClient], str]
+TUniqueCacheName = Callable[[CacheClient], str]
 
 
 @pytest.fixture
-def unique_cache_name(client: SimpleCacheClient) -> Iterator[Callable[[SimpleCacheClient], str]]:
+def unique_cache_name(client: CacheClient) -> Iterator[Callable[[CacheClient], str]]:
     """Synchronous version of unique_cache_name_async."""
     cache_names = []
 
-    def _unique_cache_name(client: SimpleCacheClient) -> str:
+    def _unique_cache_name(client: CacheClient) -> str:
         cache_name = unique_test_cache_name()
         cache_names.append(cache_name)
         return cache_name
@@ -249,13 +244,13 @@ def unique_cache_name(client: SimpleCacheClient) -> Iterator[Callable[[SimpleCac
             client.delete_cache(cache_name)
 
 
-TUniqueCacheNameAsync = Callable[[SimpleCacheClientAsync], str]
+TUniqueCacheNameAsync = Callable[[CacheClientAsync], str]
 
 
 @pytest_asyncio.fixture
 async def unique_cache_name_async(
-    client_async: SimpleCacheClientAsync,
-) -> AsyncIterator[Callable[[SimpleCacheClientAsync], str]]:
+    client_async: CacheClientAsync,
+) -> AsyncIterator[Callable[[CacheClientAsync], str]]:
     """Returns unique cache name for testing.
 
     Also ensures the cache is deleted after the test, even if the test fails.
@@ -270,7 +265,7 @@ async def unique_cache_name_async(
     """
     cache_names = []
 
-    def _unique_cache_name_async(client: SimpleCacheClientAsync) -> str:
+    def _unique_cache_name_async(client: CacheClientAsync) -> str:
         cache_name = unique_test_cache_name()
         cache_names.append(cache_name)
         return cache_name

--- a/tests/momento/internal/test_codegen.py
+++ b/tests/momento/internal/test_codegen.py
@@ -123,11 +123,11 @@ def test_name_replacement(input_: str, expected: str) -> None:
         (
             """
 class A:
-    \"\"\"Async Simple Cache Client\"\"\"
+    \"\"\"Async Cache Client\"\"\"
 """,
             """
 class A:
-    \"\"\"Synchronous Simple Cache Client\"\"\"
+    \"\"\"Synchronous Cache Client\"\"\"
 """,
         ),
         (

--- a/tests/momento/simple_cache_client/shared_behaviors.py
+++ b/tests/momento/simple_cache_client/shared_behaviors.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -70,7 +70,7 @@ def a_key_validator() -> None:
 
 
 class TConnectionValidator(Protocol):
-    def __call__(self, client: SimpleCacheClient) -> CacheResponse:
+    def __call__(self, client: CacheClient) -> CacheResponse:
         ...
 
 
@@ -81,7 +81,7 @@ def a_connection_validator() -> None:
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
-        with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
+        with CacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
             response = connection_validator(client)
             assert_response_is_error(response, error_code=MomentoErrorCode.AUTHENTICATION_ERROR)
 
@@ -92,6 +92,6 @@ def a_connection_validator() -> None:
         connection_validator: TConnectionValidator,
     ) -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
-        with SimpleCacheClient(configuration, credential_provider, default_ttl_seconds) as client:
+        with CacheClient(configuration, credential_provider, default_ttl_seconds) as client:
             response = connection_validator(client)
             assert_response_is_error(response, error_code=MomentoErrorCode.TIMEOUT_ERROR)

--- a/tests/momento/simple_cache_client/shared_behaviors_async.py
+++ b/tests/momento/simple_cache_client/shared_behaviors_async.py
@@ -5,7 +5,7 @@ from typing import Awaitable
 
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -71,7 +71,7 @@ def a_key_validator() -> None:
 
 
 class TConnectionValidator(Protocol):
-    def __call__(self, client_async: SimpleCacheClientAsync) -> Awaitable[CacheResponse]:
+    def __call__(self, client_async: CacheClientAsync) -> Awaitable[CacheResponse]:
         ...
 
 
@@ -82,9 +82,7 @@ def a_connection_validator() -> None:
         default_ttl_seconds: timedelta,
         connection_validator: TConnectionValidator,
     ) -> None:
-        async with SimpleCacheClientAsync(
-            configuration, bad_token_credential_provider, default_ttl_seconds
-        ) as client_async:
+        async with CacheClientAsync(configuration, bad_token_credential_provider, default_ttl_seconds) as client_async:
             response = await connection_validator(client_async)
             assert_response_is_error(response, error_code=MomentoErrorCode.AUTHENTICATION_ERROR)
 
@@ -95,6 +93,6 @@ def a_connection_validator() -> None:
         connection_validator: TConnectionValidator,
     ) -> None:
         configuration = configuration.with_client_timeout(timedelta(milliseconds=1))
-        async with SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds) as client_async:
+        async with CacheClientAsync(configuration, credential_provider, default_ttl_seconds) as client_async:
             response = await connection_validator(client_async)
             assert_response_is_error(response, error_code=MomentoErrorCode.TIMEOUT_ERROR)

--- a/tests/momento/simple_cache_client/test_control.py
+++ b/tests/momento/simple_cache_client/test_control.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 import momento.errors as errors
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -20,7 +20,7 @@ from tests.utils import uuid_str
 
 
 def test_create_cache_get_set_values_and_delete_cache(
-    client: SimpleCacheClient,
+    client: CacheClient,
     cache_name: str,
     unique_cache_name: TUniqueCacheName,
 ) -> None:
@@ -41,13 +41,13 @@ def test_create_cache_get_set_values_and_delete_cache(
     assert isinstance(get_for_key_in_some_other_cache, CacheGet.Miss)
 
 
-def test_create_cache__already_exists_when_creating_existing_cache(client: SimpleCacheClient, cache_name: str) -> None:
+def test_create_cache__already_exists_when_creating_existing_cache(client: CacheClient, cache_name: str) -> None:
     response = client.create_cache(cache_name)
     assert isinstance(response, CreateCache.CacheAlreadyExists)
 
 
 def test_create_cache_throws_exception_for_empty_cache_name(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     response = client.create_cache("")
     assert isinstance(response, CreateCache.Error)
@@ -55,7 +55,7 @@ def test_create_cache_throws_exception_for_empty_cache_name(
 
 
 def test_create_cache_throws_validation_exception_for_null_cache_name(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     response = client.create_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
@@ -64,7 +64,7 @@ def test_create_cache_throws_validation_exception_for_null_cache_name(
 
 
 def test_create_cache_with_bad_cache_name_throws_exception(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     response = client.create_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
@@ -78,7 +78,7 @@ def test_create_cache_throws_authentication_exception_for_bad_token(
     default_ttl_seconds: timedelta,
     unique_cache_name: TUniqueCacheName,
 ) -> None:
-    with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
+    with CacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
         new_cache_name = unique_cache_name(client)
         response = client.create_cache(new_cache_name)
         assert isinstance(response, CreateCache.Error)
@@ -86,7 +86,7 @@ def test_create_cache_throws_authentication_exception_for_bad_token(
 
 
 # Delete cache
-def test_delete_cache_succeeds(client: SimpleCacheClient, cache_name: str) -> None:
+def test_delete_cache_succeeds(client: CacheClient, cache_name: str) -> None:
     cache_name = uuid_str()
 
     response = client.create_cache(cache_name)
@@ -101,7 +101,7 @@ def test_delete_cache_succeeds(client: SimpleCacheClient, cache_name: str) -> No
 
 
 def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     cache_name = uuid_str()
     response = client.delete_cache(cache_name)
@@ -110,7 +110,7 @@ def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
 
 
 def test_delete_cache_throws_invalid_input_for_null_cache_name(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     response = client.delete_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
@@ -118,14 +118,14 @@ def test_delete_cache_throws_invalid_input_for_null_cache_name(
 
 
 def test_delete_cache_throws_exception_for_empty_cache_name(
-    client: SimpleCacheClient,
+    client: CacheClient,
 ) -> None:
     response = client.delete_cache("")
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-def test_delete_with_bad_cache_name_throws_exception(client: SimpleCacheClient) -> None:
+def test_delete_with_bad_cache_name_throws_exception(client: CacheClient) -> None:
     response = client.delete_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -135,14 +135,14 @@ def test_delete_with_bad_cache_name_throws_exception(client: SimpleCacheClient) 
 def test_delete_cache_throws_authentication_exception_for_bad_token(
     bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
-    with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
+    with CacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
         response = client.delete_cache(uuid_str())
         assert isinstance(response, DeleteCache.Error)
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
 # List caches
-def test_list_caches_succeeds(client: SimpleCacheClient, cache_name: str) -> None:
+def test_list_caches_succeeds(client: CacheClient, cache_name: str) -> None:
     cache_name = uuid_str()
 
     initial_response = client.list_caches()
@@ -168,13 +168,13 @@ def test_list_caches_succeeds(client: SimpleCacheClient, cache_name: str) -> Non
 def test_list_caches_throws_authentication_exception_for_bad_token(
     bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
-    with SimpleCacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
+    with CacheClient(configuration, bad_token_credential_provider, default_ttl_seconds) as client:
         response = client.list_caches()
         assert isinstance(response, ListCaches.Error)
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
-def test_create_list_revoke_signing_keys(client: SimpleCacheClient) -> None:
+def test_create_list_revoke_signing_keys(client: CacheClient) -> None:
     create_response = client.create_signing_key(timedelta(minutes=30))
     assert isinstance(create_response, CreateSigningKey.Success)
 

--- a/tests/momento/simple_cache_client/test_control_async.py
+++ b/tests/momento/simple_cache_client/test_control_async.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 import momento.errors as errors
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -20,7 +20,7 @@ from tests.utils import uuid_str
 
 
 async def test_create_cache_get_set_values_and_delete_cache(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
     cache_name: str,
     unique_cache_name_async: TUniqueCacheNameAsync,
 ) -> None:
@@ -42,14 +42,14 @@ async def test_create_cache_get_set_values_and_delete_cache(
 
 
 async def test_create_cache__already_exists_when_creating_existing_cache(
-    client_async: SimpleCacheClientAsync, cache_name: str
+    client_async: CacheClientAsync, cache_name: str
 ) -> None:
     response = await client_async.create_cache(cache_name)
     assert isinstance(response, CreateCache.CacheAlreadyExists)
 
 
 async def test_create_cache_throws_exception_for_empty_cache_name(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     response = await client_async.create_cache("")
     assert isinstance(response, CreateCache.Error)
@@ -57,7 +57,7 @@ async def test_create_cache_throws_exception_for_empty_cache_name(
 
 
 async def test_create_cache_throws_validation_exception_for_null_cache_name(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     response = await client_async.create_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
@@ -66,7 +66,7 @@ async def test_create_cache_throws_validation_exception_for_null_cache_name(
 
 
 async def test_create_cache_with_bad_cache_name_throws_exception(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     response = await client_async.create_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, CreateCache.Error)
@@ -80,9 +80,7 @@ async def test_create_cache_throws_authentication_exception_for_bad_token(
     default_ttl_seconds: timedelta,
     unique_cache_name_async: TUniqueCacheNameAsync,
 ) -> None:
-    async with SimpleCacheClientAsync(
-        configuration, bad_token_credential_provider, default_ttl_seconds
-    ) as client_async:
+    async with CacheClientAsync(configuration, bad_token_credential_provider, default_ttl_seconds) as client_async:
         new_cache_name = unique_cache_name_async(client_async)
         response = await client_async.create_cache(new_cache_name)
         assert isinstance(response, CreateCache.Error)
@@ -90,7 +88,7 @@ async def test_create_cache_throws_authentication_exception_for_bad_token(
 
 
 # Delete cache
-async def test_delete_cache_succeeds(client_async: SimpleCacheClientAsync, cache_name: str) -> None:
+async def test_delete_cache_succeeds(client_async: CacheClientAsync, cache_name: str) -> None:
     cache_name = uuid_str()
 
     response = await client_async.create_cache(cache_name)
@@ -105,7 +103,7 @@ async def test_delete_cache_succeeds(client_async: SimpleCacheClientAsync, cache
 
 
 async def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     cache_name = uuid_str()
     response = await client_async.delete_cache(cache_name)
@@ -114,7 +112,7 @@ async def test_delete_cache_throws_not_found_when_deleting_unknown_cache(
 
 
 async def test_delete_cache_throws_invalid_input_for_null_cache_name(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     response = await client_async.delete_cache(None)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
@@ -122,14 +120,14 @@ async def test_delete_cache_throws_invalid_input_for_null_cache_name(
 
 
 async def test_delete_cache_throws_exception_for_empty_cache_name(
-    client_async: SimpleCacheClientAsync,
+    client_async: CacheClientAsync,
 ) -> None:
     response = await client_async.delete_cache("")
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-async def test_delete_with_bad_cache_name_throws_exception(client_async: SimpleCacheClientAsync) -> None:
+async def test_delete_with_bad_cache_name_throws_exception(client_async: CacheClientAsync) -> None:
     response = await client_async.delete_cache(1)  # type: ignore[arg-type]
     assert isinstance(response, DeleteCache.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -139,16 +137,14 @@ async def test_delete_with_bad_cache_name_throws_exception(client_async: SimpleC
 async def test_delete_cache_throws_authentication_exception_for_bad_token(
     bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
-    async with SimpleCacheClientAsync(
-        configuration, bad_token_credential_provider, default_ttl_seconds
-    ) as client_async:
+    async with CacheClientAsync(configuration, bad_token_credential_provider, default_ttl_seconds) as client_async:
         response = await client_async.delete_cache(uuid_str())
         assert isinstance(response, DeleteCache.Error)
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
 # List caches
-async def test_list_caches_succeeds(client_async: SimpleCacheClientAsync, cache_name: str) -> None:
+async def test_list_caches_succeeds(client_async: CacheClientAsync, cache_name: str) -> None:
     cache_name = uuid_str()
 
     initial_response = await client_async.list_caches()
@@ -174,15 +170,13 @@ async def test_list_caches_succeeds(client_async: SimpleCacheClientAsync, cache_
 async def test_list_caches_throws_authentication_exception_for_bad_token(
     bad_token_credential_provider: CredentialProvider, configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
-    async with SimpleCacheClientAsync(
-        configuration, bad_token_credential_provider, default_ttl_seconds
-    ) as client_async:
+    async with CacheClientAsync(configuration, bad_token_credential_provider, default_ttl_seconds) as client_async:
         response = await client_async.list_caches()
         assert isinstance(response, ListCaches.Error)
         assert response.error_code == MomentoErrorCode.AUTHENTICATION_ERROR
 
 
-async def test_create_list_revoke_signing_keys(client_async: SimpleCacheClientAsync) -> None:
+async def test_create_list_revoke_signing_keys(client_async: CacheClientAsync) -> None:
     create_response = await client_async.create_signing_key(timedelta(minutes=30))
     assert isinstance(create_response, CreateSigningKey.Success)
 

--- a/tests/momento/simple_cache_client/test_dictionary.py
+++ b/tests/momento/simple_cache_client/test_dictionary.py
@@ -9,7 +9,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -134,7 +134,7 @@ class TDictionaryGetter(Protocol):
 def a_dictionary_getter() -> None:
     def with_bytes_it_succeeds(
         dictionary_getter: TDictionaryGetter,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -154,7 +154,7 @@ def a_dictionary_getter() -> None:
 
     def with_string_it_succeeds(
         dictionary_getter: TDictionaryGetter,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -182,7 +182,7 @@ class TDictionaryRemover(Protocol):
 
 def a_dictionary_remover() -> None:
     def with_string_field_succeeds(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -204,7 +204,7 @@ def a_dictionary_remover() -> None:
 
     def with_bytes_field_succeeds(
         dictionary_remover: TDictionaryRemover,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -227,7 +227,7 @@ def a_dictionary_remover() -> None:
 class TDictionarySetter(Protocol):
     def __call__(
         self,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         field: TDictionaryField,
@@ -247,7 +247,7 @@ def a_dictionary_setter() -> None:
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> None:
-        with SimpleCacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -260,7 +260,7 @@ def a_dictionary_setter() -> None:
             assert isinstance(fetch_response, CacheDictionaryFetch.Miss)
 
     def it_refreshes_the_ttl(
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_setter: TDictionarySetter,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
@@ -287,7 +287,7 @@ def a_dictionary_setter() -> None:
         dictionary_value_str: str,
     ) -> None:
         ttl_seconds = 1
-        with SimpleCacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             dictionary_setter(client, cache_name, dictionary_name, dictionary_field_str, dictionary_value_str, ttl=ttl)
@@ -304,7 +304,7 @@ def a_dictionary_setter() -> None:
 
     def with_bytes_it_succeeds(
         dictionary_setter: TDictionarySetter,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -323,7 +323,7 @@ def a_dictionary_setter() -> None:
 
     def with_strings_it_succeeds(
         dictionary_setter: TDictionarySetter,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -336,7 +336,7 @@ def a_dictionary_setter() -> None:
 
     def with_other_values_type_it_errors(
         dictionary_setter: TDictionarySetter,
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_name: TDictionaryName,
     ) -> None:
         for field, value, bad_type in [
@@ -383,7 +383,7 @@ def a_dictionary_value_validator() -> None:
 def describe_dictionary_get_field() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient, dictionary_name: TDictionaryName, dictionary_field_str: str
+        client: CacheClient, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TCacheNameValidator:
         return partial(client.dictionary_get_field, dictionary_name=dictionary_name, field=dictionary_field_str)
 
@@ -391,14 +391,14 @@ def describe_dictionary_get_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_get_field(cache_name, dictionary_name=dictionary_name, field=dictionary_field_str)
 
         return _connection_validator
 
     @fixture
     def dictionary_field_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldValidator:
@@ -406,18 +406,18 @@ def describe_dictionary_get_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client.dictionary_get_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client: SimpleCacheClient) -> TDictionaryGetter:
+    def dictionary_getter(client: CacheClient) -> TDictionaryGetter:
         return partial(client.dictionary_get_field)
 
     def misses_when_the_dictionary_does_not_exist(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -434,7 +434,7 @@ def describe_dictionary_get_field() -> None:
 def describe_dictionary_get_fields() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
+        client: CacheClient, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TCacheNameValidator:
         return partial(client.dictionary_get_fields, dictionary_name=dictionary_name, fields=dictionary_fields)
 
@@ -442,14 +442,14 @@ def describe_dictionary_get_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_get_fields(cache_name, dictionary_name, dictionary_fields)
 
         return _connection_validator
 
     @fixture
     def dictionary_fields_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldsValidator:
@@ -457,14 +457,14 @@ def describe_dictionary_get_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client.dictionary_get_fields, cache_name=cache_name, fields=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client: SimpleCacheClient) -> TDictionaryGetter:
+    def dictionary_getter(client: CacheClient) -> TDictionaryGetter:
         def _dictionary_getter(
             cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheDictionaryGetFieldResponse:
@@ -479,7 +479,7 @@ def describe_dictionary_get_fields() -> None:
         return _dictionary_getter
 
     def it_misses_when_the_dictionary_does_not_exist(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_fields: TDictionaryFields,
@@ -488,7 +488,7 @@ def describe_dictionary_get_fields() -> None:
         assert isinstance(get_response, CacheDictionaryGetFields.Miss)
 
     def it_decodes_responses_to_dictionaries_correctly(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> None:
@@ -511,7 +511,7 @@ def describe_dictionary_get_fields() -> None:
         assert get_response.value_dictionary_string_string == dictionary_items
 
     def it_excludes_misses_from_dictionary(
-        client: SimpleCacheClient, cache_name: TCacheName, dictionary_name: TDictionaryName
+        client: CacheClient, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
         dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
         set_response = client.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
@@ -536,22 +536,22 @@ def describe_dictionary_get_fields() -> None:
 @behaves_like(a_dictionary_name_validator)
 def describe_dictionary_fetch() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient, dictionary_name: TDictionaryName) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient, dictionary_name: TDictionaryName) -> TCacheNameValidator:
         return partial(client.dictionary_fetch, dictionary_name=dictionary_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, dictionary_name: TDictionaryName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_fetch(cache_name, dictionary_name=dictionary_name)
 
         return _connection_validator
 
     @fixture
-    def dictionary_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TDictionaryNameValidator:
+    def dictionary_name_validator(client: CacheClient, cache_name: TCacheName) -> TDictionaryNameValidator:
         return partial(client.dictionary_fetch, cache_name=cache_name)
 
     def misses_when_the_dictionary_does_not_exist(
-        client: SimpleCacheClient, cache_name: TCacheName, dictionary_name: TDictionaryName
+        client: CacheClient, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
         fetch_response = client.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Miss)
@@ -564,7 +564,7 @@ def describe_dictionary_fetch() -> None:
 def describe_dictionary_increment() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
         increment_amount: int,
@@ -583,7 +583,7 @@ def describe_dictionary_increment() -> None:
         dictionary_field_str: str,
         increment_amount: int,
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_increment(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str, amount=increment_amount
             )
@@ -592,7 +592,7 @@ def describe_dictionary_increment() -> None:
 
     @fixture
     def dictionary_field_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         increment_amount: int,
@@ -606,7 +606,7 @@ def describe_dictionary_increment() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_field_str: str,
         increment_amount: int,
@@ -619,7 +619,7 @@ def describe_dictionary_increment() -> None:
         )
 
     def it_starts_at_zero(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -629,7 +629,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == 0
 
     def it_increments_when_the_field_does_not_exist(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -642,7 +642,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == increment_amount
 
     def it_increments_an_existing_field(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -660,7 +660,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == 2 * increment_amount
 
     def it_errors_on_bad_initial_values(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -684,7 +684,7 @@ def describe_dictionary_increment() -> None:
 def describe_dictionary_remove_field() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient, dictionary_name: TDictionaryName, dictionary_field_str: str
+        client: CacheClient, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TCacheNameValidator:
         return partial(client.dictionary_remove_field, dictionary_name=dictionary_name, field=dictionary_field_str)
 
@@ -692,7 +692,7 @@ def describe_dictionary_remove_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_remove_field(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
             )
@@ -701,7 +701,7 @@ def describe_dictionary_remove_field() -> None:
 
     @fixture
     def dictionary_field_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldValidator:
@@ -709,18 +709,18 @@ def describe_dictionary_remove_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client.dictionary_remove_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_remover(client: SimpleCacheClient) -> TDictionaryRemover:
+    def dictionary_remover(client: CacheClient) -> TDictionaryRemover:
         return partial(client.dictionary_remove_field)
 
     def it_removes_a_field(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -753,7 +753,7 @@ def describe_dictionary_remove_field() -> None:
 def describe_dictionary_remove_fields() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_name: TDictionaryName,
         dictionary_fields: TDictionaryFields,
     ) -> TCacheNameValidator:
@@ -763,7 +763,7 @@ def describe_dictionary_remove_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_remove_fields(
                 cache_name, dictionary_name=dictionary_name, fields=dictionary_fields
             )
@@ -772,7 +772,7 @@ def describe_dictionary_remove_fields() -> None:
 
     @fixture
     def dictionary_fields_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldsValidator:
@@ -780,14 +780,14 @@ def describe_dictionary_remove_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_fields: TDictionaryFields,
     ) -> TDictionaryNameValidator:
         return partial(client.dictionary_remove_fields, cache_name=cache_name, fields=dictionary_fields)
 
     @fixture
-    def dictionary_remover(client: SimpleCacheClient) -> TDictionaryRemover:
+    def dictionary_remover(client: CacheClient) -> TDictionaryRemover:
         def _dictionary_remover(
             cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheResponse:
@@ -798,7 +798,7 @@ def describe_dictionary_remove_fields() -> None:
         return _dictionary_remover
 
     def it_removes_multiple_items(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
@@ -827,7 +827,7 @@ def describe_dictionary_remove_fields() -> None:
 def describe_dictionary_set_field() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
         dictionary_value_str: str,
@@ -843,7 +843,7 @@ def describe_dictionary_set_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str, dictionary_value_str: str
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_set_field(
                 cache_name,
                 dictionary_name=dictionary_name,
@@ -855,7 +855,7 @@ def describe_dictionary_set_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_field_str: str,
         dictionary_value_str: str,
@@ -870,7 +870,7 @@ def describe_dictionary_set_field() -> None:
     @fixture
     def dictionary_setter() -> TDictionarySetter:
         def _dictionary_setter(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
@@ -890,7 +890,7 @@ def describe_dictionary_set_field() -> None:
 
     @fixture
     def dictionary_value_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -911,7 +911,7 @@ def describe_dictionary_set_field() -> None:
 def describe_dictionary_set_fields() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> TCacheNameValidator:
@@ -921,14 +921,14 @@ def describe_dictionary_set_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_items: TDictionaryItems
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.dictionary_set_fields(cache_name, dictionary_name=dictionary_name, items=dictionary_items)
 
         return _connection_validator
 
     @fixture
     def dictionary_items_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryItemsValidator:
@@ -940,7 +940,7 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_items: TDictionaryItems,
     ) -> TDictionaryNameValidator:
@@ -949,7 +949,7 @@ def describe_dictionary_set_fields() -> None:
     @fixture
     def dictionary_setter() -> TDictionarySetter:
         def _dictionary_setter(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
@@ -968,7 +968,7 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def dictionary_value_validator(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         field: TDictionaryField,
@@ -983,7 +983,7 @@ def describe_dictionary_set_fields() -> None:
         return _value_validator
 
     def it_sets_multiple_items(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,

--- a/tests/momento/simple_cache_client/test_dictionary_async.py
+++ b/tests/momento/simple_cache_client/test_dictionary_async.py
@@ -9,7 +9,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -134,7 +134,7 @@ class TDictionaryGetter(Protocol):
 def a_dictionary_getter() -> None:
     async def with_bytes_it_succeeds(
         dictionary_getter: TDictionaryGetter,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -154,7 +154,7 @@ def a_dictionary_getter() -> None:
 
     async def with_string_it_succeeds(
         dictionary_getter: TDictionaryGetter,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -182,7 +182,7 @@ class TDictionaryRemover(Protocol):
 
 def a_dictionary_remover() -> None:
     async def with_string_field_succeeds(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -204,7 +204,7 @@ def a_dictionary_remover() -> None:
 
     async def with_bytes_field_succeeds(
         dictionary_remover: TDictionaryRemover,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -227,7 +227,7 @@ def a_dictionary_remover() -> None:
 class TDictionarySetter(Protocol):
     def __call__(
         self,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         field: TDictionaryField,
@@ -247,7 +247,7 @@ def a_dictionary_setter() -> None:
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> None:
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -260,7 +260,7 @@ def a_dictionary_setter() -> None:
             assert isinstance(fetch_response, CacheDictionaryFetch.Miss)
 
     async def it_refreshes_the_ttl(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_setter: TDictionarySetter,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
@@ -287,7 +287,7 @@ def a_dictionary_setter() -> None:
         dictionary_value_str: str,
     ) -> None:
         ttl_seconds = 1
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             await dictionary_setter(
@@ -306,7 +306,7 @@ def a_dictionary_setter() -> None:
 
     async def with_bytes_it_succeeds(
         dictionary_setter: TDictionarySetter,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_bytes: bytes,
@@ -325,7 +325,7 @@ def a_dictionary_setter() -> None:
 
     async def with_strings_it_succeeds(
         dictionary_setter: TDictionarySetter,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -338,7 +338,7 @@ def a_dictionary_setter() -> None:
 
     async def with_other_values_type_it_errors(
         dictionary_setter: TDictionarySetter,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_name: TDictionaryName,
     ) -> None:
         for field, value, bad_type in [
@@ -385,7 +385,7 @@ def a_dictionary_value_validator() -> None:
 def describe_dictionary_get_field() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, dictionary_name: TDictionaryName, dictionary_field_str: str
+        client_async: CacheClientAsync, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TCacheNameValidator:
         return partial(client_async.dictionary_get_field, dictionary_name=dictionary_name, field=dictionary_field_str)
 
@@ -393,7 +393,7 @@ def describe_dictionary_get_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_get_field(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
             )
@@ -402,7 +402,7 @@ def describe_dictionary_get_field() -> None:
 
     @fixture
     def dictionary_field_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldValidator:
@@ -410,18 +410,18 @@ def describe_dictionary_get_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client_async.dictionary_get_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client_async: SimpleCacheClientAsync) -> TDictionaryGetter:
+    def dictionary_getter(client_async: CacheClientAsync) -> TDictionaryGetter:
         return partial(client_async.dictionary_get_field)
 
     async def misses_when_the_dictionary_does_not_exist(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -438,7 +438,7 @@ def describe_dictionary_get_field() -> None:
 def describe_dictionary_get_fields() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
+        client_async: CacheClientAsync, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TCacheNameValidator:
         return partial(client_async.dictionary_get_fields, dictionary_name=dictionary_name, fields=dictionary_fields)
 
@@ -446,14 +446,14 @@ def describe_dictionary_get_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_get_fields(cache_name, dictionary_name, dictionary_fields)
 
         return _connection_validator
 
     @fixture
     def dictionary_fields_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldsValidator:
@@ -461,14 +461,14 @@ def describe_dictionary_get_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client_async.dictionary_get_fields, cache_name=cache_name, fields=dictionary_field_str)
 
     @fixture
-    def dictionary_getter(client_async: SimpleCacheClientAsync) -> TDictionaryGetter:
+    def dictionary_getter(client_async: CacheClientAsync) -> TDictionaryGetter:
         async def _dictionary_getter(
             cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheDictionaryGetFieldResponse:
@@ -483,7 +483,7 @@ def describe_dictionary_get_fields() -> None:
         return _dictionary_getter
 
     async def it_misses_when_the_dictionary_does_not_exist(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_fields: TDictionaryFields,
@@ -492,7 +492,7 @@ def describe_dictionary_get_fields() -> None:
         assert isinstance(get_response, CacheDictionaryGetFields.Miss)
 
     async def it_decodes_responses_to_dictionaries_correctly(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> None:
@@ -515,7 +515,7 @@ def describe_dictionary_get_fields() -> None:
         assert get_response.value_dictionary_string_string == dictionary_items
 
     async def it_excludes_misses_from_dictionary(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, dictionary_name: TDictionaryName
+        client_async: CacheClientAsync, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
         dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
         set_response = await client_async.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
@@ -540,26 +540,22 @@ def describe_dictionary_get_fields() -> None:
 @behaves_like(a_dictionary_name_validator)
 def describe_dictionary_fetch() -> None:
     @fixture
-    def cache_name_validator(
-        client_async: SimpleCacheClientAsync, dictionary_name: TDictionaryName
-    ) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync, dictionary_name: TDictionaryName) -> TCacheNameValidator:
         return partial(client_async.dictionary_fetch, dictionary_name=dictionary_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, dictionary_name: TDictionaryName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_fetch(cache_name, dictionary_name=dictionary_name)
 
         return _connection_validator
 
     @fixture
-    def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName
-    ) -> TDictionaryNameValidator:
+    def dictionary_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TDictionaryNameValidator:
         return partial(client_async.dictionary_fetch, cache_name=cache_name)
 
     async def misses_when_the_dictionary_does_not_exist(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, dictionary_name: TDictionaryName
+        client_async: CacheClientAsync, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
         fetch_response = await client_async.dictionary_fetch(cache_name, dictionary_name)
         assert isinstance(fetch_response, CacheDictionaryFetch.Miss)
@@ -572,7 +568,7 @@ def describe_dictionary_fetch() -> None:
 def describe_dictionary_increment() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
         increment_amount: int,
@@ -591,7 +587,7 @@ def describe_dictionary_increment() -> None:
         dictionary_field_str: str,
         increment_amount: int,
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_increment(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str, amount=increment_amount
             )
@@ -600,7 +596,7 @@ def describe_dictionary_increment() -> None:
 
     @fixture
     def dictionary_field_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         increment_amount: int,
@@ -614,7 +610,7 @@ def describe_dictionary_increment() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_field_str: str,
         increment_amount: int,
@@ -627,7 +623,7 @@ def describe_dictionary_increment() -> None:
         )
 
     async def it_starts_at_zero(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -639,7 +635,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == 0
 
     async def it_increments_when_the_field_does_not_exist(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -652,7 +648,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == increment_amount
 
     async def it_increments_an_existing_field(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -670,7 +666,7 @@ def describe_dictionary_increment() -> None:
         assert increment_response.value == 2 * increment_amount
 
     async def it_errors_on_bad_initial_values(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -696,7 +692,7 @@ def describe_dictionary_increment() -> None:
 def describe_dictionary_remove_field() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, dictionary_name: TDictionaryName, dictionary_field_str: str
+        client_async: CacheClientAsync, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TCacheNameValidator:
         return partial(
             client_async.dictionary_remove_field, dictionary_name=dictionary_name, field=dictionary_field_str
@@ -706,7 +702,7 @@ def describe_dictionary_remove_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_remove_field(
                 cache_name, dictionary_name=dictionary_name, field=dictionary_field_str
             )
@@ -715,7 +711,7 @@ def describe_dictionary_remove_field() -> None:
 
     @fixture
     def dictionary_field_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldValidator:
@@ -723,18 +719,18 @@ def describe_dictionary_remove_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_field_str: str,
     ) -> TDictionaryNameValidator:
         return partial(client_async.dictionary_remove_field, cache_name=cache_name, field=dictionary_field_str)
 
     @fixture
-    def dictionary_remover(client_async: SimpleCacheClientAsync) -> TDictionaryRemover:
+    def dictionary_remover(client_async: CacheClientAsync) -> TDictionaryRemover:
         return partial(client_async.dictionary_remove_field)
 
     async def it_removes_a_field(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -769,7 +765,7 @@ def describe_dictionary_remove_field() -> None:
 def describe_dictionary_remove_fields() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_name: TDictionaryName,
         dictionary_fields: TDictionaryFields,
     ) -> TCacheNameValidator:
@@ -779,7 +775,7 @@ def describe_dictionary_remove_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_fields: TDictionaryFields
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_remove_fields(
                 cache_name, dictionary_name=dictionary_name, fields=dictionary_fields
             )
@@ -788,7 +784,7 @@ def describe_dictionary_remove_fields() -> None:
 
     @fixture
     def dictionary_fields_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryFieldsValidator:
@@ -796,14 +792,14 @@ def describe_dictionary_remove_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_fields: TDictionaryFields,
     ) -> TDictionaryNameValidator:
         return partial(client_async.dictionary_remove_fields, cache_name=cache_name, fields=dictionary_fields)
 
     @fixture
-    def dictionary_remover(client_async: SimpleCacheClientAsync) -> TDictionaryRemover:
+    def dictionary_remover(client_async: CacheClientAsync) -> TDictionaryRemover:
         async def _dictionary_remover(
             cache_name: TCacheName, dictionary_name: TDictionaryName, field: TDictionaryField
         ) -> CacheResponse:
@@ -814,7 +810,7 @@ def describe_dictionary_remove_fields() -> None:
         return _dictionary_remover
 
     async def it_removes_multiple_items(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
@@ -845,7 +841,7 @@ def describe_dictionary_remove_fields() -> None:
 def describe_dictionary_set_field() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
         dictionary_value_str: str,
@@ -861,7 +857,7 @@ def describe_dictionary_set_field() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_field_str: str, dictionary_value_str: str
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_set_field(
                 cache_name,
                 dictionary_name=dictionary_name,
@@ -873,7 +869,7 @@ def describe_dictionary_set_field() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_field_str: str,
         dictionary_value_str: str,
@@ -888,7 +884,7 @@ def describe_dictionary_set_field() -> None:
     @fixture
     def dictionary_setter() -> TDictionarySetter:
         async def _dictionary_setter(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
@@ -908,7 +904,7 @@ def describe_dictionary_set_field() -> None:
 
     @fixture
     def dictionary_value_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_field_str: str,
@@ -929,7 +925,7 @@ def describe_dictionary_set_field() -> None:
 def describe_dictionary_set_fields() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,
     ) -> TCacheNameValidator:
@@ -939,7 +935,7 @@ def describe_dictionary_set_fields() -> None:
     def connection_validator(
         cache_name: TCacheName, dictionary_name: TDictionaryName, dictionary_items: TDictionaryItems
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.dictionary_set_fields(
                 cache_name, dictionary_name=dictionary_name, items=dictionary_items
             )
@@ -948,7 +944,7 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def dictionary_items_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> TDictionaryItemsValidator:
@@ -960,7 +956,7 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def dictionary_name_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_items: TDictionaryItems,
     ) -> TDictionaryNameValidator:
@@ -969,7 +965,7 @@ def describe_dictionary_set_fields() -> None:
     @fixture
     def dictionary_setter() -> TDictionarySetter:
         async def _dictionary_setter(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             dictionary_name: TDictionaryName,
             field: TDictionaryField,
@@ -988,7 +984,7 @@ def describe_dictionary_set_fields() -> None:
 
     @fixture
     def dictionary_value_validator(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         field: TDictionaryField,
@@ -1003,7 +999,7 @@ def describe_dictionary_set_fields() -> None:
         return _value_validator
 
     async def it_sets_multiple_items(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
         dictionary_items: TDictionaryItems,

--- a/tests/momento/simple_cache_client/test_init.py
+++ b/tests/momento/simple_cache_client/test_init.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import InvalidArgumentException
@@ -13,14 +13,14 @@ def test_init_throws_exception_when_client_uses_negative_default_ttl(
     configuration: Configuration, credential_provider: CredentialProvider
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="TTL must be a positive amount of time."):
-        SimpleCacheClient(configuration, credential_provider, timedelta(seconds=-1))
+        CacheClient(configuration, credential_provider, timedelta(seconds=-1))
 
 
 def test_init_throws_exception_for_non_jwt_token(configuration: Configuration, default_ttl_seconds: timedelta) -> None:
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
         os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
         credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
-        SimpleCacheClient(configuration, credential_provider, default_ttl_seconds)
+        CacheClient(configuration, credential_provider, default_ttl_seconds)
 
 
 def test_init_throws_exception_when_client_uses_integer_request_timeout_ms(
@@ -35,7 +35,7 @@ def test_init_throws_exception_when_client_uses_negative_request_timeout_ms(
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=-1))
-        SimpleCacheClient(configuration, credential_provider, default_ttl_seconds)
+        CacheClient(configuration, credential_provider, default_ttl_seconds)
 
 
 def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
@@ -43,4 +43,4 @@ def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=0))
-        SimpleCacheClient(configuration, credential_provider, default_ttl_seconds)
+        CacheClient(configuration, credential_provider, default_ttl_seconds)

--- a/tests/momento/simple_cache_client/test_init_async.py
+++ b/tests/momento/simple_cache_client/test_init_async.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import InvalidArgumentException
@@ -13,7 +13,7 @@ async def test_init_throws_exception_when_client_uses_negative_default_ttl(
     configuration: Configuration, credential_provider: CredentialProvider
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="TTL must be a positive amount of time."):
-        SimpleCacheClientAsync(configuration, credential_provider, timedelta(seconds=-1))
+        CacheClientAsync(configuration, credential_provider, timedelta(seconds=-1))
 
 
 async def test_init_throws_exception_for_non_jwt_token(
@@ -22,7 +22,7 @@ async def test_init_throws_exception_for_non_jwt_token(
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
         os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
         credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
-        SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds)
+        CacheClientAsync(configuration, credential_provider, default_ttl_seconds)
 
 
 async def test_init_throws_exception_when_client_uses_integer_request_timeout_ms(
@@ -37,7 +37,7 @@ async def test_init_throws_exception_when_client_uses_negative_request_timeout_m
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=-1))
-        SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds)
+        CacheClientAsync(configuration, credential_provider, default_ttl_seconds)
 
 
 async def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
@@ -45,4 +45,4 @@ async def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=0))
-        SimpleCacheClientAsync(configuration, credential_provider, default_ttl_seconds)
+        CacheClientAsync(configuration, credential_provider, default_ttl_seconds)

--- a/tests/momento/simple_cache_client/test_list.py
+++ b/tests/momento/simple_cache_client/test_list.py
@@ -10,7 +10,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -47,7 +47,7 @@ from .shared_behaviors import (
 class TListAdder(Protocol):
     def __call__(
         self,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         value: TListValue,
@@ -66,7 +66,7 @@ def a_list_adder() -> None:
         list_name: TListName,
         values: TListValuesInput,
     ) -> None:
-        with SimpleCacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -79,7 +79,7 @@ def a_list_adder() -> None:
             assert isinstance(fetch_resp, CacheListFetch.Miss)
 
     def it_refreshes_the_ttl(
-        client: SimpleCacheClient, list_adder: TListAdder, cache_name: TCacheName, list_name: TListName
+        client: CacheClient, list_adder: TListAdder, cache_name: TCacheName, list_name: TListName
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
@@ -101,7 +101,7 @@ def a_list_adder() -> None:
         list_name: TListName,
     ) -> None:
         ttl_seconds = 1
-        with SimpleCacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             value = uuid_str()
@@ -142,7 +142,7 @@ def a_list_concatenator() -> None:
 
     def with_bytes_it_succeeds(
         list_concatenator: TListConcatenator,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         values_bytes: list[bytes],
@@ -159,7 +159,7 @@ def a_list_concatenator() -> None:
 
     def with_strings_it_succeeds(
         list_concatenator: TListConcatenator,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         values_str: list[str],
@@ -176,7 +176,7 @@ def a_list_concatenator() -> None:
 
     def with_iterable_values_it_succeeds(
         list_concatenator: TListConcatenator,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
         values_str: list[str],
@@ -194,7 +194,7 @@ def a_list_concatenator() -> None:
 
     def with_other_values_type_it_errors(
         list_concatenator: TListConcatenator,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -252,7 +252,7 @@ def a_list_pusher() -> None:
 
     def with_bytes_it_succeeds(
         list_pusher: TListPusher,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -267,7 +267,7 @@ def a_list_pusher() -> None:
 
     def with_strings_it_succeeds(
         list_pusher: TListPusher,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -282,7 +282,7 @@ def a_list_pusher() -> None:
 
     def with_other_value_type_it_errors(
         list_pusher: TListPusher,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -299,7 +299,7 @@ def a_list_pusher() -> None:
 @behaves_like(a_list_concatenator)
 def describe_list_concatenate_back() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_concatenate_back, list_name=list_name, values=[uuid_str()])
 
@@ -307,7 +307,7 @@ def describe_list_concatenate_back() -> None:
     def connection_validator(
         cache_name: TCacheName, list_name: TListName, values: TListValuesInput
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_concatenate_back(cache_name, list_name, values)
 
         return _connection_validator
@@ -315,7 +315,7 @@ def describe_list_concatenate_back() -> None:
     @fixture
     def list_adder() -> TListAdder:
         def _list_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -328,16 +328,16 @@ def describe_list_concatenate_back() -> None:
 
     @fixture
     def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, values: TListValuesInput
+        client: CacheClient, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
         return partial(client.list_concatenate_back, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(client: SimpleCacheClient) -> TListConcatenator:
+    def list_concatenator(client: CacheClient) -> TListConcatenator:
         return partial(client.list_concatenate_back)
 
     def it_truncates_the_front(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -375,7 +375,7 @@ def describe_list_concatenate_back() -> None:
 @behaves_like(a_list_concatenator)
 def describe_list_concatenate_front() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_concatenate_front, list_name=list_name, values=[uuid_str()])
 
@@ -383,7 +383,7 @@ def describe_list_concatenate_front() -> None:
     def connection_validator(
         cache_name: TCacheName, list_name: TListName, values: TListValuesInput
     ) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             list_name = uuid_str()
             return client.list_concatenate_front(cache_name, list_name, values)
 
@@ -392,7 +392,7 @@ def describe_list_concatenate_front() -> None:
     @fixture
     def list_adder() -> TListAdder:
         def _list_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -405,16 +405,16 @@ def describe_list_concatenate_front() -> None:
 
     @fixture
     def list_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, values: TListValuesInput
+        client: CacheClient, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
         return partial(client.list_concatenate_front, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(client: SimpleCacheClient) -> TListConcatenator:
+    def list_concatenator(client: CacheClient) -> TListConcatenator:
         return partial(client.list_concatenate_front)
 
     def it_truncates_the_back(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -450,24 +450,22 @@ def describe_list_concatenate_front() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_fetch() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_fetch, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         return partial(client.list_fetch, cache_name=cache_name)
 
-    def misses_when_the_list_does_not_exist(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
-    ) -> None:
+    def misses_when_the_list_does_not_exist(client: CacheClient, cache_name: TCacheName, list_name: TListName) -> None:
         resp = client.list_fetch(cache_name, list_name)
         assert isinstance(resp, CacheListFetch.Miss)
 
@@ -477,23 +475,23 @@ def describe_list_fetch() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_length() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_length, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_length(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         return partial(client.list_length, cache_name=cache_name)
 
     def it_returns_the_list_length(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName, values: list[str | bytes]
+        client: CacheClient, cache_name: TCacheName, list_name: TListName, values: list[str | bytes]
     ) -> None:
         client.list_concatenate_back(cache_name, list_name, values)
 
@@ -502,7 +500,7 @@ def describe_list_length() -> None:
         assert resp.length == len(values)
 
     def it_misses_when_the_list_does_not_exist(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
+        client: CacheClient, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = client.list_length(cache_name, list_name)
         assert isinstance(resp, CacheListLength.Miss)
@@ -513,22 +511,22 @@ def describe_list_length() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_pop_back() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_pop_back, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_pop_back(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         return partial(client.list_pop_back, cache_name=cache_name)
 
-    def it_pops_the_back(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> None:
+    def it_pops_the_back(client: CacheClient, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
         client.list_concatenate_front(cache_name, list_name, values)
 
@@ -538,7 +536,7 @@ def describe_list_pop_back() -> None:
         assert resp.value_bytes == b"three"
 
     def it_misses_when_the_list_does_not_exist(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
+        client: CacheClient, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = client.list_pop_back(cache_name, list_name)
         assert isinstance(resp, CacheListPopBack.Miss)
@@ -549,22 +547,22 @@ def describe_list_pop_back() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_pop_front() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_pop_front, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_pop_front(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         return partial(client.list_pop_front, cache_name=cache_name)
 
-    def it_pops_the_front(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> None:
+    def it_pops_the_front(client: CacheClient, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
         client.list_concatenate_front(cache_name, list_name, values)
 
@@ -574,7 +572,7 @@ def describe_list_pop_front() -> None:
         assert resp.value_bytes == b"one"
 
     def it_misses_when_the_list_does_not_exist(
-        client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName
+        client: CacheClient, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = client.list_pop_front(cache_name, list_name)
         assert isinstance(resp, CacheListPopFront.Miss)
@@ -587,13 +585,13 @@ def describe_list_pop_front() -> None:
 @behaves_like(a_list_pusher)
 def describe_list_push_back() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_push_back, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_push_back(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
@@ -601,7 +599,7 @@ def describe_list_push_back() -> None:
     @fixture
     def list_adder() -> TListAdder:
         def _list_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -612,16 +610,16 @@ def describe_list_push_back() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client.list_push_back, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(client: SimpleCacheClient, cache_name: TCacheName, list_name: TListName) -> TListPusher:
+    def list_pusher(client: CacheClient, cache_name: TCacheName, list_name: TListName) -> TListPusher:
         return partial(client.list_push_back)
 
     def it_truncates_the_front(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -650,13 +648,13 @@ def describe_list_push_back() -> None:
 @behaves_like(a_list_pusher)
 def describe_list_push_front() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_push_front, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_push_front(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
@@ -664,7 +662,7 @@ def describe_list_push_front() -> None:
     @fixture
     def list_adder() -> TListAdder:
         def _list_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -676,16 +674,16 @@ def describe_list_push_front() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client.list_push_front, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(client: SimpleCacheClient) -> TListPusher:
+    def list_pusher(client: CacheClient) -> TListPusher:
         return partial(client.list_push_front)
 
     def it_truncates_the_back(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -712,19 +710,19 @@ def describe_list_push_front() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_remove_value() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client.list_remove_value, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             return client.list_remove_value(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client: CacheClient, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client.list_remove_value, cache_name=cache_name, value=value)
 
@@ -743,7 +741,7 @@ def describe_list_remove_value() -> None:
         values: TListValuesInput,
         to_remove: TListValue,
         expected_values: TListValuesInputStr,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:

--- a/tests/momento/simple_cache_client/test_list_async.py
+++ b/tests/momento/simple_cache_client/test_list_async.py
@@ -11,7 +11,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -48,7 +48,7 @@ from .shared_behaviors_async import (
 class TListAdder(Protocol):
     def __call__(
         self,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         value: TListValue,
@@ -67,7 +67,7 @@ def a_list_adder() -> None:
         list_name: TListName,
         values: TListValuesInput,
     ) -> None:
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -80,7 +80,7 @@ def a_list_adder() -> None:
             assert isinstance(fetch_resp, CacheListFetch.Miss)
 
     async def it_refreshes_the_ttl(
-        client_async: SimpleCacheClientAsync, list_adder: TListAdder, cache_name: TCacheName, list_name: TListName
+        client_async: CacheClientAsync, list_adder: TListAdder, cache_name: TCacheName, list_name: TListName
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
@@ -102,7 +102,7 @@ def a_list_adder() -> None:
         list_name: TListName,
     ) -> None:
         ttl_seconds = 1
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             value = uuid_str()
@@ -145,7 +145,7 @@ def a_list_concatenator() -> None:
 
     async def with_bytes_it_succeeds(
         list_concatenator: TListConcatenator,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         values_bytes: list[bytes],
@@ -162,7 +162,7 @@ def a_list_concatenator() -> None:
 
     async def with_strings_it_succeeds(
         list_concatenator: TListConcatenator,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         values_str: list[str],
@@ -179,7 +179,7 @@ def a_list_concatenator() -> None:
 
     async def with_iterable_values_it_succeeds(
         list_concatenator: TListConcatenator,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
         values_str: list[str],
@@ -197,7 +197,7 @@ def a_list_concatenator() -> None:
 
     async def with_other_values_type_it_errors(
         list_concatenator: TListConcatenator,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -255,7 +255,7 @@ def a_list_pusher() -> None:
 
     async def with_bytes_it_succeeds(
         list_pusher: TListPusher,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -270,7 +270,7 @@ def a_list_pusher() -> None:
 
     async def with_strings_it_succeeds(
         list_pusher: TListPusher,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -285,7 +285,7 @@ def a_list_pusher() -> None:
 
     async def with_other_value_type_it_errors(
         list_pusher: TListPusher,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -302,7 +302,7 @@ def a_list_pusher() -> None:
 @behaves_like(a_list_concatenator)
 def describe_list_concatenate_back() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_concatenate_back, list_name=list_name, values=[uuid_str()])
 
@@ -310,7 +310,7 @@ def describe_list_concatenate_back() -> None:
     def connection_validator(
         cache_name: TCacheName, list_name: TListName, values: TListValuesInput
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_concatenate_back(cache_name, list_name, values)
 
         return _connection_validator
@@ -318,7 +318,7 @@ def describe_list_concatenate_back() -> None:
     @fixture
     def list_adder() -> TListAdder:
         async def _list_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -331,16 +331,16 @@ def describe_list_concatenate_back() -> None:
 
     @fixture
     def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, values: TListValuesInput
+        client_async: CacheClientAsync, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
         return partial(client_async.list_concatenate_back, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(client_async: SimpleCacheClientAsync) -> TListConcatenator:
+    def list_concatenator(client_async: CacheClientAsync) -> TListConcatenator:
         return partial(client_async.list_concatenate_back)
 
     async def it_truncates_the_front(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -378,7 +378,7 @@ def describe_list_concatenate_back() -> None:
 @behaves_like(a_list_concatenator)
 def describe_list_concatenate_front() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_concatenate_front, list_name=list_name, values=[uuid_str()])
 
@@ -386,7 +386,7 @@ def describe_list_concatenate_front() -> None:
     def connection_validator(
         cache_name: TCacheName, list_name: TListName, values: TListValuesInput
     ) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             list_name = uuid_str()
             return await client_async.list_concatenate_front(cache_name, list_name, values)
 
@@ -395,7 +395,7 @@ def describe_list_concatenate_front() -> None:
     @fixture
     def list_adder() -> TListAdder:
         async def _list_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -408,16 +408,16 @@ def describe_list_concatenate_front() -> None:
 
     @fixture
     def list_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, values: TListValuesInput
+        client_async: CacheClientAsync, cache_name: TCacheName, values: TListValuesInput
     ) -> TListNameValidator:
         return partial(client_async.list_concatenate_front, cache_name=cache_name, values=values)
 
     @fixture
-    def list_concatenator(client_async: SimpleCacheClientAsync) -> TListConcatenator:
+    def list_concatenator(client_async: CacheClientAsync) -> TListConcatenator:
         return partial(client_async.list_concatenate_front)
 
     async def it_truncates_the_back(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -453,23 +453,23 @@ def describe_list_concatenate_front() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_fetch() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_fetch, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_fetch(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         return partial(client_async.list_fetch, cache_name=cache_name)
 
     async def misses_when_the_list_does_not_exist(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
+        client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = await client_async.list_fetch(cache_name, list_name)
         assert isinstance(resp, CacheListFetch.Miss)
@@ -480,23 +480,23 @@ def describe_list_fetch() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_length() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_length, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_length(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         return partial(client_async.list_length, cache_name=cache_name)
 
     async def it_returns_the_list_length(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName, values: list[str | bytes]
+        client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName, values: list[str | bytes]
     ) -> None:
         await client_async.list_concatenate_back(cache_name, list_name, values)
 
@@ -505,7 +505,7 @@ def describe_list_length() -> None:
         assert resp.length == len(values)
 
     async def it_misses_when_the_list_does_not_exist(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
+        client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = await client_async.list_length(cache_name, list_name)
         assert isinstance(resp, CacheListLength.Miss)
@@ -516,24 +516,22 @@ def describe_list_length() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_pop_back() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_pop_back, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_pop_back(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         return partial(client_async.list_pop_back, cache_name=cache_name)
 
-    async def it_pops_the_back(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> None:
+    async def it_pops_the_back(client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
         await client_async.list_concatenate_front(cache_name, list_name, values)
 
@@ -543,7 +541,7 @@ def describe_list_pop_back() -> None:
         assert resp.value_bytes == b"three"
 
     async def it_misses_when_the_list_does_not_exist(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
+        client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = await client_async.list_pop_back(cache_name, list_name)
         assert isinstance(resp, CacheListPopBack.Miss)
@@ -554,24 +552,22 @@ def describe_list_pop_back() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_pop_front() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_pop_front, list_name=list_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_pop_front(cache_name, list_name)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         return partial(client_async.list_pop_front, cache_name=cache_name)
 
-    async def it_pops_the_front(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
-    ) -> None:
+    async def it_pops_the_front(client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName) -> None:
         values = ["one", "two", "three"]
         await client_async.list_concatenate_front(cache_name, list_name, values)
 
@@ -581,7 +577,7 @@ def describe_list_pop_front() -> None:
         assert resp.value_bytes == b"one"
 
     async def it_misses_when_the_list_does_not_exist(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName
+        client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName
     ) -> None:
         resp = await client_async.list_pop_front(cache_name, list_name)
         assert isinstance(resp, CacheListPopFront.Miss)
@@ -594,13 +590,13 @@ def describe_list_pop_front() -> None:
 @behaves_like(a_list_pusher)
 def describe_list_push_back() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_push_back, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_push_back(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
@@ -608,7 +604,7 @@ def describe_list_push_back() -> None:
     @fixture
     def list_adder() -> TListAdder:
         async def _list_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -619,16 +615,16 @@ def describe_list_push_back() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client_async.list_push_back, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(client_async: SimpleCacheClientAsync, cache_name: TCacheName, list_name: TListName) -> TListPusher:
+    def list_pusher(client_async: CacheClientAsync, cache_name: TCacheName, list_name: TListName) -> TListPusher:
         return partial(client_async.list_push_back)
 
     async def it_truncates_the_front(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -657,13 +653,13 @@ def describe_list_push_back() -> None:
 @behaves_like(a_list_pusher)
 def describe_list_push_front() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_push_front, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_push_front(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
@@ -671,7 +667,7 @@ def describe_list_push_front() -> None:
     @fixture
     def list_adder() -> TListAdder:
         async def _list_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             list_name: TListName,
             value: TListValue,
@@ -683,16 +679,16 @@ def describe_list_push_front() -> None:
         return _list_adder
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client_async.list_push_front, cache_name=cache_name, value=value)
 
     @fixture
-    def list_pusher(client_async: SimpleCacheClientAsync) -> TListPusher:
+    def list_pusher(client_async: CacheClientAsync) -> TListPusher:
         return partial(client_async.list_push_front)
 
     async def it_truncates_the_back(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:
@@ -719,19 +715,19 @@ def describe_list_push_front() -> None:
 @behaves_like(a_list_name_validator)
 def describe_list_remove_value() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync) -> TCacheNameValidator:
         list_name = uuid_str()
         return partial(client_async.list_remove_value, list_name=list_name, value=uuid_str())
 
     @fixture
     def connection_validator(cache_name: TCacheName, list_name: TListName, value: TListValue) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             return await client_async.list_remove_value(cache_name=cache_name, list_name=list_name, value=value)
 
         return _connection_validator
 
     @fixture
-    def list_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
+    def list_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TListNameValidator:
         value = uuid_str()
         return partial(client_async.list_remove_value, cache_name=cache_name, value=value)
 
@@ -750,7 +746,7 @@ def describe_list_remove_value() -> None:
         values: TListValuesInput,
         to_remove: TListValue,
         expected_values: TListValuesInputStr,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         list_name: TListName,
     ) -> None:

--- a/tests/momento/simple_cache_client/test_set.py
+++ b/tests/momento/simple_cache_client/test_set.py
@@ -8,7 +8,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClient
+from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -36,7 +36,7 @@ from .shared_behaviors import (
 class TSetAdder(Protocol):
     def __call__(
         self,
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
         element: TSetElement,
@@ -55,7 +55,7 @@ def a_set_adder() -> None:
         set_name: TSetName,
         elements: TSetElementsInput,
     ) -> None:
-        with SimpleCacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -68,7 +68,7 @@ def a_set_adder() -> None:
             assert isinstance(fetch_resp, CacheSetFetch.Miss)
 
     def it_refreshes_the_ttl(
-        client: SimpleCacheClient, set_adder: TSetAdder, cache_name: TCacheName, set_name: TSetName
+        client: CacheClient, set_adder: TSetAdder, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
@@ -90,7 +90,7 @@ def a_set_adder() -> None:
         set_name: TSetName,
     ) -> None:
         ttl_seconds = 1
-        with SimpleCacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        with CacheClient(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             element = uuid_str()
@@ -172,14 +172,12 @@ def a_set_name_validator() -> None:
 @behaves_like(a_set_which_takes_an_element)
 def describe_set_add_element() -> None:
     @fixture
-    def cache_name_validator(
-        client: SimpleCacheClient, set_name: TSetName, element: TSetElement
-    ) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient, set_name: TSetName, element: TSetElement) -> TCacheNameValidator:
         return partial(client.set_add_element, set_name=set_name, element=element)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return client.set_add_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -187,9 +185,9 @@ def describe_set_add_element() -> None:
         return _connection_validator
 
     @fixture
-    def set_adder(client: SimpleCacheClient) -> TSetAdder:
+    def set_adder(client: CacheClient) -> TSetAdder:
         def _set_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             set_name: TSetName,
             element: TSetElement,
@@ -201,13 +199,11 @@ def describe_set_add_element() -> None:
         return _set_adder
 
     @fixture
-    def set_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, element: TSetElement
-    ) -> TSetNameValidator:
+    def set_name_validator(client: CacheClient, cache_name: TCacheName, element: TSetElement) -> TSetNameValidator:
         return partial(client.set_add_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: CacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -215,7 +211,7 @@ def describe_set_add_element() -> None:
 
         return _set_which_takes_an_element
 
-    def it_adds_a_string_element(client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
+    def it_adds_a_string_element(client: CacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
         element1 = uuid_str()
         element2 = uuid_str()
 
@@ -235,7 +231,7 @@ def describe_set_add_element() -> None:
         assert isinstance(fetch_resp, CacheSetFetch.Hit)
         assert fetch_resp.value_set_string == {element1, element2}
 
-    def it_adds_a_byte_element(client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
+    def it_adds_a_byte_element(client: CacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
         element1 = uuid_bytes()
         element2 = uuid_bytes()
 
@@ -264,13 +260,13 @@ def describe_set_add_element() -> None:
 def describe_set_add_elements() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient, set_name: TSetName, elements: TSetElementsInput
+        client: CacheClient, set_name: TSetName, elements: TSetElementsInput
     ) -> TCacheNameValidator:
         return partial(client.set_add_elements, set_name=set_name, elements=elements)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return client.set_add_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -278,9 +274,9 @@ def describe_set_add_elements() -> None:
         return _connection_validator
 
     @fixture
-    def set_adder(client: SimpleCacheClient) -> TSetAdder:
+    def set_adder(client: CacheClient) -> TSetAdder:
         def _set_adder(
-            client: SimpleCacheClient,
+            client: CacheClient,
             cache_name: TCacheName,
             set_name: TSetName,
             element: TSetElement,
@@ -293,12 +289,12 @@ def describe_set_add_elements() -> None:
 
     @fixture
     def set_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, elements: TSetElementsInput
+        client: CacheClient, cache_name: TCacheName, elements: TSetElementsInput
     ) -> TSetNameValidator:
         return partial(client.set_add_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: CacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -307,7 +303,7 @@ def describe_set_add_elements() -> None:
         return _set_which_takes_an_element
 
     def it_adds_string_elements(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_str: set[str],
@@ -328,7 +324,7 @@ def describe_set_add_elements() -> None:
         assert fetch_resp.value_set_string == elements_str
 
     def it_adds_byte_elements(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_bytes: set[bytes],
@@ -355,22 +351,22 @@ def describe_set_add_elements() -> None:
 @behaves_like(a_set_name_validator)
 def describe_set_fetch() -> None:
     @fixture
-    def cache_name_validator(client: SimpleCacheClient, set_name: TSetName) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient, set_name: TSetName) -> TCacheNameValidator:
         return partial(client.set_fetch, set_name=set_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             set_name = uuid_str()
             return client.set_fetch(cache_name=cache_name, set_name=set_name)
 
         return _connection_validator
 
     @fixture
-    def set_name_validator(client: SimpleCacheClient, cache_name: TCacheName) -> TSetNameValidator:
+    def set_name_validator(client: CacheClient, cache_name: TCacheName) -> TSetNameValidator:
         return partial(client.set_fetch, cache_name=cache_name)
 
-    def when_the_set_exists_it_fetches(client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
+    def when_the_set_exists_it_fetches(client: CacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
         elements = {"one", "two"}
         client.set_add_elements(cache_name, set_name, elements)
 
@@ -379,9 +375,7 @@ def describe_set_fetch() -> None:
         assert resp.value_set_string == elements
         assert resp.value_set_bytes == {b"one", b"two"}
 
-    def when_the_set_does_not_exist_it_misses(
-        client: SimpleCacheClient, cache_name: TCacheName, set_name: TSetName
-    ) -> None:
+    def when_the_set_does_not_exist_it_misses(client: CacheClient, cache_name: TCacheName, set_name: TSetName) -> None:
         resp = client.set_fetch(cache_name, set_name)
         assert isinstance(resp, CacheSetFetch.Miss)
 
@@ -392,14 +386,12 @@ def describe_set_fetch() -> None:
 @behaves_like(a_set_which_takes_an_element)
 def describe_set_remove_element() -> None:
     @fixture
-    def cache_name_validator(
-        client: SimpleCacheClient, set_name: TSetName, element: TSetElement
-    ) -> TCacheNameValidator:
+    def cache_name_validator(client: CacheClient, set_name: TSetName, element: TSetElement) -> TCacheNameValidator:
         return partial(client.set_remove_element, set_name=set_name, element=element)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return client.set_remove_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -407,13 +399,11 @@ def describe_set_remove_element() -> None:
         return _connection_validator
 
     @fixture
-    def set_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, element: TSetElement
-    ) -> TSetNameValidator:
+    def set_name_validator(client: CacheClient, cache_name: TCacheName, element: TSetElement) -> TSetNameValidator:
         return partial(client.set_remove_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: CacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -422,7 +412,7 @@ def describe_set_remove_element() -> None:
         return _set_which_takes_an_element
 
     def it_removes_a_string_element(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
@@ -447,7 +437,7 @@ def describe_set_remove_element() -> None:
         assert fetch_resp.value_set_string == new_elements
 
     def it_removes_a_byte_element(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
@@ -479,13 +469,13 @@ def describe_set_remove_element() -> None:
 def describe_set_remove_elements() -> None:
     @fixture
     def cache_name_validator(
-        client: SimpleCacheClient, set_name: TSetName, elements: TSetElementsInput
+        client: CacheClient, set_name: TSetName, elements: TSetElementsInput
     ) -> TCacheNameValidator:
         return partial(client.set_remove_elements, set_name=set_name, elements=elements)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        def _connection_validator(client: SimpleCacheClient) -> CacheResponse:
+        def _connection_validator(client: CacheClient) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return client.set_remove_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -494,12 +484,12 @@ def describe_set_remove_elements() -> None:
 
     @fixture
     def set_name_validator(
-        client: SimpleCacheClient, cache_name: TCacheName, elements: TSetElementsInput
+        client: CacheClient, cache_name: TCacheName, elements: TSetElementsInput
     ) -> TSetNameValidator:
         return partial(client.set_remove_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element(client: SimpleCacheClient) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client: CacheClient) -> TSetWhichTakesAnElement:
         def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -508,7 +498,7 @@ def describe_set_remove_elements() -> None:
         return _set_which_takes_an_element
 
     def it_removes_string_elements(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_str: set[str],
@@ -531,7 +521,7 @@ def describe_set_remove_elements() -> None:
         assert fetch_resp.value_set_string == new_elements
 
     def it_removes_bytes_elements(
-        client: SimpleCacheClient,
+        client: CacheClient,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_bytes: set[bytes],

--- a/tests/momento/simple_cache_client/test_set_async.py
+++ b/tests/momento/simple_cache_client/test_set_async.py
@@ -9,7 +9,7 @@ from pytest import fixture
 from pytest_describe import behaves_like
 from typing_extensions import Protocol
 
-from momento import SimpleCacheClientAsync
+from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -37,7 +37,7 @@ from .shared_behaviors_async import (
 class TSetAdder(Protocol):
     def __call__(
         self,
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
         element: TSetElement,
@@ -56,7 +56,7 @@ def a_set_adder() -> None:
         set_name: TSetName,
         elements: TSetElementsInput,
     ) -> None:
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(hours=1)) as client:
             ttl_seconds = 0.5
             ttl = CollectionTtl(ttl=timedelta(seconds=ttl_seconds), refresh_ttl=False)
 
@@ -69,7 +69,7 @@ def a_set_adder() -> None:
             assert isinstance(fetch_resp, CacheSetFetch.Miss)
 
     async def it_refreshes_the_ttl(
-        client_async: SimpleCacheClientAsync, set_adder: TSetAdder, cache_name: TCacheName, set_name: TSetName
+        client_async: CacheClientAsync, set_adder: TSetAdder, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
@@ -91,7 +91,7 @@ def a_set_adder() -> None:
         set_name: TSetName,
     ) -> None:
         ttl_seconds = 1
-        async with SimpleCacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
+        async with CacheClientAsync(configuration, credential_provider, timedelta(seconds=ttl_seconds)) as client:
             ttl = CollectionTtl.from_cache_ttl().with_no_refresh_ttl_on_updates()
 
             element = uuid_str()
@@ -174,13 +174,13 @@ def a_set_name_validator() -> None:
 def describe_set_add_element() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, set_name: TSetName, element: TSetElement
+        client_async: CacheClientAsync, set_name: TSetName, element: TSetElement
     ) -> TCacheNameValidator:
         return partial(client_async.set_add_element, set_name=set_name, element=element)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return await client_async.set_add_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -188,9 +188,9 @@ def describe_set_add_element() -> None:
         return _connection_validator
 
     @fixture
-    def set_adder(client_async: SimpleCacheClientAsync) -> TSetAdder:
+    def set_adder(client_async: CacheClientAsync) -> TSetAdder:
         async def _set_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             set_name: TSetName,
             element: TSetElement,
@@ -203,12 +203,12 @@ def describe_set_add_element() -> None:
 
     @fixture
     def set_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, element: TSetElement
+        client_async: CacheClientAsync, cache_name: TCacheName, element: TSetElement
     ) -> TSetNameValidator:
         return partial(client_async.set_add_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element(client_async: SimpleCacheClientAsync) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client_async: CacheClientAsync) -> TSetWhichTakesAnElement:
         async def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -217,7 +217,7 @@ def describe_set_add_element() -> None:
         return _set_which_takes_an_element
 
     async def it_adds_a_string_element(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, set_name: TSetName
+        client_async: CacheClientAsync, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         element1 = uuid_str()
         element2 = uuid_str()
@@ -239,7 +239,7 @@ def describe_set_add_element() -> None:
         assert fetch_resp.value_set_string == {element1, element2}
 
     async def it_adds_a_byte_element(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, set_name: TSetName
+        client_async: CacheClientAsync, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         element1 = uuid_bytes()
         element2 = uuid_bytes()
@@ -269,13 +269,13 @@ def describe_set_add_element() -> None:
 def describe_set_add_elements() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, set_name: TSetName, elements: TSetElementsInput
+        client_async: CacheClientAsync, set_name: TSetName, elements: TSetElementsInput
     ) -> TCacheNameValidator:
         return partial(client_async.set_add_elements, set_name=set_name, elements=elements)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return await client_async.set_add_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -283,9 +283,9 @@ def describe_set_add_elements() -> None:
         return _connection_validator
 
     @fixture
-    def set_adder(client_async: SimpleCacheClientAsync) -> TSetAdder:
+    def set_adder(client_async: CacheClientAsync) -> TSetAdder:
         async def _set_adder(
-            client_async: SimpleCacheClientAsync,
+            client_async: CacheClientAsync,
             cache_name: TCacheName,
             set_name: TSetName,
             element: TSetElement,
@@ -298,12 +298,12 @@ def describe_set_add_elements() -> None:
 
     @fixture
     def set_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, elements: TSetElementsInput
+        client_async: CacheClientAsync, cache_name: TCacheName, elements: TSetElementsInput
     ) -> TSetNameValidator:
         return partial(client_async.set_add_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element(client_async: SimpleCacheClientAsync) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client_async: CacheClientAsync) -> TSetWhichTakesAnElement:
         async def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -312,7 +312,7 @@ def describe_set_add_elements() -> None:
         return _set_which_takes_an_element
 
     async def it_adds_string_elements(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_str: set[str],
@@ -333,7 +333,7 @@ def describe_set_add_elements() -> None:
         assert fetch_resp.value_set_string == elements_str
 
     async def it_adds_byte_elements(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_bytes: set[bytes],
@@ -360,23 +360,23 @@ def describe_set_add_elements() -> None:
 @behaves_like(a_set_name_validator)
 def describe_set_fetch() -> None:
     @fixture
-    def cache_name_validator(client_async: SimpleCacheClientAsync, set_name: TSetName) -> TCacheNameValidator:
+    def cache_name_validator(client_async: CacheClientAsync, set_name: TSetName) -> TCacheNameValidator:
         return partial(client_async.set_fetch, set_name=set_name)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             set_name = uuid_str()
             return await client_async.set_fetch(cache_name=cache_name, set_name=set_name)
 
         return _connection_validator
 
     @fixture
-    def set_name_validator(client_async: SimpleCacheClientAsync, cache_name: TCacheName) -> TSetNameValidator:
+    def set_name_validator(client_async: CacheClientAsync, cache_name: TCacheName) -> TSetNameValidator:
         return partial(client_async.set_fetch, cache_name=cache_name)
 
     async def when_the_set_exists_it_fetches(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, set_name: TSetName
+        client_async: CacheClientAsync, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         elements = {"one", "two"}
         await client_async.set_add_elements(cache_name, set_name, elements)
@@ -387,7 +387,7 @@ def describe_set_fetch() -> None:
         assert resp.value_set_bytes == {b"one", b"two"}
 
     async def when_the_set_does_not_exist_it_misses(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, set_name: TSetName
+        client_async: CacheClientAsync, cache_name: TCacheName, set_name: TSetName
     ) -> None:
         resp = await client_async.set_fetch(cache_name, set_name)
         assert isinstance(resp, CacheSetFetch.Miss)
@@ -400,13 +400,13 @@ def describe_set_fetch() -> None:
 def describe_set_remove_element() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, set_name: TSetName, element: TSetElement
+        client_async: CacheClientAsync, set_name: TSetName, element: TSetElement
     ) -> TCacheNameValidator:
         return partial(client_async.set_remove_element, set_name=set_name, element=element)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             set_name = uuid_str()
             element = uuid_str()
             return await client_async.set_remove_element(cache_name=cache_name, set_name=set_name, element=element)
@@ -415,12 +415,12 @@ def describe_set_remove_element() -> None:
 
     @fixture
     def set_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, element: TSetElement
+        client_async: CacheClientAsync, cache_name: TCacheName, element: TSetElement
     ) -> TSetNameValidator:
         return partial(client_async.set_remove_element, cache_name=cache_name, element=element)
 
     @fixture
-    def set_which_takes_an_element(client_async: SimpleCacheClientAsync) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client_async: CacheClientAsync) -> TSetWhichTakesAnElement:
         async def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -429,7 +429,7 @@ def describe_set_remove_element() -> None:
         return _set_which_takes_an_element
 
     async def it_removes_a_string_element(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
@@ -454,7 +454,7 @@ def describe_set_remove_element() -> None:
         assert fetch_resp.value_set_string == new_elements
 
     async def it_removes_a_byte_element(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
     ) -> None:
@@ -486,13 +486,13 @@ def describe_set_remove_element() -> None:
 def describe_set_remove_elements() -> None:
     @fixture
     def cache_name_validator(
-        client_async: SimpleCacheClientAsync, set_name: TSetName, elements: TSetElementsInput
+        client_async: CacheClientAsync, set_name: TSetName, elements: TSetElementsInput
     ) -> TCacheNameValidator:
         return partial(client_async.set_remove_elements, set_name=set_name, elements=elements)
 
     @fixture
     def connection_validator(cache_name: TCacheName) -> TConnectionValidator:
-        async def _connection_validator(client_async: SimpleCacheClientAsync) -> CacheResponse:
+        async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
             set_name = uuid_str()
             elements = {uuid_str()}
             return await client_async.set_remove_elements(cache_name=cache_name, set_name=set_name, elements=elements)
@@ -501,12 +501,12 @@ def describe_set_remove_elements() -> None:
 
     @fixture
     def set_name_validator(
-        client_async: SimpleCacheClientAsync, cache_name: TCacheName, elements: TSetElementsInput
+        client_async: CacheClientAsync, cache_name: TCacheName, elements: TSetElementsInput
     ) -> TSetNameValidator:
         return partial(client_async.set_remove_elements, cache_name=cache_name, elements=elements)
 
     @fixture
-    def set_which_takes_an_element(client_async: SimpleCacheClientAsync) -> TSetWhichTakesAnElement:
+    def set_which_takes_an_element(client_async: CacheClientAsync) -> TSetWhichTakesAnElement:
         async def _set_which_takes_an_element(
             cache_name: TCacheName, set_name: TSetName, element: TSetElement
         ) -> CacheResponse:
@@ -515,7 +515,7 @@ def describe_set_remove_elements() -> None:
         return _set_which_takes_an_element
 
     async def it_removes_string_elements(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_str: set[str],
@@ -538,7 +538,7 @@ def describe_set_remove_elements() -> None:
         assert fetch_resp.value_set_string == new_elements
 
     async def it_removes_bytes_elements(
-        client_async: SimpleCacheClientAsync,
+        client_async: CacheClientAsync,
         cache_name: TCacheName,
         set_name: TSetName,
         elements_bytes: set[bytes],


### PR DESCRIPTION
- feat: rename `SimpleCacheClient` to `CacheClient`
- docs: update documentation to use `CacheClient`

We will update the examples post release. The issue tracking this is [here](https://github.com/momentohq/client-sdk-python/issues/294).

Closes #300 