### PR TITLE
fix: remove manual release footgun

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -3,8 +3,6 @@ name: On push to release branch
 on:
   push:
     branches: [release]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
The `on-push-to-release-branch` workflow should not be able to be run manually. It should only be run when a commit gets pushed to release