### PR TITLE
feat: support more vector item metadata value types

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -271,13 +271,13 @@ files = [
 
 [[package]]
 name = "momento-wire-types"
-version = "0.84.0"
+version = "0.86.0"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.84.0-py3-none-any.whl", hash = "sha256:c2f8980213c3b36e5299b220a39efd589ff8dfc75ac81bd01473ff6445f09109"},
-    {file = "momento_wire_types-0.84.0.tar.gz", hash = "sha256:64d5a569ecd71f9618f47c224f1f77c5fc66585204bc0c68997195bf03ff4493"},
+    {file = "momento_wire_types-0.86.0-py3-none-any.whl", hash = "sha256:1079f61f3a0aa90865870b116a8699289e6f03b969a349265abdd605b073251c"},
+    {file = "momento_wire_types-0.86.0.tar.gz", hash = "sha256:7695a448382fbfda8ad7a51c307b34a2ef3d81d883f77b71891c27a4c25aed18"},
 ]
 
 [package.dependencies]
@@ -756,4 +756,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b784750ec39153f1a92cc75991cc6db156a8abdcbde1c2c92b98ddb55396deea"
+content-hash = "eb46485d13ae5fdc7ee9d429d75b19b471cde9646ec08378fbc997b7c14dd78a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ module = [
   "momento.internal.aio._vector_index_grpc_manager",
   "momento.internal.aio._utilities",
   "momento.responses.control.signing_key.*",
+  "momento.responses.vector_index.data.search",
 ]
 disallow_any_expr           = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.84.0"
+momento-wire-types = "^0.86.0"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/requests/vector_index/item.py
+++ b/src/momento/requests/vector_index/item.py
@@ -19,7 +19,7 @@ class Item:
     vector: list[float]
     """The vector of the item."""
 
-    metadata: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str | int | float | bool | list[str]] = field(default_factory=dict)
     """The metadata of the item."""
 
     def to_proto(self) -> pb._Item:
@@ -27,11 +27,21 @@ class Item:
         metadata = []
         if self.metadata is not None:
             for k, v in self.metadata.items():
-                if type(v) is not str:
+                if type(v) == str:
+                    metadata.append(pb._Metadata(field=k, string_value=v))
+                elif type(v) == int:
+                    metadata.append(pb._Metadata(field=k, integer_value=v))
+                elif type(v) == float:
+                    metadata.append(pb._Metadata(field=k, double_value=v))
+                elif type(v) == bool:
+                    metadata.append(pb._Metadata(field=k, boolean_value=v))
+                elif type(v) == list and all(type(x) == str for x in v):
+                    list_of_strings = pb._Metadata._ListOfStrings(values=v)
+                    metadata.append(pb._Metadata(field=k, list_of_strings_value=list_of_strings))
+                else:
                     raise InvalidArgumentException(
-                        f"Metadata values must be strings. Field {k!r} has a value of type {type(v)!r} with value {v!r}.",  # noqa: E501
+                        f"Metadata values must be either str, int, float, bool, or list[str]. Field {k!r} has a value of type {type(v)!r} with value {v!r}.",  # noqa: E501
                         Service.INDEX,
                     )
-                metadata.append(pb._Metadata(field=k, string_value=v))
 
         return pb._Item(id=self.id, vector=vector, metadata=metadata)

--- a/src/momento/responses/vector_index/data/search.py
+++ b/src/momento/responses/vector_index/data/search.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 
 from momento_wire_types import vectorindex_pb2 as vectorindex_pb
 
+from momento.errors import UnknownException
+
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse
 
@@ -24,15 +26,27 @@ class SearchResponse(VectorIndexResponse):
 class SearchHit:
     id: str
     distance: float
-    metadata: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str | int | float | bool | list[str]] = field(default_factory=dict)
 
     @staticmethod
     def from_proto(hit: vectorindex_pb._SearchHit) -> SearchHit:
-        metadata = {  # type: ignore
-            item.field: item.string_value  # type: ignore
-            for item in hit.metadata  # type: ignore
-        }
-        return SearchHit(id=hit.id, distance=hit.distance, metadata=metadata)  # type: ignore
+        metadata = {}
+        for item in hit.metadata:
+            type = item.WhichOneof("value")
+            field = item.field
+            if type == "string_value":
+                metadata[field] = item.string_value
+            elif type == "integer_value":
+                metadata[field] = item.integer_value
+            elif type == "double_value":
+                metadata[field] = item.double_value
+            elif type == "boolean_value":
+                metadata[field] = item.boolean_value
+            elif type == "list_of_strings_value":
+                metadata[field] = item.list_of_strings_value.values
+            else:
+                raise UnknownException(f"Unknown metadata value: {type}")
+        return SearchHit(id=hit.id, distance=hit.distance, metadata=metadata)
 
 
 class Search(ABC):

--- a/tests/momento/requests/vector_index/test_item.py
+++ b/tests/momento/requests/vector_index/test_item.py
@@ -30,7 +30,7 @@ def test_serialize_item_with_diverse_metadata() -> None:
     assert item.metadata[2].double_value == 3.14
 
     assert item.metadata[3].field == "bool_key"
-    assert item.metadata[3].boolean_value == True
+    assert item.metadata[3].boolean_value is True
 
     assert item.metadata[4].field == "list_of_strings_key"
     assert item.metadata[4].list_of_strings_value.values == ["one", "two"]

--- a/tests/momento/requests/vector_index/test_item.py
+++ b/tests/momento/requests/vector_index/test_item.py
@@ -5,22 +5,45 @@ from momento.internal.services import Service
 from momento.requests.vector_index import Item
 
 
-def test_serialize_item_with_string_metadata() -> None:
-    item = Item(id="id", vector=[1, 2, 3], metadata={"key": "value"}).to_proto()
+def test_serialize_item_with_diverse_metadata() -> None:
+    item = Item(
+        id="id",
+        vector=[1, 2, 3],
+        metadata={
+            "string_key": "value",
+            "int_key": 1,
+            "double_key": 3.14,
+            "bool_key": True,
+            "list_of_strings_key": ["one", "two"],
+        },
+    ).to_proto()
     assert item.id == "id"
     assert item.vector.elements == [1, 2, 3]
-    assert item.metadata[0].field == "key"
+
+    assert item.metadata[0].field == "string_key"
     assert item.metadata[0].string_value == "value"
+
+    assert item.metadata[1].field == "int_key"
+    assert item.metadata[1].integer_value == 1
+
+    assert item.metadata[2].field == "double_key"
+    assert item.metadata[2].double_value == 3.14
+
+    assert item.metadata[3].field == "bool_key"
+    assert item.metadata[3].boolean_value == True
+
+    assert item.metadata[4].field == "list_of_strings_key"
+    assert item.metadata[4].list_of_strings_value.values == ["one", "two"]
 
 
 def test_serialize_item_with_bad_metadata() -> None:
     with pytest.raises(InvalidArgumentException) as exc_info:
-        Item(id="id", vector=[1, 2, 3], metadata={"key": 1}).to_proto()  # type: ignore
+        Item(id="id", vector=[1, 2, 3], metadata={"key": {"nested_key": "nested_value"}}).to_proto()  # type: ignore
 
     assert exc_info.value.service == Service.INDEX
     assert (
         exc_info.value.message
-        == "Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."  # noqa: E501 W503
+        == "Metadata values must be either str, int, float, bool, or list[str]. Field 'key' has a value of type <class 'dict'> with value {'nested_key': 'nested_value'}."  # noqa: E501 W503
     )
 
 
@@ -31,5 +54,5 @@ def test_serialize_item_with_null_metadata() -> None:
     assert exc_info.value.service == Service.INDEX
     assert (
         exc_info.value.message
-        == "Metadata values must be strings. Field 'key' has a value of type <class 'NoneType'> with value None."  # noqa: E501 W503
+        == "Metadata values must be either str, int, float, bool, or list[str]. Field 'key' has a value of type <class 'NoneType'> with value None."  # noqa: E501 W503
     )

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from momento import PreviewVectorIndexClientAsync
 from momento.errors import MomentoErrorCode
 from momento.requests.vector_index import ALL_METADATA, Item, SimilarityMetric
@@ -222,13 +224,14 @@ async def test_upsert_and_search_with_metadata_happy_path(
 
 async def test_upsert_with_bad_metadata(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
     response = await vector_index_client_async.upsert_item_batch(
-        index_name="test_index", items=[Item(id="test_item", vector=[1.0, 2.0], metadata={"key": 1})]  # type: ignore
+        index_name="test_index",
+        items=[Item(id="test_item", vector=[1.0, 2.0], metadata={"key": {"subkey": "subvalue"}})],  # type: ignore
     )
     assert isinstance(response, UpsertItemBatch.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert (
         response.message
-        == "Invalid argument passed to Momento client: Metadata values must be strings. Field 'key' has a value of type <class 'int'> with value 1."  # noqa: E501 W503
+        == "Invalid argument passed to Momento client: Metadata values must be either str, int, float, bool, or list[str]. Field 'key' has a value of type <class 'dict'> with value {'subkey': 'subvalue'}."  # noqa: E501 W503
     )
 
 
@@ -274,6 +277,49 @@ async def test_upsert_and_search_with_all_metadata_happy_path(
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3", "key3": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={"key2": "value2"}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
+    ]
+
+
+async def test_upsert_and_search_with_diverse_metadata_happy_path(
+    vector_index_client_async: PreviewVectorIndexClientAsync,
+    unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+) -> None:
+    index_name = unique_vector_index_name_async(vector_index_client_async)
+    create_response = await vector_index_client_async.create_index(
+        index_name, num_dimensions=2, similarity_metric=SimilarityMetric.INNER_PRODUCT
+    )
+    assert isinstance(create_response, CreateIndex.Success)
+
+    metadata: dict[str, str | bool | int | float | list[str]] = {
+        "string": "value",
+        "bool": True,
+        "int": 1,
+        "float": 3.14,
+        "list": ["a", "b", "c"],
+        "empty_list": [],
+    }
+    upsert_response = await vector_index_client_async.upsert_item_batch(
+        index_name,
+        items=[
+            Item(id="test_item_1", vector=[1.0, 2.0], metadata=metadata),
+        ],
+    )
+    assert isinstance(upsert_response, UpsertItemBatch.Success)
+
+    await sleep_async(2)
+
+    search_response = await vector_index_client_async.search(
+        index_name, query_vector=[1.0, 2.0], top_k=1, metadata_fields=ALL_METADATA
+    )
+    assert isinstance(search_response, Search.Success)
+    assert len(search_response.hits) == 1
+
+    assert search_response.hits == [
+        SearchHit(
+            id="test_item_1",
+            metadata=metadata,
+            distance=5.0,
+        ),
     ]
 
 


### PR DESCRIPTION
In the previous version of the service, we only supported
string-valued metadata. In the latest version, we support the
following value types:

- string
- int
- float
- bool
- list of strings

We update the `Item` class to support serializing these types and the
`SearchHit` class to deserialize.