### PR TITLE
chore: expand test matrix to include python 3.12

### DIFF
--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         new-python-protobuf: ["true"]
         include:
           - python-version: "3.7"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         new-python-protobuf: ["true"]
         include:
           - python-version: "3.7"
@@ -80,6 +80,8 @@ jobs:
           - python-version: "3.10"
             package: py310
           - python-version: "3.11"
+            package: py310
+          - python-version: "3.12"
             package: py310
 
     env:

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         new-python-protobuf: ["true"]
         include:
           - python-version: "3.7"

--- a/examples/poetry.lock
+++ b/examples/poetry.lock
@@ -566,5 +566,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<3.12"
-content-hash = "555ec56ce9febe47a470212e97c546ba2339be893a7eeb7f1959a9f78fd2ca49"
+python-versions = "^3.7"
+content-hash = "86eb667150d34dffe9d21e710d864b6cde0b9a4788463882c3e8fd16e6a19553"

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Momento <hello@momentohq.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = "^3.7"
 
 momento = "1.10.0"
 colorlog = "6.7.0"


### PR DESCRIPTION
Python 3.12 was released in October of this year. We add that to the test matrix to ensure coverage and allow this version on the examples.