### PR TITLE
feat: relax grpcio dependency lower bound

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -778,4 +778,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "99348037382f981beb3d7feb475041de38e92d39a98dab770da21b3c1ac735f9"
+content-hash = "9098962f4c227f99f4dd035fcaa9f67dca627e7e08ac62a558f6ef9fe228da38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["src/momento/internal/codegen.py"]
 python = "^3.7"
 
 momento-wire-types = "^0.60"
-grpcio = "^1.50.0"
+grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"
 


### PR DESCRIPTION
This allows installation on systems using `grpcio` versions as low as
1.46.0. Integration tests run locally with this version passed.

[Previously](https://github.com/momentohq/client-sdk-python/pull/140)
we had bumped the `gprcio` dependency after a security vulnerability
was reported for `protobuf-python`. Because that is a transitive
dependency of `momento-wire-types` and not `grpcio`, we did not need
to bump the `grpcio` dependency at that time.
