### PR TITLE
feat: add traces with open telemetry

### DIFF
--- a/examples/config/prometheus.yml
+++ b/examples/config/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:9464']
+

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,0 +1,41 @@
+version: '3'
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    restart: always
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - 9090:9090
+
+  zipkin:
+    image: openzipkin/zipkin
+    container_name: zipkin
+    ports:
+      - 9411:9411
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/examples/grafana/dashboards/scalar.json
+++ b/examples/grafana/dashboards/scalar.json
@@ -1,0 +1,243 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "momento_requests_counter_total{request_type=\"_GetRequest\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Momento Get Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "{__name__=\"momento_requests_counter_total\", instance=\"host.docker.internal:9464\", job=\"prometheus\", request_type=\"_SetRequest\"}"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "momento_requests_counter_total{request_type=\"_SetRequest\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Momento Set Requests",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Momento Requests",
+  "uid": "a6ad4b53-8ba7-4ea7-bf40-38884c08ebd6",
+  "version": 2,
+  "weekStart": ""
+}

--- a/examples/grafana/provisioning/dashboards/dashboards.yml
+++ b/examples/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name. Required
+  - name: 'prometheus'
+    # <int> Org id. Default to 1
+#    orgId: 1
+    # <string> name of the dashboard folder.
+#    folder: ''
+    # <string> folder UID. will be automatically generated if not specified
+#    folderUid: ''
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /var/lib/grafana/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: false

--- a/examples/grafana/provisioning/datasources/datasource.yml
+++ b/examples/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    editable: true

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -5,15 +5,12 @@ example_observability_setup_tracing()
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CreateCache, CacheSet, CacheGet
 from datetime import timedelta
-import logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _CACHE_NAME = "test-cache"
 _KEY = "test-key"
 _VALUE = "test-value"
-_logger = logging.getLogger("momento-example")
-
 
 def _create_cache(cache_client: CacheClient) -> None:
     create_cache_response = cache_client.create_cache(_CACHE_NAME)
@@ -56,7 +53,7 @@ def main() -> None:
         _create_cache(cache_client)
         _set_cache(cache_client)
         _get_cache(cache_client)
-
+        
 
 main()
 print('Success! Zipkin at http://localhost:9411 should contain traces for the cache creation, get, and set.')

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -2,9 +2,10 @@ from utils.instrumentation import example_observability_setup_tracing
 
 example_observability_setup_tracing()
 
-from momento import CacheClient, Configurations, CredentialProvider
-from momento.responses import CreateCache, CacheSet, CacheGet
 from datetime import timedelta
+
+from momento import CacheClient, Configurations, CredentialProvider
+from momento.responses import CacheGet, CacheSet, CreateCache
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -1,0 +1,62 @@
+from utils.instrumentation import example_observability_setup_tracing
+
+example_observability_setup_tracing()
+
+from momento import CacheClient, Configurations, CredentialProvider
+from momento.responses import CreateCache, CacheSet, CacheGet
+from datetime import timedelta
+import logging
+
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
+_CACHE_NAME = "test-cache"
+_KEY = "test-key"
+_VALUE = "test-value"
+_logger = logging.getLogger("momento-example")
+
+
+def _create_cache(cache_client: CacheClient) -> None:
+    create_cache_response = cache_client.create_cache(_CACHE_NAME)
+    match create_cache_response:
+        case CreateCache.Success():
+            pass
+        case CreateCache.CacheAlreadyExists():
+            print(f"Cache with name: {_CACHE_NAME!r} already exists.")
+        case CreateCache.Error() as error:
+            print(f"Error creating cache: {error.message}")
+        case _:
+            print("Unreachable")
+
+
+def _set_cache(cache_client: CacheClient) -> None:
+    set_cache_response = cache_client.set(_CACHE_NAME, _KEY, _VALUE)
+    match set_cache_response:
+        case CacheSet.Success():
+            pass
+        case CacheSet.Error() as error:
+            print(f"Error setting value: {error.message}")
+        case _:
+            print("Unreachable")
+
+
+def _get_cache(cache_client: CacheClient) -> None:
+    get_cache_response = cache_client.get(_CACHE_NAME, _KEY)
+    match get_cache_response:
+        case CacheGet.Hit():
+            print("Value is " + get_cache_response.value_string)
+            pass
+        case CacheGet.Error() as error:
+            print(f"Error setting value: {error.message}")
+        case _:
+            print("Unreachable")
+
+
+def main() -> None:
+    with CacheClient(Configurations.Laptop.v1(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+        _create_cache(cache_client)
+        _set_cache(cache_client)
+        _get_cache(cache_client)
+
+
+main()
+print('Success! Zipkin at http://localhost:9411 should contain traces for the cache creation, get, and set.')

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -53,7 +53,7 @@ def main() -> None:
         _create_cache(cache_client)
         _set_cache(cache_client)
         _get_cache(cache_client)
-        
+
 
 main()
 print('Success! Zipkin at http://localhost:9411 should contain traces for the cache creation, get, and set.')

--- a/examples/utils/instrumentation.py
+++ b/examples/utils/instrumentation.py
@@ -1,0 +1,29 @@
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.exporter.zipkin.json import ZipkinExporter
+from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+
+
+def example_observability_setup_tracing():
+    # Create a resource object
+    resource = Resource(attributes={
+        SERVICE_NAME: "momento_requests_counter"
+    })
+
+    # Create a tracer provider
+    tracer_provider = TracerProvider(resource=resource)
+
+    # Create a Zipkin exporter
+    zipkin_exporter = ZipkinExporter()
+
+    # Create a span processor and add the exporter
+    span_processor = SimpleSpanProcessor(zipkin_exporter)
+    tracer_provider.add_span_processor(span_processor)
+
+    # Register the tracer provider
+    trace.set_tracer_provider(tracer_provider)
+
+    # Register the gRPC instrumentation
+    GrpcInstrumentorClient().instrument()

--- a/examples/utils/instrumentation.py
+++ b/examples/utils/instrumentation.py
@@ -1,9 +1,9 @@
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.exporter.zipkin.json import ZipkinExporter
 from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 
 def example_observability_setup_tracing():


### PR DESCRIPTION
## PR Description:
- Add traces with open telemetry

## Testing
1. Run  `docker-compose up -d` to start the zipkin server
2. Run `MOMENTO_AUTH_TOKEN=<token> python3 observability.py` using the cli  
3. Verify zipkins running at `http://localhost:9411`. 

## Result:
<img width="1512" alt="Screenshot 2023-06-05 at 9 41 56 AM" src="https://github.com/momentohq/client-sdk-python/assets/127137312/2844b35a-9ff1-4ae7-bff7-b5ecbfab260e">
