### PR TITLE
chore: restrict importlib_metadata package to python < 3.8

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -778,4 +778,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "dfe53817b7e8a8b6938078851f28feedae4daeb5e26ac8a0a539fd25b5c72900"
+content-hash = "2ad82f57de28ac79bf502ae000e2a08dad1082d30de8f4443b4924666c6176f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"
 # Need a lower bound of 4 to be compatible with python 3.7 flake8
-importlib-metadata = ">=4"
+importlib-metadata = { version=">=4", python="<3.8" }
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"

--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -12,3 +12,4 @@ from ._data_validation import (
     _validate_timedelta_ttl,
     _validate_ttl,
 )
+from ._momento_version import momento_version

--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -1,0 +1,14 @@
+momento_version = ""
+
+try:
+    # For python < 3.8
+    import importlib_metadata
+
+    momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
+except ImportError:
+    # For python >= 3.8
+    from importlib.metdata import version  # type: ignore[import]
+
+    momento_version = version("momento")
+
+assert momento_version != ""

--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -7,7 +7,7 @@ try:
     momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
 except ImportError:
     # For python >= 3.8
-    from importlib.metdata import version  # type: ignore[import]
+    from importlib.metadata import version  # type: ignore[import]
 
     momento_version = version("momento")
 

--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -1,3 +1,9 @@
+"""Detect the version of momento installed.
+
+This module is used to detect the version of momento installed. It is used
+internally to add the version to the gRPC headers.
+"""
+
 momento_version = ""
 
 try:

--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -10,5 +10,3 @@ except ImportError:
     from importlib.metadata import version  # type: ignore[import]
 
     momento_version = version("momento")
-
-assert momento_version != ""

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import grpc
-import importlib_metadata
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
 
 from momento.auth import CredentialProvider
 from momento.config import Configuration
+from momento.internal._utilities import momento_version
 from momento.retry import RetryStrategy
 
 from ._add_header_client_interceptor import AddHeaderClientInterceptor, Header
@@ -16,7 +16,7 @@ from ._retry_interceptor import RetryInterceptor
 class _ControlGrpcManager:
     """Internal gRPC control mananger."""
 
-    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
+    version = momento_version
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
@@ -35,7 +35,7 @@ class _ControlGrpcManager:
 class _DataGrpcManager:
     """Internal gRPC data mananger."""
 
-    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
+    version = momento_version
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import grpc
-import importlib_metadata
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
 
 from momento.auth import CredentialProvider
 from momento.config import Configuration
+from momento.internal._utilities import momento_version
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     Header,
@@ -18,7 +18,7 @@ from momento.retry import RetryStrategy
 class _ControlGrpcManager:
     """Internal gRPC control mananger."""
 
-    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
+    version = momento_version
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
@@ -39,7 +39,7 @@ class _ControlGrpcManager:
 class _DataGrpcManager:
     """Internal gRPC data mananger."""
 
-    version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call]
+    version = momento_version
 
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(

--- a/tests/momento/internal/_utilities/test_momento_version.py
+++ b/tests/momento/internal/_utilities/test_momento_version.py
@@ -1,0 +1,5 @@
+from momento.internal._utilities import momento_version
+
+
+def test_momento_version() -> None:
+    assert momento_version != ""


### PR DESCRIPTION
Python 3.8 introduced a standard library `importlib.metadata` to
introspect package versions at runtime. Because of this, we only need
`importlib_metadata`, the backported library for python versions
<3.8. We modify the project requirements to only install this on those
versions, and to use the standard library when available.
