### PR TITLE
chore: upgrade project stability to stable

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ matrix.python-version }} == '3.10'
         with:
           project_status: official
-          project_stability: beta
+          project_stability: stable
           project_type: sdk
           sdk_language: Python
           usage_example_path: ./examples/${{ matrix.package }}/quickstart.py

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -18,7 +18,7 @@ jobs:
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
         with:
           project_status: official
-          project_stability: beta
+          project_stability: stable
           project_type: sdk
           sdk_language: Python
           usage_example_path: ./examples/py310/quickstart.py


### PR DESCRIPTION
With the 1.0 SDK release, the project is now `stable`.
