### PR TITLE
chore: prefer API key over AUTH token terminology

### DIFF
--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -61,7 +61,7 @@ jobs:
         run: /Users/runner/.local/bin/poetry run black src tests --check --diff
 
       - name: Run isort
-        run: /Users/runner/.local/bin/poetry run isort . --check --diff
+        run: /Users/runner/.local/bin/poetry run isort src tests --check --diff
 
       - name: Run tests
         run: /Users/runner/.local/bin/poetry run pytest tests/momento/vector_index_client -p no:sugar -q

--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -17,7 +17,7 @@ jobs:
             new-python-protobuf: "false"
 
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
       TEST_VECTOR_INDEX_NAME: python-integration-test-vector-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
             new-python-protobuf: "false"
 
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
       TEST_VECTOR_INDEX_NAME: python-integration-test-vector-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -60,7 +60,7 @@ jobs:
         run: poetry run black src tests --check --diff
 
       - name: Run isort
-        run: poetry run isort . --check --diff
+        run: poetry run isort src tests --check --diff
 
       - name: Run tests
         run: poetry run pytest -p no:sugar -q --ignore=tests/momento/vector_index_client

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -85,7 +85,7 @@ jobs:
     env:
       # TODO: remove token stored as secret in favor of using a
       # momento-local instance that can be spun up for testing
-      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_API_KEY }}
     steps:
       - uses: actions/checkout@v3
       - name: Python SDK sample

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -85,7 +85,7 @@ jobs:
     env:
       # TODO: remove token stored as secret in favor of using a
       # momento-local instance that can be spun up for testing
-      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_API_KEY }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Python SDK sample

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -79,7 +79,7 @@ jobs:
         run: poetry run black src tests --check --diff
 
       - name: Run isort
-        run: poetry run isort . --check --diff
+        run: poetry run isort src tests --check --diff
 
       - name: Run tests
         run: poetry run pytest -p no:sugar -q --ignore=tests/momento/vector_index_client

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -39,7 +39,7 @@ jobs:
           - python-version: "3.7"
             new-python-protobuf: "false"
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
       TEST_VECTOR_INDEX_NAME: python-integration-test-vector-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,13 +169,13 @@ poetry run isort .
 
 ## Tests :zap:
 
-Integration tests require an auth token for testing. Set the env var `TEST_AUTH_TOKEN` to
+Integration tests require an api key for testing. Set the env var `TEST_API_KEY` to
 provide it. The env `TEST_CACHE_NAME` is also required, but for now any string value works.
 
 Example of running tests against all python versions:
 
 ```
-TEST_AUTH_TOKEN=<auth token> TEST_CACHE_NAME=<cache name> poetry run pytest
+TEST_API_KEY=<api key> TEST_CACHE_NAME=<cache name> poetry run pytest
 ```
 
 ### For M1 Users
@@ -188,7 +188,7 @@ a github issue with us to let us know.  And in the meantime you can work around 
 issue by installing Rosetta 2 and re-running with:
 
 ```
-arch -x86_64 TEST_AUTH_TOKEN=<auth token> TEST_CACHE_NAME=<cache name> poetry run pytest
+arch -x86_64 TEST_API_KEY=<api key> TEST_CACHE_NAME=<cache name> poetry run pytest
 ```
 
 ### Developing new test cases?

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 ## Format the code using black and isort
 format:
 	@poetry run black src tests
-	@poetry run isort .
+	@poetry run isort src tests
 
 .PHONY: lint
 ## Lint the code using mypy and flake8

--- a/README.template.md
+++ b/README.template.md
@@ -9,7 +9,6 @@ The Momento Python SDK package is available on pypi: [momento](https://pypi.org/
 The examples below require an environment variable named MOMENTO_API_KEY which must
 be set to a valid Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
 
-
 Python 3.10 introduced the `match` statement, which allows for [structural pattern matching on objects](https://peps.python.org/pep-0636/#adding-a-ui-matching-objects).
 If you are running python 3.10 or greater, here is a quickstart you can use in your own project:
 

--- a/README.template.md
+++ b/README.template.md
@@ -6,8 +6,9 @@ The Momento Python SDK package is available on pypi: [momento](https://pypi.org/
 
 ## Usage
 
-The examples below require an environment variable named MOMENTO_AUTH_TOKEN which must
-be set to a valid [Momento authentication token](https://docs.momentohq.com/docs/getting-started#obtain-an-auth-token).
+The examples below require an environment variable named MOMENTO_API_KEY which must
+be set to a valid Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
+
 
 Python 3.10 introduced the `match` statement, which allows for [structural pattern matching on objects](https://peps.python.org/pep-0636/#adding-a-ui-matching-objects).
 If you are running python 3.10 or greater, here is a quickstart you can use in your own project:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,3 +7,8 @@ format:
 	@poetry run black prepy310 py310
 	@poetry run isort prepy310 py310
 
+
+.PHONY: lint
+lint:
+	@poetry run mypy prepy310 py310
+	@poetry run flake8 prepy310 py310

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,3 +1,9 @@
 .PHONY: export
 export:
 	@poetry export -f requirements.txt --output requirements.txt
+
+.PHONY: format
+format:
+	@poetry run black prepy310 py310
+	@poetry run isort prepy310 py310
+

--- a/examples/README.ja.md
+++ b/examples/README.ja.md
@@ -15,15 +15,15 @@ pipenv install
 ```
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> pipenv run python example.py
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> pipenv run python example_async.py
+MOMENTO_API_KEY=<YOUR_API_KEY> pipenv run python example.py
+MOMENTO_API_KEY=<YOUR_API_KEY> pipenv run python example_async.py
 ```
 
 SDK のデバッグログをオンするには、下記のように実行して下さい:
 
 ```bash
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> pipenv run python example.py
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> pipenv run python example_async.py
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> pipenv run python example.py
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> pipenv run python example_async.py
 ```
 
 ## SDK を自身のプロジェクトで使用する

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ _Read this in other languages_: [日本語](README.ja.md)
 ## Prereqs
 
 - [Python 3.7 or above is required](https://www.python.org/downloads/)
-- A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
+- To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
 - Developer libraries (gcc/python dev headers) installed on machine you intend to run on
 
 **Amazon Linux**
@@ -44,29 +44,29 @@ poetry install
 To run the python version 3.10+ examples:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m py310.example
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m py310.example_async
+MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m py310.example
+MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m py310.example_async
 ```
 
 To run the examples with SDK debug logging enabled:
 
 ```bash
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m py310.example
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m py310.example_async
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m py310.example
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m py310.example_async
 ```
 
 To run the python version <3.10 examples:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m prepy310.example
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m prepy310.example_async
+MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m prepy310.example
+MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m prepy310.example_async
 ```
 
 To run the examples with SDK debug logging enabled:
 
 ```bash
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m prepy310.example
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m prepy310.example_async
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m prepy310.example
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m prepy310.example_async
 ```
 
 ## Running the Example Using pip
@@ -80,29 +80,29 @@ pip install -r requirements.txt
 To run the python version 3.10+ examples:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m py310.example
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m py310.example_async
+MOMENTO_API_KEY=<YOUR_API_KEY> python -m py310.example
+MOMENTO_API_KEY=<YOUR_API_KEY> python -m py310.example_async
 ```
 
 To run the examples with SDK debug logging enabled:
 
 ```bash
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m py310.example
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m py310.example_async
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> python -m py310.example
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> python -m py310.example_async
 ```
 
 To run the python version <3.10 examples:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m prepy310.example
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m prepy310.example_async
+MOMENTO_API_KEY=<YOUR_API_KEY> python -m prepy310.example
+MOMENTO_API_KEY=<YOUR_API_KEY> python -m prepy310.example_async
 ```
 
 To run the examples with SDK debug logging enabled:
 
 ```bash
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m prepy310.example
-DEBUG=true MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> python -m prepy310.example_async
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> python -m prepy310.example
+DEBUG=true MOMENTO_API_KEY=<YOUR_API_KEY> python -m prepy310.example_async
 ```
 
 ## Running the load generator example
@@ -135,7 +135,7 @@ To run the load generator:
 
 ```bash
 # Run example load generator
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> poetry run python -m py310.example_load_gen
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> poetry run python -m py310.example_load_gen
 ```
 
 You can check out the example code in [example_load_gen.py](py310/example_load_gen.py). The configurable

--- a/examples/example_utils/example_logging.py
+++ b/examples/example_utils/example_logging.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 import colorlog  # type: ignore
-
 from momento.logs import TRACE, initialize_momento_logging
 
 

--- a/examples/example_utils/example_logging.py
+++ b/examples/example_utils/example_logging.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import colorlog  # type: ignore
+
 from momento.logs import TRACE, initialize_momento_logging
 
 

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -36,7 +36,7 @@ You will also need a superuser token generated from the [Momento Console](https:
 Then run:
 
 ```
-export MOMENTO_AUTH_TOKEN=<YOUR_MOMENTO_AUTH_TOKEN>
+export MOMENTO_API_KEY=<YOUR_MOMENTO_API_KEY>
 npm run cdk deploy
 ```
 

--- a/examples/lambda/docker/lambda/index.py
+++ b/examples/lambda/docker/lambda/index.py
@@ -8,7 +8,7 @@ def handler(event, lambda_context):
     cache_name = "default-cache"
     with CacheClient.create(
             configuration=Configurations.Lambda.latest(),
-            credential_provider=CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+            credential_provider=CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
             default_ttl=timedelta(seconds=60),
     ) as cache_client:
         create_cache_response = cache_client.create_cache(cache_name)

--- a/examples/lambda/infrastructure/lib/stack.ts
+++ b/examples/lambda/infrastructure/lib/stack.ts
@@ -7,8 +7,8 @@ export class MomentoLambdaStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
-        if (!process.env.MOMENTO_AUTH_TOKEN) {
-            throw new Error('The environment variable MOMENTO_AUTH_TOKEN must be set.');
+        if (!process.env.MOMENTO_API_KEY) {
+            throw new Error('The environment variable MOMENTO_API_KEY must be set.');
         }
 
         // Create Lambda function from Docker Image
@@ -16,7 +16,7 @@ export class MomentoLambdaStack extends cdk.Stack {
             functionName: 'MomentoDockerLambda',
             code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../../docker')), // Point to the root since Dockerfile should be there
             environment: {
-                MOMENTO_AUTH_TOKEN: process.env.MOMENTO_AUTH_TOKEN || ''
+                MOMENTO_API_KEY: process.env.MOMENTO_API_KEY || ''
             },
             memorySize: 128,
             timeout: cdk.Duration.seconds(30)

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _CACHE_NAME = "test-cache"
 _KEY = "test-key"

--- a/examples/prepy310/example.py
+++ b/examples/prepy310/example.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/example.py
+++ b/examples/prepy310/example.py
@@ -6,7 +6,7 @@ from example_utils.example_logging import initialize_logging
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _KEY = "MyKey"

--- a/examples/prepy310/example.py
+++ b/examples/prepy310/example.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -56,7 +56,9 @@ async def _list_caches(cache_client: CacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with await CacheClientAsync.create(Configurations.Laptop.v1(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with await CacheClientAsync.create(
+        Configurations.Laptop.v1(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS
+    ) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/example_async.py
+++ b/examples/prepy310/example_async.py
@@ -7,7 +7,7 @@ from example_utils.example_logging import initialize_logging
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _KEY = "MyKey"

--- a/examples/prepy310/quickstart.py
+++ b/examples/prepy310/quickstart.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     cache_name = "default-cache"
     with CacheClient.create(
         configuration=Configurations.Laptop.v1(),
-        credential_provider=CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+        credential_provider=CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
         default_ttl=timedelta(seconds=60),
     ) as cache_client:
         create_cache_response = cache_client.create_cache(cache_name)

--- a/examples/prepy310/readme.py
+++ b/examples/prepy310/readme.py
@@ -5,8 +5,8 @@ from momento.responses import CacheGet, CacheSet, CreateCache
 
 cache_client = CacheClient(
     configuration=Configurations.Laptop.v1(),
-    credential_provider=CredentialProvider.from_environment_variable('MOMENTO_API_KEY'),
-    default_ttl=timedelta(seconds=60)
+    credential_provider=CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
+    default_ttl=timedelta(seconds=60),
 )
 cache_client.create_cache("cache")
 cache_client.set("cache", "myKey", "myValue")

--- a/examples/prepy310/readme.py
+++ b/examples/prepy310/readme.py
@@ -5,7 +5,7 @@ from momento.responses import CacheGet, CacheSet, CreateCache
 
 cache_client = CacheClient(
     configuration=Configurations.Laptop.v1(),
-    credential_provider=CredentialProvider.from_environment_variable('MOMENTO_AUTH_TOKEN'),
+    credential_provider=CredentialProvider.from_environment_variable('MOMENTO_API_KEY'),
     default_ttl=timedelta(seconds=60)
 )
 cache_client.create_cache("cache")

--- a/examples/prepy310/readme.py
+++ b/examples/prepy310/readme.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from momento import CacheClient, Configurations, CredentialProvider
-from momento.responses import CacheGet, CacheSet, CreateCache
+from momento.responses import CacheGet
 
 cache_client = CacheClient(
     configuration=Configurations.Laptop.v1(),

--- a/examples/prepy310/topic_publish.py
+++ b/examples/prepy310/topic_publish.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -9,8 +11,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_publish.py
+++ b/examples/prepy310/topic_publish.py
@@ -12,7 +12,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicPublish
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-publish-example")
 

--- a/examples/prepy310/topic_publish.py
+++ b/examples/prepy310/topic_publish.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -11,6 +9,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_publish_async.py
+++ b/examples/prepy310/topic_publish_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -12,6 +10,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_publish_async.py
+++ b/examples/prepy310/topic_publish_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -12,6 +10,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -33,6 +33,7 @@ async def main() -> None:
         response = await client.publish("cache", "my_topic", "my_value")
         if isinstance(response, TopicPublish.Error):
             print("error: ", response.message)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/prepy310/topic_publish_async.py
+++ b/examples/prepy310/topic_publish_async.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -10,8 +12,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_publish_async.py
+++ b/examples/prepy310/topic_publish_async.py
@@ -13,7 +13,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicPublish
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-publish-example")
 

--- a/examples/prepy310/topic_subscribe.py
+++ b/examples/prepy310/topic_subscribe.py
@@ -12,7 +12,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-subscribe-example")
 

--- a/examples/prepy310/topic_subscribe.py
+++ b/examples/prepy310/topic_subscribe.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -9,8 +11,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_subscribe.py
+++ b/examples/prepy310/topic_subscribe.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -11,6 +9,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_subscribe.py
+++ b/examples/prepy310/topic_subscribe.py
@@ -39,7 +39,7 @@ def main() -> None:
                 if isinstance(item, TopicSubscriptionItem.Text):
                     print(f"got item as string: {item.value}")
                 elif isinstance(item, TopicSubscriptionItem.Binary):
-                    print(f"got item as bytes: {item.value}")
+                    print(f"got item as bytes: {item.value!r}")
                 elif isinstance(item, TopicSubscriptionItem.Error):
                     print(f"got item error: {item.message}")
 

--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -14,7 +14,7 @@ from momento import (
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _NUM_SUBSCRIBERS = 10
 _logger = logging.getLogger("topic-subscribe-example")

--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -11,8 +13,6 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -13,6 +11,8 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -65,6 +65,7 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
             print("stream closed")
             print(item.inner_exception.message)
             return
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -13,6 +11,8 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/prepy310/topic_subscribe_async.py
+++ b/examples/prepy310/topic_subscribe_async.py
@@ -49,8 +49,8 @@ async def main() -> None:
         tasks = [asyncio.create_task(poll_subscription(subscription)) for subscription in subscriptions]
         try:
             await asyncio.gather(*tasks)
-        except SdkException as e:
-            print(f"got exception")
+        except SdkException:
+            print("got exception")
             for task in tasks:
                 task.cancel()
 
@@ -60,7 +60,7 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
         if isinstance(item, TopicSubscriptionItem.Text):
             print(f"got item as string: {item.value}")
         elif isinstance(item, TopicSubscriptionItem.Binary):
-            print(f"got item as bytes: {item.value}")
+            print(f"got item as bytes: {item.value!r}")
         elif isinstance(item, TopicSubscriptionItem.Error):
             print("stream closed")
             print(item.inner_exception.message)

--- a/examples/py310/doc-examples-python-apis.py
+++ b/examples/py310/doc-examples-python-apis.py
@@ -124,7 +124,7 @@ async def example_API_Delete(cache_client: CacheClientAsync):
 
 
 async def example_API_InstantiateTopicClient():
-    topic_client = TopicClientAsync(
+    TopicClientAsync(
         TopicConfigurations.Default.latest(), CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
     )
 

--- a/examples/py310/doc-examples-python-apis.py
+++ b/examples/py310/doc-examples-python-apis.py
@@ -22,14 +22,14 @@ from momento.responses import (
 
 
 def example_API_CredentialProviderFromEnvVar():
-    CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+    CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 # end example
 
 
 async def example_API_InstantiateCacheClient():
     await CacheClientAsync.create(
         Configurations.Laptop.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+        CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
         timedelta(seconds=60)
     )
 # end example
@@ -108,7 +108,7 @@ async def example_API_Delete(cache_client: CacheClientAsync):
 async def example_API_InstantiateTopicClient():
     topic_client = TopicClientAsync(
         TopicConfigurations.Default.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+        CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
     )
 # end example
 
@@ -150,7 +150,7 @@ async def main():
     await example_API_InstantiateCacheClient()
     cache_client = await CacheClientAsync.create(
         Configurations.Laptop.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+        CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
         timedelta(seconds=60)
     )
 
@@ -167,7 +167,7 @@ async def main():
 
     topic_client = TopicClientAsync(
         TopicConfigurations.Default.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+        CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
     )
     await example_API_InstantiateTopicClient()
     await example_API_TopicPublish(topic_client)

--- a/examples/py310/doc-examples-python-apis.py
+++ b/examples/py310/doc-examples-python-apis.py
@@ -23,6 +23,8 @@ from momento.responses import (
 
 def example_API_CredentialProviderFromEnvVar():
     CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
+
+
 # end example
 
 
@@ -30,13 +32,15 @@ async def example_API_InstantiateCacheClient():
     await CacheClientAsync.create(
         Configurations.Laptop.latest(),
         CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
-        timedelta(seconds=60)
+        timedelta(seconds=60),
     )
+
+
 # end example
 
 
 async def example_API_CreateCache(cache_client: CacheClientAsync):
-    create_cache_response = await cache_client.create_cache('test-cache')
+    create_cache_response = await cache_client.create_cache("test-cache")
     match create_cache_response:
         case CreateCache.Success():
             print("Cache 'test-cache' created")
@@ -44,16 +48,20 @@ async def example_API_CreateCache(cache_client: CacheClientAsync):
             print("Cache 'test-cache' already exists.")
         case CreateCache.Error() as error:
             print(f"An error occurred while attempting to create cache 'test-cache': {error.message}")
+
+
 # end example
 
 
 async def example_API_DeleteCache(cache_client: CacheClientAsync):
-    delete_cache_response = await cache_client.delete_cache('test-cache')
+    delete_cache_response = await cache_client.delete_cache("test-cache")
     match delete_cache_response:
         case DeleteCache.Success():
             print("Cache 'test-cache' deleted")
         case DeleteCache.Error() as error:
             raise Exception(f"An error occurred while attempting to delete 'test-cache': {error.message}")
+
+
 # end example
 
 
@@ -66,11 +74,13 @@ async def example_API_ListCaches(cache_client: CacheClientAsync):
                 print(f"- {cache_info.name!r}")
         case ListCaches.Error() as error:
             raise Exception(f"An error occurred while attempting to list caches: {error.message}")
+
+
 # end example
 
 
 async def example_API_Set(cache_client: CacheClientAsync):
-    set_response = await cache_client.set('test-cache', 'test-key', 'test-value')
+    set_response = await cache_client.set("test-cache", "test-key", "test-value")
     match set_response:
         case CacheSet.Success():
             print("Key 'test-key' stored successfully")
@@ -78,11 +88,13 @@ async def example_API_Set(cache_client: CacheClientAsync):
             raise Exception(
                 f"An error occurred while attempting to store key 'test-key' in cache 'test-cache': {error.message}"
             )
+
+
 # end example
 
 
 async def example_API_Get(cache_client: CacheClientAsync):
-    get_response = await cache_client.get('test-cache', 'test-key')
+    get_response = await cache_client.get("test-cache", "test-key")
     match get_response:
         case CacheGet.Hit() as hit:
             print(f"Retrieved value for key 'test-key': {hit.value_string}")
@@ -92,24 +104,31 @@ async def example_API_Get(cache_client: CacheClientAsync):
             raise Exception(
                 f"An error occurred while attempting to get key 'test-key' from cache 'test-cache': {error.message}"
             )
+
+
 # end example
 
 
 async def example_API_Delete(cache_client: CacheClientAsync):
-    delete_response = await cache_client.delete('test-cache', 'test-key')
+    delete_response = await cache_client.delete("test-cache", "test-key")
     match delete_response:
         case CacheDelete.Success():
             print("Key 'test-key' deleted successfully")
         case CacheDelete.Error() as error:
-            raise Exception(f"An error occurred while attempting to delete key 'test-key' from cache 'test-cache': {error.message}")
+            raise Exception(
+                f"An error occurred while attempting to delete key 'test-key' from cache 'test-cache': {error.message}"
+            )
+
+
 # end example
 
 
 async def example_API_InstantiateTopicClient():
     topic_client = TopicClientAsync(
-        TopicConfigurations.Default.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
+        TopicConfigurations.Default.latest(), CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
     )
+
+
 # end example
 
 
@@ -131,6 +150,8 @@ async def example_API_TopicSubscribe(topic_client: TopicClientAsync):
                     case TopicSubscriptionItem.Error():
                         print("Error with received message:", item.inner_exception.message)
                         return
+
+
 # end example
 
 
@@ -141,6 +162,8 @@ async def example_API_TopicPublish(topic_client: TopicClientAsync):
             print("Successfully published a message")
         case TopicPublish.Error():
             print("Error publishing a message: ", response.message)
+
+
 # end example
 
 
@@ -151,7 +174,7 @@ async def main():
     cache_client = await CacheClientAsync.create(
         Configurations.Laptop.latest(),
         CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
-        timedelta(seconds=60)
+        timedelta(seconds=60),
     )
 
     await example_API_CreateCache(cache_client)
@@ -166,13 +189,13 @@ async def main():
     await example_API_DeleteCache(cache_client)
 
     topic_client = TopicClientAsync(
-        TopicConfigurations.Default.latest(),
-        CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
+        TopicConfigurations.Default.latest(), CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
     )
     await example_API_InstantiateTopicClient()
     await example_API_TopicPublish(topic_client)
     await example_API_TopicSubscribe(topic_client)
     await topic_client.close()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/py310/doc-examples-python-apis.py
+++ b/examples/py310/doc-examples-python-apis.py
@@ -145,7 +145,7 @@ async def example_API_TopicSubscribe(topic_client: TopicClientAsync):
                         print(f"Received message as string: {item.value}")
                         return
                     case TopicSubscriptionItem.Binary():
-                        print(f"Received message as bytes: {item.value}")
+                        print(f"Received message as bytes: {item.value!r}")
                         return
                     case TopicSubscriptionItem.Error():
                         print("Error with received message:", item.inner_exception.message)

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -6,7 +6,7 @@ from example_utils.example_logging import initialize_logging
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _KEY = "MyKey"

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
         match set_response:
             case CacheSet.Success():
                 pass
-            case CacheSet.Error() as error:
-                _logger.error(f"Error creating cache: {error.message}")
+            case CacheSet.Error() as cache_set_error:
+                _logger.error(f"Error creating cache: {cache_set_error.message}")
             case _:
                 _logger.error("Unreachable")
 
@@ -79,8 +79,8 @@ if __name__ == "__main__":
                 _logger.info(f"Looked up Value: {hit.value_string!r}")
             case CacheGet.Miss():
                 _logger.info("Look up resulted in a: miss. This is unexpected.")
-            case CacheGet.Error() as error:
-                _logger.error(f"Error creating cache: {error.message}")
+            case CacheGet.Error() as cache_get_error:
+                _logger.error(f"Error creating cache: {cache_get_error.message}")
             case _:
                 _logger.error("Unreachable")
     _print_end_banner()

--- a/examples/py310/example.py
+++ b/examples/py310/example.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -69,8 +69,8 @@ async def main() -> None:
         match set_response:
             case CacheSet.Success():
                 pass
-            case CacheSet.Error() as error:
-                _logger.error(f"Error creating cache: {error.message}")
+            case CacheSet.Error() as cache_set_error:
+                _logger.error(f"Error creating cache: {cache_set_error.message}")
             case _:
                 _logger.error("Unreachable")
 
@@ -82,8 +82,8 @@ async def main() -> None:
                 _logger.info(f"Looked up Value: {hit.value_string!r}")
             case CacheGet.Miss():
                 _logger.info("Look up resulted in a: miss. This is unexpected.")
-            case CacheGet.Error() as error:
-                _logger.error(f"Error creating cache: {error.message}")
+            case CacheGet.Error() as cache_get_error:
+                _logger.error(f"Error creating cache: {cache_get_error.message}")
             case _:
                 _logger.error("Unreachable")
     _print_end_banner()

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -58,7 +58,9 @@ async def _list_caches(cache_client: CacheClientAsync) -> None:
 async def main() -> None:
     initialize_logging()
     _print_start_banner()
-    async with await CacheClientAsync.create(Configurations.Laptop.v1(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS) as cache_client:
+    async with await CacheClientAsync.create(
+        Configurations.Laptop.v1(), _AUTH_PROVIDER, _ITEM_DEFAULT_TTL_SECONDS
+    ) as cache_client:
         await _create_cache(cache_client, _CACHE_NAME)
         await _list_caches(cache_client)
 

--- a/examples/py310/example_async.py
+++ b/examples/py310/example_async.py
@@ -7,7 +7,7 @@ from example_utils.example_logging import initialize_logging
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _ITEM_DEFAULT_TTL_SECONDS = timedelta(seconds=60)
 _KEY = "MyKey"

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -9,7 +9,7 @@ from typing import Callable, Coroutine, Optional, Tuple, TypeVar
 
 import colorlog  # type: ignore
 import momento.errors
-from hdrh.histogram import HdrHistogram
+from hdrh.histogram import HdrHistogram  # type: ignore[import]
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.logs import initialize_momento_logging
 from momento.responses import (
@@ -223,7 +223,7 @@ class BasicPythonLoadGen:
 
         match result:
             case CacheGet.Hit() | CacheGet.Miss() | CacheSet.Success():
-                return AsyncSetGetResult.SUCCESS, result
+                return AsyncSetGetResult.SUCCESS, result  # type: ignore[return-value]
             case CacheGet.Error() | CacheSet.Error():
                 match result.inner_exception:
                     case momento.errors.InternalServerException() as e:

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -8,8 +8,9 @@ from time import perf_counter_ns
 from typing import Callable, Coroutine, Optional, Tuple, TypeVar
 
 import colorlog  # type: ignore
-import momento.errors
 from hdrh.histogram import HdrHistogram
+
+import momento.errors
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.logs import initialize_momento_logging
 from momento.responses import (

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -8,9 +8,8 @@ from time import perf_counter_ns
 from typing import Callable, Coroutine, Optional, Tuple, TypeVar
 
 import colorlog  # type: ignore
-from hdrh.histogram import HdrHistogram
-
 import momento.errors
+from hdrh.histogram import HdrHistogram
 from momento import CacheClientAsync, Configurations, CredentialProvider
 from momento.logs import initialize_momento_logging
 from momento.responses import (

--- a/examples/py310/example_load_gen.py
+++ b/examples/py310/example_load_gen.py
@@ -75,7 +75,7 @@ class BasicPythonLoadGen:
 
     def __init__(self, options: BasicPythonLoadGenOptions):
         self.logger = logging.getLogger("load-gen")
-        self.auth_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+        self.auth_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
         self.options = options
         self.cache_value = "x" * options.cache_item_payload_bytes
         self.request_interval_ms = options.number_of_concurrent_requests / options.max_requests_per_second * 1000

--- a/examples/py310/quickstart.py
+++ b/examples/py310/quickstart.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     cache_name = "default-cache"
     with CacheClient.create(
         configuration=Configurations.Laptop.v1(),
-        credential_provider=CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+        credential_provider=CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
         default_ttl=timedelta(seconds=60),
     ) as cache_client:
         create_cache_response = cache_client.create_cache(cache_name)

--- a/examples/py310/quickstart.py
+++ b/examples/py310/quickstart.py
@@ -14,14 +14,14 @@ if __name__ == "__main__":
         match create_cache_response:
             case CreateCache.CacheAlreadyExists():
                 print(f"Cache with name: {cache_name} already exists.")
-            case CreateCache.Error() as error:
-                raise error.inner_exception
+            case CreateCache.Error() as create_cache_error:
+                raise create_cache_error.inner_exception
 
         print("Setting Key: foo to Value: FOO")
         set_response = cache_client.set(cache_name, "foo", "FOO")
         match set_response:
-            case CacheSet.Error() as error:
-                raise error.inner_exception
+            case CacheSet.Error() as cache_set_error:
+                raise cache_set_error.inner_exception
 
         print("Getting Key: foo")
         get_response = cache_client.get(cache_name, "foo")
@@ -31,5 +31,5 @@ if __name__ == "__main__":
                 print(f"Looked up Value: {hit.value_string!r}")
             case CacheGet.Miss():
                 print("Look up resulted in a: miss. This is unexpected.")
-            case CacheGet.Error() as error:
-                raise error.inner_exception
+            case CacheGet.Error() as cache_get_error:
+                raise cache_get_error.inner_exception

--- a/examples/py310/readme.py
+++ b/examples/py310/readme.py
@@ -5,7 +5,7 @@ from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
 cache_client = CacheClient(
     Configurations.Laptop.v1(),
-    CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN"),
+    CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
     timedelta(seconds=60)
 )
 

--- a/examples/py310/readme.py
+++ b/examples/py310/readme.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from momento import CacheClient, Configurations, CredentialProvider
-from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
+from momento.responses import CacheGet
 
 cache_client = CacheClient(
     Configurations.Laptop.v1(), CredentialProvider.from_environment_variable("MOMENTO_API_KEY"), timedelta(seconds=60)

--- a/examples/py310/readme.py
+++ b/examples/py310/readme.py
@@ -4,9 +4,7 @@ from momento import CacheClient, Configurations, CredentialProvider
 from momento.responses import CacheGet, CacheSet, CreateCache, ListCaches
 
 cache_client = CacheClient(
-    Configurations.Laptop.v1(),
-    CredentialProvider.from_environment_variable("MOMENTO_API_KEY"),
-    timedelta(seconds=60)
+    Configurations.Laptop.v1(), CredentialProvider.from_environment_variable("MOMENTO_API_KEY"), timedelta(seconds=60)
 )
 
 cache_client.create_cache("cache")

--- a/examples/py310/topic_publish.py
+++ b/examples/py310/topic_publish.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -9,8 +11,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_publish.py
+++ b/examples/py310/topic_publish.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -11,6 +9,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -34,6 +34,7 @@ def main() -> None:
         match response:
             case TopicPublish.Error():
                 print("error: ", response.message)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/py310/topic_publish.py
+++ b/examples/py310/topic_publish.py
@@ -12,7 +12,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicPublish
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-publish-example")
 

--- a/examples/py310/topic_publish.py
+++ b/examples/py310/topic_publish.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -11,6 +9,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_publish_async.py
+++ b/examples/py310/topic_publish_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -12,6 +10,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_publish_async.py
+++ b/examples/py310/topic_publish_async.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -10,8 +12,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_publish_async.py
+++ b/examples/py310/topic_publish_async.py
@@ -13,7 +13,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicPublish
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-publish-example")
 

--- a/examples/py310/topic_publish_async.py
+++ b/examples/py310/topic_publish_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -12,6 +10,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicPublish
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -35,6 +35,7 @@ async def main() -> None:
         match response:
             case TopicPublish.Error():
                 print("error: ", response.message)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/py310/topic_subscribe.py
+++ b/examples/py310/topic_subscribe.py
@@ -12,7 +12,7 @@ from momento import (
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _logger = logging.getLogger("topic-subscribe-example")
 

--- a/examples/py310/topic_subscribe.py
+++ b/examples/py310/topic_subscribe.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -9,8 +11,6 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_subscribe.py
+++ b/examples/py310/topic_subscribe.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -11,6 +9,8 @@ from momento import (
     TopicConfigurations,
 )
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_subscribe.py
+++ b/examples/py310/topic_subscribe.py
@@ -41,7 +41,7 @@ def main() -> None:
                         case TopicSubscriptionItem.Text():
                             print(f"got item as string: {item.value}")
                         case TopicSubscriptionItem.Binary():
-                            print(f"got item as bytes: {item.value}")
+                            print(f"got item as bytes: {item.value!r}")
                         case TopicSubscriptionItem.Error():
                             print(f"got item error: {item.message}")
 

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -62,7 +62,7 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
             case TopicSubscriptionItem.Text():
                 print(f"got item as string: {item.value}")
             case TopicSubscriptionItem.Binary():
-                print(f"got item as bytes: {item.value}")
+                print(f"got item as bytes: {item.value!r}")
             case TopicSubscriptionItem.Error():
                 print("stream closed")
                 print(item.inner_exception.message)

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -14,7 +14,7 @@ from momento import (
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
 
-_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
 _NUM_SUBSCRIBERS = 10
 _logger = logging.getLogger("topic-subscribe-example")

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from example_utils.example_logging import initialize_logging
+
 from momento import (
     CacheClient,
     Configurations,
@@ -11,8 +13,6 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
-
-from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -13,6 +11,8 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"
@@ -33,7 +33,7 @@ async def main() -> None:
     setup_cache()
     _logger.info("hello")
     async with TopicClientAsync(
-            TopicConfigurations.Default.v1().with_max_subscriptions(_NUM_SUBSCRIBERS), _AUTH_PROVIDER
+        TopicConfigurations.Default.v1().with_max_subscriptions(_NUM_SUBSCRIBERS), _AUTH_PROVIDER
     ) as client:
         tasks = []
         for i in range(0, _NUM_SUBSCRIBERS):
@@ -68,6 +68,6 @@ async def poll_subscription(subscription: TopicSubscribe.SubscriptionAsync):
                 print(item.inner_exception.message)
                 return
 
+
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -51,7 +51,7 @@ async def main() -> None:
         try:
             await asyncio.gather(*tasks)
         except SdkException:
-            print(f"got exception")
+            print("got exception")
             for task in tasks:
                 task.cancel()
 

--- a/examples/py310/topic_subscribe_async.py
+++ b/examples/py310/topic_subscribe_async.py
@@ -2,8 +2,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from example_utils.example_logging import initialize_logging
-
 from momento import (
     CacheClient,
     Configurations,
@@ -13,6 +11,8 @@ from momento import (
 )
 from momento.errors import SdkException
 from momento.responses import CreateCache, TopicSubscribe, TopicSubscriptionItem
+
+from example_utils.example_logging import initialize_logging
 
 _AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 _CACHE_NAME = "cache"

--- a/examples/vector-index/README.md
+++ b/examples/vector-index/README.md
@@ -21,5 +21,5 @@ poetry install
 To run the basic Momento Vector Index example
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_TOKEN> poetry run python -m example
+MOMENTO_API_KEY=<YOUR_API_KEY> poetry run python -m example
 ```

--- a/examples/vector-index/example.py
+++ b/examples/vector-index/example.py
@@ -17,7 +17,7 @@ from momento.responses.vector_index import (
 )
 
 VECTOR_INDEX_CONFIGURATION: VectorIndexConfiguration = VectorIndexConfigurations.Default.latest()
-VECTOR_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+VECTOR_AUTH_PROVIDER = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
 
 
 def _print_start_banner() -> None:

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -27,7 +27,7 @@ class CredentialProvider:
         """Reads and parses a Momento auth token stored as an environment variable.
 
         Args:
-            env_var_name (str): Name of the environment variable from which the auth token will be read
+            env_var_name (str): Name of the environment variable from which the API key will be read
             control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
             Defaults to None.
             cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.
@@ -41,10 +41,10 @@ class CredentialProvider:
         Returns:
             CredentialProvider
         """
-        auth_token = os.getenv(env_var_name)
-        if not auth_token:
+        api_key = os.getenv(env_var_name)
+        if not api_key:
             raise RuntimeError(f"Missing required environment variable {env_var_name}")
-        return CredentialProvider.from_string(auth_token, control_endpoint, cache_endpoint, vector_endpoint)
+        return CredentialProvider.from_string(api_key, control_endpoint, cache_endpoint, vector_endpoint)
 
     @staticmethod
     def from_string(
@@ -56,7 +56,7 @@ class CredentialProvider:
         """Reads and parses a Momento auth token.
 
         Args:
-            auth_token (str): the Momento auth token
+            auth_token (str): the Momento API key (previously: auth token)
             control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
             Defaults to None.
             cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -162,7 +162,7 @@ class CacheClient:
             from momento import Configurations, CredentialProvider, CacheClient
 
             configuration = Configurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             ttl_seconds = timedelta(seconds=60)
             client = CacheClient(configuration, credential_provider, ttl_seconds)
         """
@@ -201,7 +201,7 @@ class CacheClient:
             from momento import Configurations, CredentialProvider, CacheClient
 
             configuration = Configurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             ttl_seconds = timedelta(seconds=60)
             eager_connection_timeout = timedelta(seconds=30)
             client = CacheClient.create(configuration, credential_provider, ttl_seconds, eager_connection_timeout)

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -162,7 +162,7 @@ class CacheClientAsync:
             from momento import Configurations, CredentialProvider, CacheClientAsync
 
             configuration = Configurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             ttl_seconds = timedelta(seconds=60)
             client = CacheClientAsync(configuration, credential_provider, ttl_seconds)
         """
@@ -202,7 +202,7 @@ class CacheClientAsync:
             from momento import Configurations, CredentialProvider, CacheClientAsync
 
             configuration = Configurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             ttl_seconds = timedelta(seconds=60)
             eager_connection_timeout = timedelta(seconds=30)
             client = CacheClientAsync.create(configuration, credential_provider, ttl_seconds, eager_connection_timeout)

--- a/src/momento/topic_client.py
+++ b/src/momento/topic_client.py
@@ -50,7 +50,7 @@ class TopicClient:
             from momento import CredentialProvider, TopicClient, TopicConfigurations
 
             configuration = TopicConfigurations.Default.v1()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             client = TopicClient(configuration, credential_provider)
         """
         self._logger = logs.logger

--- a/src/momento/topic_client_async.py
+++ b/src/momento/topic_client_async.py
@@ -50,7 +50,7 @@ class TopicClientAsync:
             from momento import CredentialProvider, TopicClientAsync, TopicConfigurations
 
             configuration = TopicConfigurations.Default.v1()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             client = TopicClientAsync(configuration, credential_provider)
         """
         self._logger = logs.logger

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -94,7 +94,7 @@ class PreviewVectorIndexClient:
             from momento import CredentialProvider, PreviewVectorIndexClient, VectorIndexConfigurations
 
             configuration = VectorIndexConfigurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             client = PreviewVectorIndexClient(configuration, credential_provider)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -92,7 +92,7 @@ class PreviewVectorIndexClientAsync:
             from momento import CredentialProvider, PreviewVectorIndexClientAsync, VectorIndexConfigurations
 
             configuration = VectorIndexConfigurations.Laptop.latest()
-            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_AUTH_TOKEN")
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
             client = PreviewVectorIndexClientAsync(configuration, credential_provider)
         """
         _validate_request_timeout(configuration.get_transport_strategy().get_grpc_configuration().get_deadline())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,8 @@ TEST_TOPIC_CONFIGURATION = TopicConfigurations.Default.latest()
 TEST_VECTOR_CONFIGURATION: VectorIndexConfiguration = VectorIndexConfigurations.Default.latest()
 
 
-TEST_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
-TEST_VECTOR_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
+TEST_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_API_KEY")
+TEST_VECTOR_AUTH_PROVIDER = CredentialProvider.from_environment_variable("TEST_API_KEY")
 
 
 TEST_CACHE_NAME: Optional[str] = os.getenv("TEST_CACHE_NAME")
@@ -72,7 +72,7 @@ if not TEST_VECTOR_INDEX_NAME:
 TEST_VECTOR_DIMS = 2
 
 DEFAULT_TTL_SECONDS: timedelta = timedelta(seconds=60)
-BAD_AUTH_TOKEN: str = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoiY29udHJvbC5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSIsImMiOiJjYWNoZS5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSJ9.gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy"  # noqa: E501
+BAD_API_KEY: str = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiIsImNwIjoiY29udHJvbC5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSIsImMiOiJjYWNoZS5jZWxsLWFscGhhLWRldi5wcmVwcm9kLmEubW9tZW50b2hxLmNvbSJ9.gdghdjjfjyehhdkkkskskmmls76573jnajhjjjhjdhnndy"  # noqa: E501
 
 
 #############################################
@@ -87,8 +87,8 @@ def credential_provider() -> CredentialProvider:
 
 @pytest.fixture(scope="session")
 def bad_token_credential_provider() -> CredentialProvider:
-    os.environ["BAD_AUTH_TOKEN"] = BAD_AUTH_TOKEN
-    return CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
+    os.environ["BAD_API_KEY"] = BAD_API_KEY
+    return CredentialProvider.from_environment_variable("BAD_API_KEY")
 
 
 @pytest.fixture(scope="session")
@@ -276,7 +276,7 @@ def default_ttl_seconds() -> timedelta:
 
 @pytest.fixture(scope="session")
 def bad_auth_token() -> str:
-    return BAD_AUTH_TOKEN
+    return BAD_API_KEY
 
 
 @pytest.fixture(scope="session")

--- a/tests/momento/cache_client/test_control.py
+++ b/tests/momento/cache_client/test_control.py
@@ -205,7 +205,7 @@ def test_list_caches_throws_authentication_exception_for_bad_token(
 
 
 def test_list_caches_succeeds_even_if_cred_provider_has_been_printed() -> None:
-    creds_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
+    creds_provider = CredentialProvider.from_environment_variable("TEST_API_KEY")
     print(f"Printing creds provider to ensure that it does not corrupt it :) : {creds_provider}")
     with CacheClient(Configurations.Laptop.v1(), creds_provider, timedelta(seconds=60)) as client:
         response = client.list_caches()

--- a/tests/momento/cache_client/test_control_async.py
+++ b/tests/momento/cache_client/test_control_async.py
@@ -209,7 +209,7 @@ async def test_list_caches_throws_authentication_exception_for_bad_token(
 
 
 async def test_list_caches_succeeds_even_if_cred_provider_has_been_printed() -> None:
-    creds_provider = CredentialProvider.from_environment_variable("TEST_AUTH_TOKEN")
+    creds_provider = CredentialProvider.from_environment_variable("TEST_API_KEY")
     print(f"Printing creds provider to ensure that it does not corrupt it :) : {creds_provider}")
     async with CacheClientAsync(Configurations.Laptop.v1(), creds_provider, timedelta(seconds=60)) as client:
         response = await client.list_caches()

--- a/tests/momento/cache_client/test_init.py
+++ b/tests/momento/cache_client/test_init.py
@@ -18,8 +18,8 @@ def test_init_throws_exception_when_client_uses_negative_default_ttl(
 
 def test_init_throws_exception_for_non_jwt_token(configuration: Configuration, default_ttl_seconds: timedelta) -> None:
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
-        os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
-        credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
+        os.environ["BAD_API_KEY"] = "notanauthtoken"
+        credential_provider = CredentialProvider.from_environment_variable("BAD_API_KEY")
         CacheClient(configuration, credential_provider, default_ttl_seconds)
 
 

--- a/tests/momento/cache_client/test_init_async.py
+++ b/tests/momento/cache_client/test_init_async.py
@@ -20,8 +20,8 @@ async def test_init_throws_exception_for_non_jwt_token(
     configuration: Configuration, default_ttl_seconds: timedelta
 ) -> None:
     with pytest.raises(InvalidArgumentException, match="Invalid Auth token."):
-        os.environ["BAD_AUTH_TOKEN"] = "notanauthtoken"
-        credential_provider = CredentialProvider.from_environment_variable("BAD_AUTH_TOKEN")
+        os.environ["BAD_API_KEY"] = "notanauthtoken"
+        credential_provider = CredentialProvider.from_environment_variable("BAD_API_KEY")
         CacheClientAsync(configuration, credential_provider, default_ttl_seconds)
 
 


### PR DESCRIPTION
We have settled on the terminology "API_KEY" instead of
"AUTH_TOKEN". This updates the examples, documentation, and workflows
to use that. An exception are the tests which are internal.

Over the course of this refactor, linting and formatting failed for the examples, so I have corrected errors as well.