### PR TITLE
fix: add back return statements for closed streams

### DIFF
--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -62,7 +62,7 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
         elif isinstance(item, TopicSubscriptionItem.Error):
             print("stream closed")
             print(item.inner_exception.message)
-
+            return
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -64,7 +64,7 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
             case TopicSubscriptionItem.Error():
                 print("stream closed")
                 print(item.inner_exception.message)
-
+                return
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Restoring return statements for closed async streams.