### PR TITLE
chore: use vector endpoint for MVI API calls

### DIFF
--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -15,12 +15,14 @@ class CredentialProvider:
     auth_token: str
     control_endpoint: str
     cache_endpoint: str
+    vector_endpoint: str
 
     @staticmethod
     def from_environment_variable(
         env_var_name: str,
         control_endpoint: Optional[str] = None,
         cache_endpoint: Optional[str] = None,
+        vector_endpoint: Optional[str] = None,
     ) -> CredentialProvider:
         """Reads and parses a Momento auth token stored as an environment variable.
 
@@ -28,7 +30,9 @@ class CredentialProvider:
             env_var_name (str): Name of the environment variable from which the auth token will be read
             control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
             Defaults to None.
-            cache_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.
+            Defaults to None.
+            vector_endpoint (Optional[str], optional): Optionally overrides the default vector endpoint.
             Defaults to None.
 
         Raises:
@@ -40,13 +44,14 @@ class CredentialProvider:
         auth_token = os.getenv(env_var_name)
         if not auth_token:
             raise RuntimeError(f"Missing required environment variable {env_var_name}")
-        return CredentialProvider.from_string(auth_token, control_endpoint, cache_endpoint)
+        return CredentialProvider.from_string(auth_token, control_endpoint, cache_endpoint, vector_endpoint)
 
     @staticmethod
     def from_string(
         auth_token: str,
         control_endpoint: Optional[str] = None,
         cache_endpoint: Optional[str] = None,
+        vector_endpoint: Optional[str] = None,
     ) -> CredentialProvider:
         """Reads and parses a Momento auth token.
 
@@ -54,7 +59,9 @@ class CredentialProvider:
             auth_token (str): the Momento auth token
             control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
             Defaults to None.
-            cache_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
+            cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.
+            Defaults to None.
+            vector_endpoint (Optional[str], optional): Optionally overrides the default vector endpoint.
             Defaults to None.
 
         Returns:
@@ -63,8 +70,9 @@ class CredentialProvider:
         token_and_endpoints = momento_endpoint_resolver.resolve(auth_token)
         control_endpoint = control_endpoint or token_and_endpoints.control_endpoint
         cache_endpoint = cache_endpoint or token_and_endpoints.cache_endpoint
+        vector_endpoint = vector_endpoint or token_and_endpoints.vector_endpoint
         auth_token = token_and_endpoints.auth_token
-        return CredentialProvider(auth_token, control_endpoint, cache_endpoint)
+        return CredentialProvider(auth_token, control_endpoint, cache_endpoint, vector_endpoint)
 
     def __repr__(self) -> str:
         attributes: Dict[str, str] = copy.copy(vars(self))  # type: ignore[misc]

--- a/src/momento/auth/momento_endpoint_resolver.py
+++ b/src/momento/auth/momento_endpoint_resolver.py
@@ -11,14 +11,17 @@ from momento.internal.services import Service
 
 _MOMENTO_CONTROL_ENDPOINT_PREFIX = "control."
 _MOMENTO_CACHE_ENDPOINT_PREFIX = "cache."
+_MOMENTO_VECTOR_ENDPOINT_PREFIX = "vector."
 _CONTROL_ENDPOINT_CLAIM_ID = "cp"
 _CACHE_ENDPOINT_CLAIM_ID = "c"
+_VECTOR_ENDPOINT_CLAIM_ID = "c"
 
 
 @dataclass
 class _TokenAndEndpoints:
     control_endpoint: str
     cache_endpoint: str
+    vector_endpoint: str
     auth_token: str
 
 
@@ -38,6 +41,7 @@ def resolve(auth_token: str) -> _TokenAndEndpoints:
         return _TokenAndEndpoints(
             control_endpoint=_MOMENTO_CONTROL_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
             cache_endpoint=_MOMENTO_CACHE_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
+            vector_endpoint=_MOMENTO_VECTOR_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
             auth_token=info["api_key"],  # type: ignore[misc]
         )
     else:
@@ -50,6 +54,7 @@ def _get_endpoint_from_token(auth_token: str) -> _TokenAndEndpoints:
         return _TokenAndEndpoints(
             control_endpoint=claims[_CONTROL_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
             cache_endpoint=claims[_CACHE_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
+            vector_endpoint=claims[_VECTOR_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
             auth_token=auth_token,
         )
     except (DecodeError, KeyError) as e:

--- a/src/momento/auth/momento_endpoint_resolver.py
+++ b/src/momento/auth/momento_endpoint_resolver.py
@@ -14,7 +14,7 @@ _MOMENTO_CACHE_ENDPOINT_PREFIX = "cache."
 _MOMENTO_VECTOR_ENDPOINT_PREFIX = "vector."
 _CONTROL_ENDPOINT_CLAIM_ID = "cp"
 _CACHE_ENDPOINT_CLAIM_ID = "c"
-_VECTOR_ENDPOINT_CLAIM_ID = "c"
+_VECTOR_ENDPOINT_CLAIM_ID = "c"  # we don't have a new claim here so defaulting to c
 
 
 @dataclass

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -29,7 +29,7 @@ class _VectorIndexDataClient:
     """Internal vector index data client."""
 
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
-        endpoint = credential_provider.cache_endpoint
+        endpoint = credential_provider.vector_endpoint
         self._logger = logs.logger
         self._logger.debug("Vector index data client instantiated with endpoint: %s", endpoint)
         self._endpoint = endpoint

--- a/src/momento/internal/aio/_vector_index_grpc_manager.py
+++ b/src/momento/internal/aio/_vector_index_grpc_manager.py
@@ -37,7 +37,7 @@ class _VectorIndexDataGrpcManager:
 
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
-            target=credential_provider.cache_endpoint,
+            target=credential_provider.vector_endpoint,
             credentials=grpc.ssl_channel_credentials(),
             interceptors=_interceptors(credential_provider.auth_token),
         )

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -31,7 +31,7 @@ class _VectorIndexDataClient:
     """Internal vector index data client."""
 
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
-        endpoint = credential_provider.cache_endpoint
+        endpoint = credential_provider.vector_endpoint
         self._logger = logs.logger
         self._logger.debug("Vector index data client instantiated with endpoint: %s", endpoint)
         self._endpoint = endpoint

--- a/src/momento/internal/synchronous/_vector_index_grpc_manager.py
+++ b/src/momento/internal/synchronous/_vector_index_grpc_manager.py
@@ -40,7 +40,7 @@ class _VectorIndexDataGrpcManager:
 
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
-            target=credential_provider.cache_endpoint,
+            target=credential_provider.vector_endpoint,
             credentials=grpc.ssl_channel_credentials(),
         )
         intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))


### PR DESCRIPTION
For MVI data plane calls, we were using `cache` as the endpoint prefix; this PR updates it to use `vector`. Note that for legacy tokens, we do not have a new JWT claim, so we will be using `cache` as the prefix for that as well.

Also, for control plane operations, the endpoint prefix is still `control`.