### PR TITLE
fix: prefer `importlib_metadata` to deprecated pkg_resources

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -176,7 +176,7 @@ protobuf = ["grpcio-tools (>=1.54.2)"]
 name = "importlib-metadata"
 version = "4.2.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -763,7 +763,7 @@ typing-extensions = ">=3.7.4"
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -778,4 +778,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "4dcf47febdf9c60786c653850ab54e7b5003d523118836b425c07a4aa6a090eb"
+content-hash = "dfe53817b7e8a8b6938078851f28feedae4daeb5e26ac8a0a539fd25b5c72900"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ momento-wire-types = "^0.64"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"
+# Need a lower bound of 4 to be compatible with python 3.7 flake8
+importlib-metadata = ">=4"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import grpc
-import pkg_resources
+import importlib_metadata
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
 
@@ -16,7 +16,7 @@ from ._retry_interceptor import RetryInterceptor
 class _ControlGrpcManager:
     """Internal gRPC control mananger."""
 
-    version = pkg_resources.get_distribution("momento").version
+    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
@@ -35,7 +35,7 @@ class _ControlGrpcManager:
 class _DataGrpcManager:
     """Internal gRPC data mananger."""
 
-    version = pkg_resources.get_distribution("momento").version
+    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import grpc
-import pkg_resources
+import importlib_metadata
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
 
@@ -18,7 +18,7 @@ from momento.retry import RetryStrategy
 class _ControlGrpcManager:
     """Internal gRPC control mananger."""
 
-    version = pkg_resources.get_distribution("momento").version
+    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
@@ -39,7 +39,7 @@ class _ControlGrpcManager:
 class _DataGrpcManager:
     """Internal gRPC data mananger."""
 
-    version = pkg_resources.get_distribution("momento").version
+    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(


### PR DESCRIPTION
Per the
[docs](https://docs.python.org/3.12/library/importlib.metadata.html):

> importlib.metadata is a library that provides access to the metadata
> of an installed Distribution Package, such as its entry points or its
> top-level names (Import Packages, modules, if any). Built in part on
> Python’s import system, this library intends to replace similar
> functionality in the entry point API and metadata API of
> pkg_resources. Along with importlib.resources, this package can
> eliminate the need to use the older and less efficient pkg_resources
> package.
> 
> importlib.metadata operates on third-party distribution packages
> installed into Python’s site-packages directory via tools such as
> pip. Specifically, it works with distributions with discoverable
> dist-info or egg-info directories, and metadata defined by the Core
> metadata specifications.

Prior to this commit, we were using `pkg_resources` to detect the
installed version of momento to include in the agent header. With this
commit we change to using the preferred `importlib.metadata`. Since
That library is standard only in python >= 3.8, we fall back to using
the backported library `importlib_metadata`.
