### PR TITLE
feat: support protobuf<3.20

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
             new-python-protobuf: "false"
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ github.sha }}
+      TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,6 +10,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        new-python-protobuf: [true]
+        include:
+          - python-version: "3.7"
+            new-python-protobuf: false
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ github.sha }}
@@ -36,6 +40,10 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
+
+      - name: Install Old Protobuf
+        if: matrix.new-python-protobuf == 'false'
+        run: poetry add "protobuf<3.20"
 
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator
@@ -126,7 +134,7 @@ jobs:
         continue-on-error: true
         working-directory: ./examples
         run: poetry run isort ${{ matrix.package }} --check --diff
-      
+
       - name: Run samples for python ${{ matrix.python-version }}
         id: validation
         continue-on-error: true

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -42,7 +42,7 @@ jobs:
         run: poetry install
 
       - name: Install Old Protobuf
-        if: matrix.new-python-protobuf == 'false'
+        if: ${{ matrix.new-python-protobuf == 'false' }}
         run: poetry add "protobuf<3.20"
 
       - name: Run mypy

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        new-python-protobuf: [true]
+        new-python-protobuf: ["true"]
         include:
           - python-version: "3.7"
-            new-python-protobuf: false
+            new-python-protobuf: "false"
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
         run: poetry install
 
       - name: Install Old Protobuf
-        if: ${{ matrix.new-python-protobuf == 'false' }}
+        if: matrix.new-python-protobuf == 'false'
         run: poetry add "protobuf<3.20"
 
       - name: Run mypy

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -42,6 +42,7 @@ jobs:
         run: poetry install
 
       - name: Install Old Protobuf
+        # Exercises the wire types generated against the old protobuf library
         if: matrix.new-python-protobuf == 'false'
         run: poetry add "protobuf<3.20"
 

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -60,6 +60,7 @@ jobs:
         run: poetry install
 
       - name: Install Old Protobuf
+        # Exercises the wire types generated against the old protobuf library
         if: matrix.new-python-protobuf == 'false'
         run: poetry add "protobuf<3.20"
 

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -40,7 +40,7 @@ jobs:
             new-python-protobuf: "false"
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ github.sha }}
+      TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -34,6 +34,10 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        new-python-protobuf: ["true"]
+        include:
+          - python-version: "3.7"
+            new-python-protobuf: "false"
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ github.sha }}
@@ -54,6 +58,10 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
+
+      - name: Install Old Protobuf
+        if: matrix.new-python-protobuf == 'false'
+        run: poetry add "protobuf<3.20"
 
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator

--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,17 @@ lint:
 
 .PHONY: do-gen-sync
 do-gen-sync:
-	@poetry run python -m momento.internal.codegen src/momento/internal/aio/_scs_control_client.py src/momento/internal/synchronous/_scs_control_client.py
-	@poetry run python -m momento.internal.codegen src/momento/internal/aio/_scs_data_client.py src/momento/internal/synchronous/_scs_data_client.py
-	@poetry run python -m momento.internal.codegen src/momento/cache_client_async.py src/momento/cache_client.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/shared_behaviors_async.py tests/momento/cache_client/shared_behaviors.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_init_async.py tests/momento/cache_client/test_init.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_control_async.py tests/momento/cache_client/test_control.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_dictionary_async.py tests/momento/cache_client/test_dictionary.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_list_async.py tests/momento/cache_client/test_list.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_scalar_async.py tests/momento/cache_client/test_scalar.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_set_async.py tests/momento/cache_client/test_set.py
-	@poetry run python -m momento.internal.codegen tests/momento/cache_client/test_sorted_set_async.py tests/momento/cache_client/test_sorted_set.py
+	@poetry run python src/momento/internal/codegen.py src/momento/internal/aio/_scs_control_client.py src/momento/internal/synchronous/_scs_control_client.py
+	@poetry run python src/momento/internal/codegen.py src/momento/internal/aio/_scs_data_client.py src/momento/internal/synchronous/_scs_data_client.py
+	@poetry run python src/momento/internal/codegen.py src/momento/cache_client_async.py src/momento/cache_client.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/shared_behaviors_async.py tests/momento/cache_client/shared_behaviors.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_init_async.py tests/momento/cache_client/test_init.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_control_async.py tests/momento/cache_client/test_control.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_dictionary_async.py tests/momento/cache_client/test_dictionary.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_list_async.py tests/momento/cache_client/test_list.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_scalar_async.py tests/momento/cache_client/test_scalar.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_set_async.py tests/momento/cache_client/test_set.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_sorted_set_async.py tests/momento/cache_client/test_sorted_set.py
 
 .PHONY: gen-sync
 ## Generate synchronous code and tests from asynchronous code.

--- a/poetry.lock
+++ b/poetry.lock
@@ -284,14 +284,14 @@ files = [
 
 [[package]]
 name = "momento-wire-types"
-version = "0.63.0"
+version = "0.64.0"
 description = "Momento Client Proto Generated Files"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.63.0-py3-none-any.whl", hash = "sha256:d6c509d9cb606f907e1ec22b21a705d3dcff20a64c3985e1b54bdbb1d89d9f84"},
-    {file = "momento_wire_types-0.63.0.tar.gz", hash = "sha256:f942b1188d7a60a4942aa0c7f4027cff05a175b66b558ac2b4ef79b8b58ae666"},
+    {file = "momento_wire_types-0.64.0-py3-none-any.whl", hash = "sha256:30a5d523cef9209c0863db25e6344044b0c7240fea183a41c1433ca83cefea5b"},
+    {file = "momento_wire_types-0.64.0.tar.gz", hash = "sha256:5d3647210d49d0c3032a74ae5f5cc012a9faf826786272e1436a3d84d70a8bd5"},
 ]
 
 [package.dependencies]
@@ -778,4 +778,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "68ace95fdafc4630f7bf3968a77066a9b2842336c10e3f1d5319d55605c55bbc"
+content-hash = "4dcf47febdf9c60786c653850ab54e7b5003d523118836b425c07a4aa6a090eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.63"
+momento-wire-types = "^0.64"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/internal/aio/_scs_control_client.py
+++ b/src/momento/internal/aio/_scs_control_client.py
@@ -1,16 +1,8 @@
 from datetime import timedelta
 
 import grpc
-from momento_wire_types.controlclient_pb2 import (
-    _CreateCacheRequest,
-    _CreateSigningKeyRequest,
-    _DeleteCacheRequest,
-    _FlushCacheRequest,
-    _ListCachesRequest,
-    _ListSigningKeysRequest,
-    _RevokeSigningKeyRequest,
-)
-from momento_wire_types.controlclient_pb2_grpc import ScsControlStub
+from momento_wire_types import controlclient_pb2 as ctrl_pb
+from momento_wire_types import controlclient_pb2_grpc as ctrl_grpc
 
 from momento import logs
 from momento.auth import CredentialProvider
@@ -56,7 +48,7 @@ class _ScsControlClient:
         try:
             self._logger.info(f"Creating cache with name: {cache_name}")
             _validate_cache_name(cache_name)
-            request = _CreateCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._CreateCacheRequest(cache_name=cache_name)
             await self._build_stub().CreateCache(request, timeout=_DEADLINE_SECONDS)
         except Exception as e:
             self._logger.debug("Failed to create cache: %s with exception: %s", cache_name, e)
@@ -69,7 +61,7 @@ class _ScsControlClient:
         try:
             self._logger.info(f"Deleting cache with name: {cache_name}")
             _validate_cache_name(cache_name)
-            request = _DeleteCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._DeleteCacheRequest(cache_name=cache_name)
             await self._build_stub().DeleteCache(request, timeout=_DEADLINE_SECONDS)
         except Exception as e:
             self._logger.debug("Failed to delete cache: %s with exception: %s", cache_name, e)
@@ -78,7 +70,7 @@ class _ScsControlClient:
 
     async def list_caches(self) -> ListCachesResponse:
         try:
-            list_caches_request = _ListCachesRequest(next_token="")
+            list_caches_request = ctrl_pb._ListCachesRequest(next_token="")
             response = await self._build_stub().ListCaches(list_caches_request, timeout=_DEADLINE_SECONDS)
             return ListCaches.Success.from_grpc_response(response)
         except Exception as e:
@@ -87,7 +79,7 @@ class _ScsControlClient:
     async def flush(self, cache_name: str) -> CacheFlushResponse:
         try:
             _validate_cache_name(cache_name)
-            request = _FlushCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._FlushCacheRequest(cache_name=cache_name)
             await self._build_stub().FlushCache(request, timeout=_DEADLINE_SECONDS)
             return CacheFlush.Success()
         except Exception as e:
@@ -99,7 +91,7 @@ class _ScsControlClient:
             _validate_ttl(ttl)
             ttl_minutes = round(ttl.total_seconds() / 60)
             self._logger.info(f"Creating signing key with ttl (in minutes): {ttl_minutes}")
-            create_signing_key_request = _CreateSigningKeyRequest(ttl_minutes=ttl_minutes)
+            create_signing_key_request = ctrl_pb._CreateSigningKeyRequest(ttl_minutes=ttl_minutes)
             response = await self._build_stub().CreateSigningKey(create_signing_key_request, timeout=_DEADLINE_SECONDS)
             return CreateSigningKey.Success.from_grpc_response(response, endpoint)
         except Exception as e:
@@ -109,7 +101,7 @@ class _ScsControlClient:
     async def revoke_signing_key(self, key_id: str) -> RevokeSigningKeyResponse:
         try:
             self._logger.info(f"Revoking signing key with key_id {key_id}")
-            request = _RevokeSigningKeyRequest(key_id=key_id)
+            request = ctrl_pb._RevokeSigningKeyRequest(key_id=key_id)
             await self._build_stub().RevokeSigningKey(request, timeout=_DEADLINE_SECONDS)
             return RevokeSigningKey.Success()
         except Exception as e:
@@ -119,7 +111,7 @@ class _ScsControlClient:
     async def list_signing_keys(self, endpoint: str) -> ListSigningKeysResponse:
         try:
             self._logger.info("List signing keys")
-            list_signing_keys_request = _ListSigningKeysRequest(next_token="")
+            list_signing_keys_request = ctrl_pb._ListSigningKeysRequest(next_token="")
             response = await self._build_stub().ListSigningKeys(list_signing_keys_request, timeout=_DEADLINE_SECONDS)
             return ListSigningKeys.Success.from_grpc_response(
                 response,
@@ -129,7 +121,7 @@ class _ScsControlClient:
             self._logger.warning(f"Failed to list signing keys with exception: {e}")
             return ListSigningKeys.Error(convert_error(e))
 
-    def _build_stub(self) -> ScsControlStub:
+    def _build_stub(self) -> ctrl_grpc.ScsControlStub:
         return self._grpc_manager.async_stub()
 
     async def close(self) -> None:

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import grpc
-import momento_wire_types.cacheclient_pb2_grpc as cache_client
-import momento_wire_types.controlclient_pb2_grpc as control_client
 import pkg_resources
+from momento_wire_types import cacheclient_pb2_grpc as cache_client
+from momento_wire_types import controlclient_pb2_grpc as control_client
 
 from momento.auth import CredentialProvider
 from momento.config import Configuration

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -1,16 +1,8 @@
 from datetime import timedelta
 
 import grpc
-from momento_wire_types.controlclient_pb2 import (
-    _CreateCacheRequest,
-    _CreateSigningKeyRequest,
-    _DeleteCacheRequest,
-    _FlushCacheRequest,
-    _ListCachesRequest,
-    _ListSigningKeysRequest,
-    _RevokeSigningKeyRequest,
-)
-from momento_wire_types.controlclient_pb2_grpc import ScsControlStub
+from momento_wire_types import controlclient_pb2 as ctrl_pb
+from momento_wire_types import controlclient_pb2_grpc as ctrl_grpc
 
 from momento import logs
 from momento.auth import CredentialProvider
@@ -56,7 +48,7 @@ class _ScsControlClient:
         try:
             self._logger.info(f"Creating cache with name: {cache_name}")
             _validate_cache_name(cache_name)
-            request = _CreateCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._CreateCacheRequest(cache_name=cache_name)
             self._build_stub().CreateCache(request, timeout=_DEADLINE_SECONDS)
         except Exception as e:
             self._logger.debug("Failed to create cache: %s with exception: %s", cache_name, e)
@@ -69,7 +61,7 @@ class _ScsControlClient:
         try:
             self._logger.info(f"Deleting cache with name: {cache_name}")
             _validate_cache_name(cache_name)
-            request = _DeleteCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._DeleteCacheRequest(cache_name=cache_name)
             self._build_stub().DeleteCache(request, timeout=_DEADLINE_SECONDS)
         except Exception as e:
             self._logger.debug("Failed to delete cache: %s with exception: %s", cache_name, e)
@@ -78,7 +70,7 @@ class _ScsControlClient:
 
     def list_caches(self) -> ListCachesResponse:
         try:
-            list_caches_request = _ListCachesRequest(next_token="")
+            list_caches_request = ctrl_pb._ListCachesRequest(next_token="")
             response = self._build_stub().ListCaches(list_caches_request, timeout=_DEADLINE_SECONDS)
             return ListCaches.Success.from_grpc_response(response)
         except Exception as e:
@@ -87,7 +79,7 @@ class _ScsControlClient:
     def flush(self, cache_name: str) -> CacheFlushResponse:
         try:
             _validate_cache_name(cache_name)
-            request = _FlushCacheRequest(cache_name=cache_name)
+            request = ctrl_pb._FlushCacheRequest(cache_name=cache_name)
             self._build_stub().FlushCache(request, timeout=_DEADLINE_SECONDS)
             return CacheFlush.Success()
         except Exception as e:
@@ -99,7 +91,7 @@ class _ScsControlClient:
             _validate_ttl(ttl)
             ttl_minutes = round(ttl.total_seconds() / 60)
             self._logger.info(f"Creating signing key with ttl (in minutes): {ttl_minutes}")
-            create_signing_key_request = _CreateSigningKeyRequest(ttl_minutes=ttl_minutes)
+            create_signing_key_request = ctrl_pb._CreateSigningKeyRequest(ttl_minutes=ttl_minutes)
             response = self._build_stub().CreateSigningKey(create_signing_key_request, timeout=_DEADLINE_SECONDS)
             return CreateSigningKey.Success.from_grpc_response(response, endpoint)
         except Exception as e:
@@ -109,7 +101,7 @@ class _ScsControlClient:
     def revoke_signing_key(self, key_id: str) -> RevokeSigningKeyResponse:
         try:
             self._logger.info(f"Revoking signing key with key_id {key_id}")
-            request = _RevokeSigningKeyRequest(key_id=key_id)
+            request = ctrl_pb._RevokeSigningKeyRequest(key_id=key_id)
             self._build_stub().RevokeSigningKey(request, timeout=_DEADLINE_SECONDS)
             return RevokeSigningKey.Success()
         except Exception as e:
@@ -119,7 +111,7 @@ class _ScsControlClient:
     def list_signing_keys(self, endpoint: str) -> ListSigningKeysResponse:
         try:
             self._logger.info("List signing keys")
-            list_signing_keys_request = _ListSigningKeysRequest(next_token="")
+            list_signing_keys_request = ctrl_pb._ListSigningKeysRequest(next_token="")
             response = self._build_stub().ListSigningKeys(list_signing_keys_request, timeout=_DEADLINE_SECONDS)
             return ListSigningKeys.Success.from_grpc_response(
                 response,
@@ -129,7 +121,7 @@ class _ScsControlClient:
             self._logger.warning(f"Failed to list signing keys with exception: {e}")
             return ListSigningKeys.Error(convert_error(e))
 
-    def _build_stub(self) -> ScsControlStub:
+    def _build_stub(self) -> ctrl_grpc.ScsControlStub:
         return self._grpc_manager.stub()
 
     def close(self) -> None:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -3,42 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Optional
 
-from momento_wire_types.cacheclient_pb2 import (
-    Hit,
-    Miss,
-    _DeleteRequest,
-    _DictionaryDeleteRequest,
-    _DictionaryFetchRequest,
-    _DictionaryFieldValuePair,
-    _DictionaryGetRequest,
-    _DictionaryIncrementRequest,
-    _DictionarySetRequest,
-    _GetRequest,
-    _IncrementRequest,
-    _ListConcatenateBackRequest,
-    _ListConcatenateFrontRequest,
-    _ListFetchRequest,
-    _ListLengthRequest,
-    _ListPopBackRequest,
-    _ListPopFrontRequest,
-    _ListPushBackRequest,
-    _ListPushFrontRequest,
-    _ListRemoveRequest,
-    _SetDifferenceRequest,
-    _SetFetchRequest,
-    _SetIfNotExistsRequest,
-    _SetRequest,
-    _SetUnionRequest,
-    _SortedSetElement,
-    _SortedSetFetchRequest,
-    _SortedSetGetRankRequest,
-    _SortedSetGetScoreRequest,
-    _SortedSetIncrementRequest,
-    _SortedSetPutRequest,
-    _SortedSetRemoveRequest,
-    _Unbounded,
-)
-from momento_wire_types.cacheclient_pb2_grpc import ScsStub
+from momento_wire_types import cacheclient_pb2 as cache_pb
+from momento_wire_types import cacheclient_pb2_grpc as cache_grpc
 
 from momento import logs
 from momento.auth import CredentialProvider
@@ -206,7 +172,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_ttl(ttl)
 
-            request = _IncrementRequest(
+            request = cache_pb._IncrementRequest(
                 cache_key=_as_bytes(key, "Unsupported type for key: "),
                 amount=amount,
                 ttl_milliseconds=self._ttl_or_default_milliseconds(ttl),
@@ -234,7 +200,7 @@ class _ScsDataClient:
             self._log_issuing_request("Set", {"key": str(key)})
             _validate_cache_name(cache_name)
             _validate_ttl(ttl)
-            request = _SetRequest(
+            request = cache_pb._SetRequest(
                 cache_key=_as_bytes(key, "Unsupported type for key: "),
                 cache_body=_as_bytes(value, "Unsupported type for value: "),
                 ttl_milliseconds=self._ttl_or_default_milliseconds(ttl),
@@ -256,7 +222,7 @@ class _ScsDataClient:
 
             _validate_cache_name(cache_name)
             _validate_ttl(ttl)
-            request = _SetIfNotExistsRequest(
+            request = cache_pb._SetIfNotExistsRequest(
                 cache_key=_as_bytes(key, "Unsupported type for key: "),
                 cache_body=_as_bytes(value, "Unsupported type for value: "),
                 ttl_milliseconds=self._ttl_or_default_milliseconds(ttl),
@@ -284,7 +250,7 @@ class _ScsDataClient:
             self._log_issuing_request("Get", {"key": str(key)})
 
             _validate_cache_name(cache_name)
-            request = _GetRequest(cache_key=_as_bytes(key, "Unsupported type for key: "))
+            request = cache_pb._GetRequest(cache_key=_as_bytes(key, "Unsupported type for key: "))
 
             response = self._build_stub().Get(
                 request, metadata=make_metadata(cache_name), timeout=self._default_deadline_seconds
@@ -292,9 +258,9 @@ class _ScsDataClient:
 
             self._log_received_response("Get", {"key": str(key)})
 
-            if response.result == Hit:
+            if response.result == cache_pb.Hit:
                 return CacheGet.Hit(response.cache_body)
-            elif response.result == Miss:
+            elif response.result == cache_pb.Miss:
                 return CacheGet.Miss()
             else:
                 raise UnknownException("Get responded with an unknown result")
@@ -306,7 +272,7 @@ class _ScsDataClient:
         try:
             self._log_issuing_request("Delete", {"key": str(key)})
             _validate_cache_name(cache_name)
-            request = _DeleteRequest(cache_key=_as_bytes(key, "Unsupported type for key: "))
+            request = cache_pb._DeleteRequest(cache_key=_as_bytes(key, "Unsupported type for key: "))
 
             self._build_stub().Delete(
                 request, metadata=make_metadata(cache_name), timeout=self._default_deadline_seconds
@@ -331,7 +297,7 @@ class _ScsDataClient:
             _validate_dictionary_name(dictionary_name)
 
             bytes_fields = list(_gen_dictionary_fields_as_bytes(fields, self.__UNSUPPORTED_DICTIONARY_FIELDS_TYPE_MSG))
-            request = _DictionaryGetRequest(
+            request = cache_pb._DictionaryGetRequest(
                 dictionary_name=_as_bytes(dictionary_name, self.__UNSUPPORTED_DICTIONARY_NAME_TYPE_MSG),
                 fields=bytes_fields,
             )
@@ -347,7 +313,7 @@ class _ScsDataClient:
             if type == "found":
                 get_responses: list[CacheDictionaryGetFieldResponse] = []
                 for field, get_response in zip(bytes_fields, response.found.items):
-                    if get_response.result == Miss:
+                    if get_response.result == cache_pb.Miss:
                         get_responses.append(CacheDictionaryGetField.Miss())
                     else:
                         get_responses.append(CacheDictionaryGetField.Hit(get_response.cache_body, field))
@@ -367,7 +333,7 @@ class _ScsDataClient:
             self._log_issuing_request("DictionaryFetch", {"dictionary_name": dictionary_name})
             _validate_cache_name(cache_name)
             _validate_dictionary_name(dictionary_name)
-            request = _DictionaryFetchRequest(
+            request = cache_pb._DictionaryFetchRequest(
                 dictionary_name=_as_bytes(dictionary_name, self.__UNSUPPORTED_DICTIONARY_NAME_TYPE_MSG)
             )
             response = self._build_stub().DictionaryFetch(
@@ -401,7 +367,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_dictionary_name(dictionary_name)
 
-            request = _DictionaryIncrementRequest(
+            request = cache_pb._DictionaryIncrementRequest(
                 dictionary_name=_as_bytes(dictionary_name, self.__UNSUPPORTED_DICTIONARY_NAME_TYPE_MSG),
                 field=_as_bytes(field, self.__UNSUPPORTED_DICTIONARY_FIELD_TYPE_MSG),
                 amount=amount,
@@ -430,9 +396,9 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_dictionary_name(dictionary_name)
 
-            request = _DictionaryDeleteRequest(
+            request = cache_pb._DictionaryDeleteRequest(
                 dictionary_name=_as_bytes(dictionary_name, self.__UNSUPPORTED_DICTIONARY_NAME_TYPE_MSG),
-                some=_DictionaryDeleteRequest.Some(
+                some=cache_pb._DictionaryDeleteRequest.Some(
                     fields=_gen_dictionary_fields_as_bytes(fields, self.__UNSUPPORTED_DICTIONARY_FIELDS_TYPE_MSG)
                 ),
             )
@@ -460,10 +426,10 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_dictionary_name(dictionary_name)
 
-            request = _DictionarySetRequest(
+            request = cache_pb._DictionarySetRequest(
                 dictionary_name=_as_bytes(dictionary_name, self.__UNSUPPORTED_DICTIONARY_NAME_TYPE_MSG),
                 items=[
-                    _DictionaryFieldValuePair(field=field, value=value)
+                    cache_pb._DictionaryFieldValuePair(field=field, value=value)
                     for field, value in _gen_dictionary_items_as_bytes(
                         items, self.__UNSUPPORTED_DICTIONARY_ITEMS_TYPE_MSG
                     )
@@ -496,7 +462,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
 
-            request = _ListConcatenateBackRequest(
+            request = cache_pb._ListConcatenateBackRequest(
                 list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG),
                 values=_gen_list_as_bytes(values, self.__UNSUPPORTED_LIST_VALUES_TYPE_MSG),
                 truncate_front_to_size=truncate_front_to_size,
@@ -527,7 +493,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
 
-            request = _ListConcatenateFrontRequest(
+            request = cache_pb._ListConcatenateFrontRequest(
                 list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG),
                 values=_gen_list_as_bytes(values, self.__UNSUPPORTED_LIST_VALUES_TYPE_MSG),
                 truncate_back_to_size=truncate_back_to_size,
@@ -550,7 +516,7 @@ class _ScsDataClient:
             self._log_issuing_request("ListFetch", {"list_name": str(list_name)})
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
-            request = _ListFetchRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
+            request = cache_pb._ListFetchRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
             response = self._build_stub().ListFetch(
                 request,
                 metadata=make_metadata(cache_name),
@@ -574,7 +540,7 @@ class _ScsDataClient:
             self._log_issuing_request("ListLength", {"list_name": str(list_name)})
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
-            request = _ListLengthRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
+            request = cache_pb._ListLengthRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
             response = self._build_stub().ListLength(
                 request,
                 metadata=make_metadata(cache_name),
@@ -598,7 +564,9 @@ class _ScsDataClient:
             self._log_issuing_request("ListPopBack", {"list_name": str(list_name)})
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
-            request = _ListPopBackRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
+            request = cache_pb._ListPopBackRequest(
+                list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG)
+            )
             response = self._build_stub().ListPopBack(
                 request,
                 metadata=make_metadata(cache_name),
@@ -622,7 +590,9 @@ class _ScsDataClient:
             self._log_issuing_request("ListPopFront", {"list_name": str(list_name)})
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
-            request = _ListPopFrontRequest(list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG))
+            request = cache_pb._ListPopFrontRequest(
+                list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG)
+            )
             response = self._build_stub().ListPopFront(
                 request,
                 metadata=make_metadata(cache_name),
@@ -654,7 +624,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
 
-            request = _ListPushBackRequest(
+            request = cache_pb._ListPushBackRequest(
                 list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG),
                 value=_as_bytes(value, self.__UNSUPPORTED_LIST_VALUE_TYPE_MSG),
                 truncate_front_to_size=truncate_front_to_size,
@@ -685,7 +655,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
 
-            request = _ListPushFrontRequest(
+            request = cache_pb._ListPushFrontRequest(
                 list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG),
                 value=_as_bytes(value, self.__UNSUPPORTED_LIST_VALUE_TYPE_MSG),
                 truncate_back_to_size=truncate_back_to_size,
@@ -714,7 +684,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_list_name(list_name)
 
-            request = _ListRemoveRequest(
+            request = cache_pb._ListRemoveRequest(
                 list_name=_as_bytes(list_name, self.__UNSUPPORTED_LIST_NAME_TYPE_MSG),
                 all_elements_with_value=_as_bytes(value, self.__UNSUPPORTED_LIST_VALUE_TYPE_MSG),
             )
@@ -743,7 +713,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_set_name(set_name)
 
-            request = _SetUnionRequest(
+            request = cache_pb._SetUnionRequest(
                 set_name=_as_bytes(set_name, self.__UNSUPPORTED_SET_NAME_TYPE_MSG),
                 elements=_gen_set_input_as_bytes(elements, self.__UNSUPPORTED_SET_ELEMENTS_TYPE_MSG),
                 **self._prepare_collection_ttl_for_request(ttl),
@@ -770,7 +740,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_set_name(set_name)
 
-            request = _SetFetchRequest(set_name=_as_bytes(set_name, "Unsupported type for set_name: "))
+            request = cache_pb._SetFetchRequest(set_name=_as_bytes(set_name, "Unsupported type for set_name: "))
             response = self._build_stub().SetFetch(
                 request,
                 metadata=make_metadata(cache_name),
@@ -797,10 +767,10 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_set_name(set_name)
 
-            request = _SetDifferenceRequest(
+            request = cache_pb._SetDifferenceRequest(
                 set_name=_as_bytes(set_name, self.__UNSUPPORTED_SET_NAME_TYPE_MSG),
-                subtrahend=_SetDifferenceRequest._Subtrahend(
-                    set=_SetDifferenceRequest._Subtrahend._Set(
+                subtrahend=cache_pb._SetDifferenceRequest._Subtrahend(
+                    set=cache_pb._SetDifferenceRequest._Subtrahend._Set(
                         elements=_gen_set_input_as_bytes(elements, self.__UNSUPPORTED_SET_ELEMENTS_TYPE_MSG)
                     )
                 ),
@@ -829,7 +799,7 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_sorted_set_name(sorted_set_name)
 
-            request = _SortedSetPutRequest(
+            request = cache_pb._SortedSetPutRequest(
                 set_name=_as_bytes(sorted_set_name, self.__UNSUPPORTED_SORTED_SET_NAME_TYPE_MSG),
                 **self._prepare_collection_ttl_for_request(ttl),
             )
@@ -837,7 +807,7 @@ class _ScsDataClient:
                 elements, self.__UNSUPPORTED_SORTED_SET_ELEMENTS_TYPE_MSG
             ):
                 _validate_sorted_set_score(score)
-                request.elements.append(_SortedSetElement(value=value, score=score))
+                request.elements.append(cache_pb._SortedSetElement(value=value, score=score))
 
             self._build_stub().SortedSetPut(
                 request,
@@ -865,19 +835,19 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_sorted_set_name(sorted_set_name)
 
-            request = _SortedSetFetchRequest(
+            request = cache_pb._SortedSetFetchRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for set_name: "), with_scores=True
             )
 
             if min_score is not None:
-                request.by_score.min_score = _SortedSetFetchRequest._ByScore._Score(score=min_score)
+                request.by_score.min_score = cache_pb._SortedSetFetchRequest._ByScore._Score(score=min_score)
             else:
-                request.by_score.unbounded_min.CopyFrom(_Unbounded())
+                request.by_score.unbounded_min.CopyFrom(cache_pb._Unbounded())
 
             if max_score is not None:
-                request.by_score.max_score = _SortedSetFetchRequest._ByScore._Score(score=max_score)
+                request.by_score.max_score = cache_pb._SortedSetFetchRequest._ByScore._Score(score=max_score)
             else:
-                request.by_score.unbounded_max.CopyFrom(_Unbounded())
+                request.by_score.unbounded_max.CopyFrom(cache_pb._Unbounded())
 
             if offset is not None:
                 request.by_score.offset = offset
@@ -890,9 +860,9 @@ class _ScsDataClient:
                 request.by_score.count = -1
 
             if sort_order == SortOrder.ASCENDING:
-                request.order = _SortedSetFetchRequest.ASCENDING
+                request.order = cache_pb._SortedSetFetchRequest.ASCENDING
             else:
-                request.order = _SortedSetFetchRequest.DESCENDING
+                request.order = cache_pb._SortedSetFetchRequest.DESCENDING
 
             response = self._build_stub().SortedSetFetch(
                 request,
@@ -927,24 +897,24 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_sorted_set_name(sorted_set_name)
 
-            request = _SortedSetFetchRequest(
+            request = cache_pb._SortedSetFetchRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for set_name: "), with_scores=True
             )
 
             if start_rank is not None:
                 request.by_index.inclusive_start_index = start_rank
             else:
-                request.by_index.unbounded_start.CopyFrom(_Unbounded())
+                request.by_index.unbounded_start.CopyFrom(cache_pb._Unbounded())
 
             if end_rank is not None:
                 request.by_index.exclusive_end_index = end_rank
             else:
-                request.by_index.unbounded_end.CopyFrom(_Unbounded())
+                request.by_index.unbounded_end.CopyFrom(cache_pb._Unbounded())
 
             if sort_order == SortOrder.ASCENDING:
-                request.order = _SortedSetFetchRequest.ASCENDING
+                request.order = cache_pb._SortedSetFetchRequest.ASCENDING
             else:
-                request.order = _SortedSetFetchRequest.DESCENDING
+                request.order = cache_pb._SortedSetFetchRequest.DESCENDING
 
             response = self._build_stub().SortedSetFetch(
                 request,
@@ -975,7 +945,7 @@ class _ScsDataClient:
             _validate_sorted_set_name(sorted_set_name)
 
             bytes_values = list(_gen_sorted_set_values_as_bytes(values, self.__UNSUPPORTED_SORTED_SET_VALUES_TYPE_MSG))
-            request = _SortedSetGetScoreRequest(
+            request = cache_pb._SortedSetGetScoreRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for sorted_set_name: "), values=bytes_values
             )
 
@@ -990,7 +960,7 @@ class _ScsDataClient:
             if type == "found":
                 get_responses: list[CacheSortedSetGetScoreResponse] = []
                 for value, get_response in zip(bytes_values, response.found.elements):
-                    if get_response.result == Miss:
+                    if get_response.result == cache_pb.Miss:
                         get_responses.append(CacheSortedSetGetScore.Miss(value))
                     else:
                         get_responses.append(CacheSortedSetGetScore.Hit(value, get_response.score))
@@ -1015,15 +985,15 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_sorted_set_name(sorted_set_name)
 
-            request = _SortedSetGetRankRequest(
+            request = cache_pb._SortedSetGetRankRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for sorted_set_name: "),
                 value=_as_bytes(value, self.__UNSUPPORTED_SORTED_SET_VALUE_TYPE_MSG),
             )
 
             if sort_order == SortOrder.ASCENDING:
-                request.order = _SortedSetGetRankRequest.ASCENDING
+                request.order = cache_pb._SortedSetGetRankRequest.ASCENDING
             else:
-                request.order = _SortedSetGetRankRequest.DESCENDING
+                request.order = cache_pb._SortedSetGetRankRequest.DESCENDING
 
             response = self._build_stub().SortedSetGetRank(
                 request,
@@ -1032,9 +1002,9 @@ class _ScsDataClient:
             )
             self._log_received_response("SortedSetGetRank", {"sorted_set_name": str(request.set_name)})
 
-            if response.element_rank.result == Hit:
+            if response.element_rank.result == cache_pb.Hit:
                 return CacheSortedSetGetRank.Hit(response.element_rank.rank)
-            if response.element_rank.result == Miss:
+            if response.element_rank.result == cache_pb.Miss:
                 return CacheSortedSetGetRank.Miss()
             else:
                 raise UnknownException(f"Unknown field in response: {type}")
@@ -1053,9 +1023,9 @@ class _ScsDataClient:
             _validate_cache_name(cache_name)
             _validate_sorted_set_name(sorted_set_name)
 
-            request = _SortedSetRemoveRequest(
+            request = cache_pb._SortedSetRemoveRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for sorted_set_name: "),
-                some=_SortedSetRemoveRequest._Some(
+                some=cache_pb._SortedSetRemoveRequest._Some(
                     values=_gen_sorted_set_values_as_bytes(values, self.__UNSUPPORTED_SORTED_SET_VALUES_TYPE_MSG)
                 ),
             )
@@ -1086,7 +1056,7 @@ class _ScsDataClient:
             _validate_sorted_set_name(sorted_set_name)
             _validate_sorted_set_score(score)
 
-            request = _SortedSetIncrementRequest(
+            request = cache_pb._SortedSetIncrementRequest(
                 set_name=_as_bytes(sorted_set_name, "Unsupported type for sorted_set_name: "),
                 value=_as_bytes(value),
                 amount=score,
@@ -1138,7 +1108,7 @@ class _ScsDataClient:
 
         return int(which_ttl.total_seconds() * 1000)
 
-    def _build_stub(self) -> ScsStub:
+    def _build_stub(self) -> cache_grpc.ScsStub:
         return self._grpc_manager.stub()
 
     def close(self) -> None:

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import grpc
-import momento_wire_types.cacheclient_pb2_grpc as cache_client
-import momento_wire_types.controlclient_pb2_grpc as control_client
 import pkg_resources
+from momento_wire_types import cacheclient_pb2_grpc as cache_client
+from momento_wire_types import controlclient_pb2_grpc as control_client
 
 from momento.auth import CredentialProvider
 from momento.config import Configuration

--- a/src/momento/responses/control/cache/list.py
+++ b/src/momento/responses/control/cache/list.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import List
 
-from momento_wire_types.controlclient_pb2 import _ListCachesResponse
+from momento_wire_types import controlclient_pb2 as ctrl_pb
 
 from momento.responses.response import ControlResponse
 
@@ -60,7 +60,7 @@ class ListCaches(ABC):
         """The list of caches available to the user."""
 
         @staticmethod
-        def from_grpc_response(grpc_list_cache_response: _ListCachesResponse) -> ListCaches.Success:
+        def from_grpc_response(grpc_list_cache_response: ctrl_pb._ListCachesResponse) -> ListCaches.Success:
             """Initializes ListCacheResponse to handle list cache response.
 
             Args:


### PR DESCRIPTION
The latest `momento-wire-types` can support both `protobuf<3.20` and
later versions. This PR bumps to that version and updates the import
statements as appropriate.