### PR TITLE
fix: validate vector index item metadata on serialization

### DIFF
--- a/src/momento/requests/vector_index/item.py
+++ b/src/momento/requests/vector_index/item.py
@@ -29,7 +29,7 @@ class Item:
             for k, v in self.metadata.items():
                 if type(v) is not str:
                     raise InvalidArgumentException(
-                        f"Metadata values must be strings. Field {k!r} has a value of type {type(v)!r} with value {v!r}.",
+                        f"Metadata values must be strings. Field {k!r} has a value of type {type(v)!r} with value {v!r}.",  # noqa: E501
                         Service.INDEX,
                     )
                 metadata.append(pb._Metadata(field=k, string_value=v))

--- a/src/momento/requests/vector_index/item.py
+++ b/src/momento/requests/vector_index/item.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass, field
 
 from momento_wire_types import vectorindex_pb2 as pb
 
+from momento.errors.exceptions import InvalidArgumentException
+from momento.internal.services import Service
+
 
 # TODO: support other datatypes for the vector (np.array, pd.Series, etc.)
 @dataclass
@@ -21,9 +24,14 @@ class Item:
 
     def to_proto(self) -> pb._Item:
         vector = pb._Vector(elements=self.vector)
-        metadata = (
-            [pb._Metadata(field=k, string_value=v) for k, v in self.metadata.items()]
-            if self.metadata is not None
-            else []
-        )
+        metadata = []
+        if self.metadata is not None:
+            for k, v in self.metadata.items():
+                if type(v) is not str:
+                    raise InvalidArgumentException(
+                        f"Metadata values must be strings. Field {k!r} has a value of type {type(v)!r} with value {v!r}.",
+                        Service.INDEX,
+                    )
+                metadata.append(pb._Metadata(field=k, string_value=v))
+
         return pb._Item(id=self.id, vector=vector, metadata=metadata)

--- a/tests/momento/requests/vector_index/test_item.py
+++ b/tests/momento/requests/vector_index/test_item.py
@@ -20,7 +20,7 @@ def test_serialize_item_with_bad_metadata() -> None:
     assert exc_info.value.service == Service.INDEX
     assert (
         exc_info.value.message
-        == "Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+        == "Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."  # noqa: E501 W503
     )
 
 
@@ -31,5 +31,5 @@ def test_serialize_item_with_null_metadata() -> None:
     assert exc_info.value.service == Service.INDEX
     assert (
         exc_info.value.message
-        == "Metadata values must be strings. Field 'key' has a value of type <class 'NoneType'> with value None."
+        == "Metadata values must be strings. Field 'key' has a value of type <class 'NoneType'> with value None."  # noqa: E501 W503
     )

--- a/tests/momento/requests/vector_index/test_item.py
+++ b/tests/momento/requests/vector_index/test_item.py
@@ -1,0 +1,35 @@
+import pytest
+
+from momento.errors.exceptions import InvalidArgumentException
+from momento.internal.services import Service
+from momento.requests.vector_index import Item
+
+
+def test_serialize_item_with_string_metadata() -> None:
+    item = Item(id="id", vector=[1, 2, 3], metadata={"key": "value"}).to_proto()
+    assert item.id == "id"
+    assert item.vector.elements == [1, 2, 3]
+    assert item.metadata[0].field == "key"
+    assert item.metadata[0].string_value == "value"
+
+
+def test_serialize_item_with_bad_metadata() -> None:
+    with pytest.raises(InvalidArgumentException) as exc_info:
+        Item(id="id", vector=[1, 2, 3], metadata={"key": 1}).to_proto()  # type: ignore
+
+    assert exc_info.value.service == Service.INDEX
+    assert (
+        exc_info.value.message
+        == "Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+    )
+
+
+def test_serialize_item_with_null_metadata() -> None:
+    with pytest.raises(InvalidArgumentException) as exc_info:
+        Item(id="id", vector=[1, 2, 3], metadata={"key": None}).to_proto()  # type: ignore
+
+    assert exc_info.value.service == Service.INDEX
+    assert (
+        exc_info.value.message
+        == "Metadata values must be strings. Field 'key' has a value of type <class 'NoneType'> with value None."
+    )

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -216,6 +216,18 @@ def test_upsert_and_search_with_metadata_happy_path(
     ]
 
 
+def test_upsert_with_bad_metadata(vector_index_client: PreviewVectorIndexClient) -> None:
+    response = vector_index_client.upsert_item_batch(
+        index_name="test_index", items=[Item(id="test_item", vector=[1.0, 2.0], metadata={"key": 1})]  # type: ignore
+    )
+    assert isinstance(response, UpsertItemBatch.Error)
+    assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    assert (
+        response.message
+        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+    )
+
+
 def test_upsert_and_search_with_all_metadata_happy_path(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -224,7 +224,7 @@ def test_upsert_with_bad_metadata(vector_index_client: PreviewVectorIndexClient)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert (
         response.message
-        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."  # noqa: E501 W503
     )
 
 

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -220,6 +220,18 @@ async def test_upsert_and_search_with_metadata_happy_path(
     ]
 
 
+async def test_upsert_with_bad_metadata(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
+    response = await vector_index_client_async.upsert_item_batch(
+        index_name="test_index", items=[Item(id="test_item", vector=[1.0, 2.0], metadata={"key": 1})]  # type: ignore
+    )
+    assert isinstance(response, UpsertItemBatch.Error)
+    assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    assert (
+        response.message
+        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+    )
+
+
 async def test_upsert_and_search_with_all_metadata_happy_path(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -228,7 +228,7 @@ async def test_upsert_with_bad_metadata(vector_index_client_async: PreviewVector
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert (
         response.message
-        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."
+        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."  # noqa: E501 W503
     )
 
 


### PR DESCRIPTION
Previously the SDK gave a vague error for bad input data. Current
metadata only supports string-valued items. When a user passed a (for
example) integer they would get an error of type "UNKNOWN" with detail
"SDK encountered an error".

This commit checks the metadata types upon serialization and generates
a nice, readable message and remediation.

A more comprehensive solution would involve using dynamic type checking
across the board such as with the pydantic library.