### PR TITLE
feat: bug fix - sorted_set_increment should be named sorted_set_increment_score

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,8 +194,8 @@ arch -x86_64 TEST_AUTH_TOKEN=<auth token> TEST_CACHE_NAME=<cache name> poetry ru
 ### Developing new test cases?
 
 Because we have both an asyncio and a synchronous client, we develop tests for both.
-Fear not! This is not twice the work. Since the synchronous client delegates behavior
-to the asynchronous one, we can re-use the async test cases.
+Fear not! This is not twice the work. Since the synchronous client code and tests are
+generated from the asynchronous ones, we can re-use the async test cases.
 
 When developing new test cases, only write tests for the async client in the appropriate
 `test_*_async.py` file. Then run `make gen-sync` to generate the synchronous client

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -19,7 +19,9 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import CacheSortedSetIncrementResponse
+from momento.responses.data.sorted_set.increment import (
+    CacheSortedSetIncrementScoreResponse,
+)
 from momento.responses.data.sorted_set.put_element import (
     CacheSortedSetPutElement,
     CacheSortedSetPutElementResponse,
@@ -1018,7 +1020,7 @@ class CacheClient:
         """
         return self._data_client.sorted_set_remove_elements(cache_name, sorted_set_name, values)
 
-    def sorted_set_increment(
+    def sorted_set_increment_score(
         self,
         cache_name: str,
         sorted_set_name: str,
@@ -1026,7 +1028,7 @@ class CacheClient:
         score: float = 1.0,
         *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> CacheSortedSetIncrementResponse:
+    ) -> CacheSortedSetIncrementScoreResponse:
         """Increments the score for the given sorted set and value.
 
         If the value doesn't exist in the sorted set, it will be added and its score set to the given score.
@@ -1040,7 +1042,7 @@ class CacheClient:
                 Defaults to `CollectionTtl.from_cache_ttl()`
 
         Returns:
-            CacheSortedSetIncrementResponse: the status and associated score for each value.
+            CacheSortedSetIncrementScoreResponse: the status and associated score for each value.
         """
         return self._data_client.sorted_set_increment(cache_name, sorted_set_name, value, score, ttl)
 

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -19,7 +19,7 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import (
+from momento.responses.data.sorted_set.increment_score import (
     CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_element import (

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -1044,7 +1044,7 @@ class CacheClient:
         Returns:
             CacheSortedSetIncrementScoreResponse: the status and associated score for each value.
         """
-        return self._data_client.sorted_set_increment(cache_name, sorted_set_name, value, score, ttl)
+        return self._data_client.sorted_set_increment_score(cache_name, sorted_set_name, value, score, ttl)
 
     @property
     def _data_client(self) -> _ScsDataClient:

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -19,7 +19,9 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import CacheSortedSetIncrementResponse
+from momento.responses.data.sorted_set.increment import (
+    CacheSortedSetIncrementScoreResponse,
+)
 from momento.responses.data.sorted_set.put_element import (
     CacheSortedSetPutElement,
     CacheSortedSetPutElementResponse,
@@ -1025,7 +1027,7 @@ class CacheClientAsync:
         """
         return await self._data_client.sorted_set_remove_elements(cache_name, sorted_set_name, values)
 
-    async def sorted_set_increment(
+    async def sorted_set_increment_score(
         self,
         cache_name: str,
         sorted_set_name: str,
@@ -1033,7 +1035,7 @@ class CacheClientAsync:
         score: float = 1.0,
         *,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> CacheSortedSetIncrementResponse:
+    ) -> CacheSortedSetIncrementScoreResponse:
         """Increments the score for the given sorted set and value.
 
         If the value doesn't exist in the sorted set, it will be added and its score set to the given score.
@@ -1047,7 +1049,7 @@ class CacheClientAsync:
                 Defaults to `CollectionTtl.from_cache_ttl()`
 
         Returns:
-            CacheSortedSetIncrementResponse: the status and associated score for each value.
+            CacheSortedSetIncrementScoreResponse: the status and associated score for each value.
         """
         return await self._data_client.sorted_set_increment(cache_name, sorted_set_name, value, score, ttl)
 

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -19,7 +19,7 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import (
+from momento.responses.data.sorted_set.increment_score import (
     CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_element import (

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -1051,7 +1051,7 @@ class CacheClientAsync:
         Returns:
             CacheSortedSetIncrementScoreResponse: the status and associated score for each value.
         """
-        return await self._data_client.sorted_set_increment(cache_name, sorted_set_name, value, score, ttl)
+        return await self._data_client.sorted_set_increment_score(cache_name, sorted_set_name, value, score, ttl)
 
     @property
     def _data_client(self) -> _ScsDataClient:

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -95,8 +95,8 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import (
-    CacheSortedSetIncrement,
+from momento.responses.data.sorted_set.increment_score import (
+    CacheSortedSetIncrementScore,
     CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_elements import (
@@ -1072,10 +1072,10 @@ class _ScsDataClient:
             )
             self._log_received_response("SortedSetIncrement", {"sorted_set_name": str(request.set_name)})
 
-            return CacheSortedSetIncrement.Success(response.score)
+            return CacheSortedSetIncrementScore.Success(response.score)
         except Exception as e:
             self._log_request_error("sorted_set_increment_score", e)
-            return CacheSortedSetIncrement.Error(convert_error(e))
+            return CacheSortedSetIncrementScore.Error(convert_error(e))
 
     def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Received a {request_type} response for {request_args}")

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -97,7 +97,7 @@ from momento.responses.data.sorted_set.get_scores import (
 )
 from momento.responses.data.sorted_set.increment import (
     CacheSortedSetIncrement,
-    CacheSortedSetIncrementResponse,
+    CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_elements import (
     CacheSortedSetPutElements,
@@ -1044,14 +1044,14 @@ class _ScsDataClient:
             self._log_request_error("sorted_set_remove_elements", e)
             return CacheSortedSetRemoveElements.Error(convert_error(e))
 
-    async def sorted_set_increment(
+    async def sorted_set_increment_score(
         self,
         cache_name: TCacheName,
         sorted_set_name: TSortedSetName,
         value: TSortedSetValue,
         score: TSortedSetScore,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> CacheSortedSetIncrementResponse:
+    ) -> CacheSortedSetIncrementScoreResponse:
         try:
             self._log_issuing_request("SortedSetIncrement", {"sorted_set_name": str(sorted_set_name)})
             _validate_cache_name(cache_name)
@@ -1074,7 +1074,7 @@ class _ScsDataClient:
 
             return CacheSortedSetIncrement.Success(response.score)
         except Exception as e:
-            self._log_request_error("sorted_set_increment", e)
+            self._log_request_error("sorted_set_increment_score", e)
             return CacheSortedSetIncrement.Error(convert_error(e))
 
     def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -97,7 +97,7 @@ from momento.responses.data.sorted_set.get_scores import (
 )
 from momento.responses.data.sorted_set.increment import (
     CacheSortedSetIncrement,
-    CacheSortedSetIncrementResponse,
+    CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_elements import (
     CacheSortedSetPutElements,
@@ -1042,14 +1042,14 @@ class _ScsDataClient:
             self._log_request_error("sorted_set_remove_elements", e)
             return CacheSortedSetRemoveElements.Error(convert_error(e))
 
-    def sorted_set_increment(
+    def sorted_set_increment_score(
         self,
         cache_name: TCacheName,
         sorted_set_name: TSortedSetName,
         value: TSortedSetValue,
         score: TSortedSetScore,
         ttl: CollectionTtl = CollectionTtl.from_cache_ttl(),
-    ) -> CacheSortedSetIncrementResponse:
+    ) -> CacheSortedSetIncrementScoreResponse:
         try:
             self._log_issuing_request("SortedSetIncrement", {"sorted_set_name": str(sorted_set_name)})
             _validate_cache_name(cache_name)
@@ -1072,7 +1072,7 @@ class _ScsDataClient:
 
             return CacheSortedSetIncrement.Success(response.score)
         except Exception as e:
-            self._log_request_error("sorted_set_increment", e)
+            self._log_request_error("sorted_set_increment_score", e)
             return CacheSortedSetIncrement.Error(convert_error(e))
 
     def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -95,8 +95,8 @@ from momento.responses.data.sorted_set.get_scores import (
     CacheSortedSetGetScores,
     CacheSortedSetGetScoresResponse,
 )
-from momento.responses.data.sorted_set.increment import (
-    CacheSortedSetIncrement,
+from momento.responses.data.sorted_set.increment_score import (
+    CacheSortedSetIncrementScore,
     CacheSortedSetIncrementScoreResponse,
 )
 from momento.responses.data.sorted_set.put_elements import (
@@ -1070,10 +1070,10 @@ class _ScsDataClient:
             )
             self._log_received_response("SortedSetIncrement", {"sorted_set_name": str(request.set_name)})
 
-            return CacheSortedSetIncrement.Success(response.score)
+            return CacheSortedSetIncrementScore.Success(response.score)
         except Exception as e:
             self._log_request_error("sorted_set_increment_score", e)
-            return CacheSortedSetIncrement.Error(convert_error(e))
+            return CacheSortedSetIncrementScore.Error(convert_error(e))
 
     def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:
         self._logger.log(logs.TRACE, f"Received a {request_type} response for {request_args}")

--- a/src/momento/responses/data/sorted_set/increment.py
+++ b/src/momento/responses/data/sorted_set/increment.py
@@ -5,8 +5,8 @@ from ...mixins import ErrorResponseMixin
 from ...response import CacheResponse
 
 
-class CacheSortedSetIncrementResponse(CacheResponse):
-    """Parent response type for a cache `sorted_set_increment` request.
+class CacheSortedSetIncrementScoreResponse(CacheResponse):
+    """Parent response type for a cache `sorted_set_increment_score` request.
 
     Its subtypes are:
     - `CacheSortedSetIncrement.Success`
@@ -16,17 +16,17 @@ class CacheSortedSetIncrementResponse(CacheResponse):
     """
 
 
-class CacheSortedSetIncrement(ABC):
-    """Groups all `CacheSortedSetIncrementResponse` derived types under a common namespace."""
+class CacheSortedSetIncrementScore(ABC):
+    """Groups all `CacheSortedSetIncrementScoreResponse` derived types under a common namespace."""
 
     @dataclass
-    class Success(CacheSortedSetIncrementResponse):
+    class Success(CacheSortedSetIncrementScoreResponse):
         """Indicates the request was successful."""
 
         score: float
         """The score of the element post-increment."""
 
-    class Error(CacheSortedSetIncrementResponse, ErrorResponseMixin):
+    class Error(CacheSortedSetIncrementScoreResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request.
 
         This includes:

--- a/src/momento/responses/data/sorted_set/increment_score.py
+++ b/src/momento/responses/data/sorted_set/increment_score.py
@@ -9,8 +9,8 @@ class CacheSortedSetIncrementScoreResponse(CacheResponse):
     """Parent response type for a cache `sorted_set_increment_score` request.
 
     Its subtypes are:
-    - `CacheSortedSetIncrement.Success`
-    - `CacheSortedSetIncrement.Error`
+    - `CacheSortedSetIncrementScore.Success`
+    - `CacheSortedSetIncrementScore.Error`
 
     See `CacheClient` for how to work with responses.
     """

--- a/tests/momento/cache_client/test_sorted_set.py
+++ b/tests/momento/cache_client/test_sorted_set.py
@@ -818,14 +818,14 @@ def describe_sorted_set_get_rank() -> None:
 @behaves_like(a_connection_validator)
 @behaves_like(a_sorted_set_name_validator)
 @behaves_like(a_sorted_set_setter)
-def describe_sorted_set_increment() -> None:
+def describe_sorted_set_increment_score() -> None:
     @fixture
     def cache_name_validator(
         client: CacheClient,
         sorted_set_name: TSortedSetName,
         sorted_set_value_str: str,
     ) -> TCacheNameValidator:
-        return partial(client.sorted_set_increment, sorted_set_name=sorted_set_name, value=sorted_set_value_str)
+        return partial(client.sorted_set_increment_score, sorted_set_name=sorted_set_name, value=sorted_set_value_str)
 
     @fixture
     def connection_validator(
@@ -834,7 +834,9 @@ def describe_sorted_set_increment() -> None:
         sorted_set_value_str: str,
     ) -> TConnectionValidator:
         def _connection_validator(client: CacheClient) -> CacheResponse:
-            return client.sorted_set_increment(cache_name, sorted_set_name=sorted_set_name, value=sorted_set_value_str)
+            return client.sorted_set_increment_score(
+                cache_name, sorted_set_name=sorted_set_name, value=sorted_set_value_str
+            )
 
         return _connection_validator
 
@@ -844,7 +846,7 @@ def describe_sorted_set_increment() -> None:
         cache_name: TCacheName,
         sorted_set_value_str: str,
     ) -> TSortedSetNameValidator:
-        return partial(client.sorted_set_increment, cache_name=cache_name, value=sorted_set_value_str)
+        return partial(client.sorted_set_increment_score, cache_name=cache_name, value=sorted_set_value_str)
 
     @fixture
     def sorted_set_setter() -> TSortedSetSetter:
@@ -858,7 +860,7 @@ def describe_sorted_set_increment() -> None:
         ) -> CacheResponse:
             response = None
             for (value, score) in elements.items():
-                response = client.sorted_set_increment(
+                response = client.sorted_set_increment_score(
                     cache_name=cache_name,
                     sorted_set_name=sorted_set_name,
                     value=value,

--- a/tests/momento/cache_client/test_sorted_set_async.py
+++ b/tests/momento/cache_client/test_sorted_set_async.py
@@ -826,14 +826,16 @@ def describe_sorted_set_get_rank() -> None:
 @behaves_like(a_connection_validator)
 @behaves_like(a_sorted_set_name_validator)
 @behaves_like(a_sorted_set_setter)
-def describe_sorted_set_increment() -> None:
+def describe_sorted_set_increment_score() -> None:
     @fixture
     def cache_name_validator(
         client_async: CacheClientAsync,
         sorted_set_name: TSortedSetName,
         sorted_set_value_str: str,
     ) -> TCacheNameValidator:
-        return partial(client_async.sorted_set_increment, sorted_set_name=sorted_set_name, value=sorted_set_value_str)
+        return partial(
+            client_async.sorted_set_increment_score, sorted_set_name=sorted_set_name, value=sorted_set_value_str
+        )
 
     @fixture
     def connection_validator(
@@ -842,7 +844,7 @@ def describe_sorted_set_increment() -> None:
         sorted_set_value_str: str,
     ) -> TConnectionValidator:
         async def _connection_validator(client_async: CacheClientAsync) -> CacheResponse:
-            return await client_async.sorted_set_increment(
+            return await client_async.sorted_set_increment_score(
                 cache_name, sorted_set_name=sorted_set_name, value=sorted_set_value_str
             )
 
@@ -854,7 +856,7 @@ def describe_sorted_set_increment() -> None:
         cache_name: TCacheName,
         sorted_set_value_str: str,
     ) -> TSortedSetNameValidator:
-        return partial(client_async.sorted_set_increment, cache_name=cache_name, value=sorted_set_value_str)
+        return partial(client_async.sorted_set_increment_score, cache_name=cache_name, value=sorted_set_value_str)
 
     @fixture
     def sorted_set_setter() -> TSortedSetSetter:
@@ -868,7 +870,7 @@ def describe_sorted_set_increment() -> None:
         ) -> CacheResponse:
             response = None
             for (value, score) in elements.items():
-                response = await client_async.sorted_set_increment(
+                response = await client_async.sorted_set_increment_score(
                     cache_name=cache_name,
                     sorted_set_name=sorted_set_name,
                     value=value,


### PR DESCRIPTION
The Python SDK had implemented increment support for sorted sets
using the name `sorted_set_increment`, when the docs and all of
the other SDKs use the name `sorted_set_increment_score`. This fixes
the name to match the docs and other SDKs.
