### PR TITLE
feat: allow custom root certificates in vector index client config

### DIFF
--- a/src/momento/config/transport/grpc_configuration.py
+++ b/src/momento/config/transport/grpc_configuration.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
+from pathlib import Path
+from typing import Optional
 
 
 class GrpcConfiguration(ABC):
@@ -11,4 +13,12 @@ class GrpcConfiguration(ABC):
 
     @abstractmethod
     def with_deadline(self, deadline: timedelta) -> GrpcConfiguration:
+        pass
+
+    @abstractmethod
+    def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> GrpcConfiguration:
+        pass
+
+    @abstractmethod
+    def get_root_certificates_pem(self) -> Optional[bytes]:
         pass

--- a/src/momento/config/transport/transport_strategy.py
+++ b/src/momento/config/transport/transport_strategy.py
@@ -64,6 +64,8 @@ class StaticGrpcConfiguration(GrpcConfiguration):
             root_certificates_pem_bytes = root_certificates_pem_path.read_bytes()
         except FileNotFoundError:
             raise FileNotFoundError(f"Root certificate file not found at path: {root_certificates_pem_path}")
+        except PermissionError:
+            raise PermissionError(f"Root certificate file not readable at path: {root_certificates_pem_path}")
         return StaticGrpcConfiguration(self._deadline, root_certificates_pem_bytes)
 
     def get_root_certificates_pem(self) -> Optional[bytes]:

--- a/src/momento/config/transport/transport_strategy.py
+++ b/src/momento/config/transport/transport_strategy.py
@@ -48,9 +48,6 @@ class TransportStrategy(ABC):
 
 
 class StaticGrpcConfiguration(GrpcConfiguration):
-    _deadline: timedelta
-    _root_certificates_pem: Optional[bytes]
-
     def __init__(self, deadline: timedelta, root_certificates_pem: Optional[bytes] = None):
         self._deadline = deadline
         self._root_certificates_pem = root_certificates_pem

--- a/src/momento/config/vector_index_configuration.py
+++ b/src/momento/config/vector_index_configuration.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from pathlib import Path
 
-from momento.config import transport
-
 from .transport.transport_strategy import TransportStrategy
 
 

--- a/src/momento/config/vector_index_configuration.py
+++ b/src/momento/config/vector_index_configuration.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from momento.config import transport
 
 from .transport.transport_strategy import TransportStrategy
-from momento.config.transport import transport_strategy
 
 
 class VectorIndexConfigurationBase(ABC):

--- a/src/momento/config/vector_index_configuration.py
+++ b/src/momento/config/vector_index_configuration.py
@@ -67,7 +67,7 @@ class VectorIndexConfiguration(VectorIndexConfigurationBase):
         """
         return VectorIndexConfiguration(self._transport_strategy.with_client_timeout(client_timeout))
 
-    def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> VectorIndexConfigurationBase:
+    def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> VectorIndexConfiguration:
         """Copies the Configuration and sets the new root certificates in the copy's TransportStrategy.
 
         Args:

--- a/src/momento/config/vector_index_configuration.py
+++ b/src/momento/config/vector_index_configuration.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
+from pathlib import Path
+
+from momento.config import transport
 
 from .transport.transport_strategy import TransportStrategy
+from momento.config.transport import transport_strategy
 
 
 class VectorIndexConfigurationBase(ABC):
@@ -17,6 +21,10 @@ class VectorIndexConfigurationBase(ABC):
 
     @abstractmethod
     def with_client_timeout(self, client_timeout: timedelta) -> VectorIndexConfigurationBase:
+        pass
+
+    @abstractmethod
+    def with_root_certificates_pem(self, root_certificate_path: Path) -> VectorIndexConfigurationBase:
         pass
 
 
@@ -61,3 +69,18 @@ class VectorIndexConfiguration(VectorIndexConfigurationBase):
             Configuration: the new Configuration.
         """
         return VectorIndexConfiguration(self._transport_strategy.with_client_timeout(client_timeout))
+
+    def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> VectorIndexConfigurationBase:
+        """Copies the Configuration and sets the new root certificates in the copy's TransportStrategy.
+
+        Args:
+            root_certificates_pem_path (Path): the new root certificates.
+
+        Returns:
+            VectorIndexConfigurationBase: the new Configuration.
+        """
+        grpc_configuration = self._transport_strategy.get_grpc_configuration().with_root_certificates_pem(
+            root_certificates_pem_path
+        )
+        transport_strategy = self._transport_strategy.with_grpc_configuration(grpc_configuration)
+        return self.with_transport_strategy(transport_strategy)

--- a/src/momento/internal/_utilities/_channel_credentials.py
+++ b/src/momento/internal/_utilities/_channel_credentials.py
@@ -1,0 +1,24 @@
+"""Helper functions for creating gRPC channel credentials.
+
+Note that this isn't in the _utilities init to avoid a circular import.
+"""
+
+import grpc
+
+from momento.config import VectorIndexConfiguration
+
+
+def vector_credentials_from_root_certs_or_default(config: VectorIndexConfiguration) -> grpc.ChannelCredentials:
+    """Create gRPC channel credentials from the root certificates or the default credentials.
+
+    Args:
+        config (VectorIndexConfiguration): the configuration to use.
+
+    Returns:
+        grpc.ChannelCredentials: the gRPC channel credentials.
+    """
+    root_certificates_pem = config.get_transport_strategy().get_grpc_configuration().get_root_certificates_pem()
+    if root_certificates_pem is None:
+        return grpc.ssl_channel_credentials()  # type: ignore[misc]
+    else:
+        return grpc.ssl_channel_credentials(root_certificates_pem)  # type: ignore[misc]

--- a/src/momento/internal/_utilities/_channel_credentials.py
+++ b/src/momento/internal/_utilities/_channel_credentials.py
@@ -17,8 +17,5 @@ def vector_credentials_from_root_certs_or_default(config: VectorIndexConfigurati
     Returns:
         grpc.ChannelCredentials: the gRPC channel credentials.
     """
-    root_certificates_pem = config.get_transport_strategy().get_grpc_configuration().get_root_certificates_pem()
-    if root_certificates_pem is None:
-        return grpc.ssl_channel_credentials()  # type: ignore[misc]
-    else:
-        return grpc.ssl_channel_credentials(root_certificates_pem)  # type: ignore[misc]
+    root_certificates = config.get_transport_strategy().get_grpc_configuration().get_root_certificates_pem()
+    return grpc.ssl_channel_credentials(root_certificates=root_certificates)  # type: ignore[misc]

--- a/src/momento/internal/aio/_vector_index_control_client.py
+++ b/src/momento/internal/aio/_vector_index_control_client.py
@@ -7,6 +7,7 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import InvalidArgumentException, convert_error
 from momento.internal._utilities import _validate_index_name, _validate_num_dimensions
+
 from momento.internal.aio._vector_index_grpc_manager import (
     _VectorIndexControlGrpcManager,
 )

--- a/src/momento/internal/aio/_vector_index_control_client.py
+++ b/src/momento/internal/aio/_vector_index_control_client.py
@@ -7,7 +7,6 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import InvalidArgumentException, convert_error
 from momento.internal._utilities import _validate_index_name, _validate_num_dimensions
-
 from momento.internal.aio._vector_index_grpc_manager import (
     _VectorIndexControlGrpcManager,
 )

--- a/src/momento/internal/aio/_vector_index_grpc_manager.py
+++ b/src/momento/internal/aio/_vector_index_grpc_manager.py
@@ -7,7 +7,9 @@ from momento_wire_types import vectorindex_pb2_grpc as vector_index_client
 from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
-from momento.internal._utilities._channel_credentials import vector_credentials_from_root_certs_or_default
+from momento.internal._utilities._channel_credentials import (
+    vector_credentials_from_root_certs_or_default,
+)
 
 from ._add_header_client_interceptor import AddHeaderClientInterceptor, Header
 

--- a/src/momento/internal/aio/_vector_index_grpc_manager.py
+++ b/src/momento/internal/aio/_vector_index_grpc_manager.py
@@ -7,6 +7,7 @@ from momento_wire_types import vectorindex_pb2_grpc as vector_index_client
 from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
+from momento.internal._utilities._channel_credentials import vector_credentials_from_root_certs_or_default
 
 from ._add_header_client_interceptor import AddHeaderClientInterceptor, Header
 
@@ -19,7 +20,7 @@ class _VectorIndexControlGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
             target=credential_provider.control_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=vector_credentials_from_root_certs_or_default(configuration),
             interceptors=_interceptors(credential_provider.auth_token),
         )
 
@@ -38,7 +39,7 @@ class _VectorIndexDataGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
             target=credential_provider.vector_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=vector_credentials_from_root_certs_or_default(configuration),
             interceptors=_interceptors(credential_provider.auth_token),
         )
 

--- a/src/momento/internal/synchronous/_vector_index_grpc_manager.py
+++ b/src/momento/internal/synchronous/_vector_index_grpc_manager.py
@@ -7,6 +7,7 @@ from momento_wire_types import vectorindex_pb2_grpc as vector_index_client
 from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
+from momento.internal._utilities._channel_credentials import vector_credentials_from_root_certs_or_default
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     Header,
@@ -21,7 +22,7 @@ class _VectorIndexControlGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.control_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=vector_credentials_from_root_certs_or_default(configuration),
         )
         intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = control_client.ScsControlStub(intercept_channel)  # type: ignore[no-untyped-call]
@@ -41,7 +42,7 @@ class _VectorIndexDataGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.vector_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=vector_credentials_from_root_certs_or_default(configuration),
         )
         intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = vector_index_client.VectorIndexStub(intercept_channel)  # type: ignore[no-untyped-call]

--- a/src/momento/internal/synchronous/_vector_index_grpc_manager.py
+++ b/src/momento/internal/synchronous/_vector_index_grpc_manager.py
@@ -7,7 +7,9 @@ from momento_wire_types import vectorindex_pb2_grpc as vector_index_client
 from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
-from momento.internal._utilities._channel_credentials import vector_credentials_from_root_certs_or_default
+from momento.internal._utilities._channel_credentials import (
+    vector_credentials_from_root_certs_or_default,
+)
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     Header,

--- a/tests/momento/config/test_vector_index_config.py
+++ b/tests/momento/config/test_vector_index_config.py
@@ -1,15 +1,16 @@
+from pathlib import Path
+
+import pytest
+
 from momento import (
-    VectorIndexConfigurations,
+    CredentialProvider,
     PreviewVectorIndexClient,
     PreviewVectorIndexClientAsync,
-    CredentialProvider,
+    VectorIndexConfigurations,
 )
 from momento.config import VectorIndexConfiguration
 from momento.errors.error_details import MomentoErrorCode
 from momento.responses.vector_index import ListIndexes, Search
-from pathlib import Path
-
-import pytest
 
 
 def test_missing_root_cert() -> None:

--- a/tests/momento/config/test_vector_index_config.py
+++ b/tests/momento/config/test_vector_index_config.py
@@ -1,0 +1,12 @@
+from momento.config import VectorIndexConfigurations
+from pathlib import Path
+
+import pytest
+
+
+def test_bad_root_cert() -> None:
+    path = Path("bad")
+    with pytest.raises(FileNotFoundError) as e:
+        VectorIndexConfigurations.Default.latest().with_root_certificates_pem(path)
+
+    assert f"Root certificate file not found at path: {path}" in str(e.value)

--- a/tests/momento/config/test_vector_index_config.py
+++ b/tests/momento/config/test_vector_index_config.py
@@ -1,12 +1,62 @@
-from momento.config import VectorIndexConfigurations
+from momento import (
+    VectorIndexConfigurations,
+    PreviewVectorIndexClient,
+    PreviewVectorIndexClientAsync,
+    CredentialProvider,
+)
+from momento.config import VectorIndexConfiguration
+from momento.errors.error_details import MomentoErrorCode
+from momento.responses.vector_index import ListIndexes, Search
 from pathlib import Path
 
 import pytest
 
 
-def test_bad_root_cert() -> None:
+def test_missing_root_cert() -> None:
     path = Path("bad")
     with pytest.raises(FileNotFoundError) as e:
         VectorIndexConfigurations.Default.latest().with_root_certificates_pem(path)
 
     assert f"Root certificate file not found at path: {path}" in str(e.value)
+
+
+def test_bad_root_cert(
+    vector_index_configuration: VectorIndexConfiguration, credential_provider: CredentialProvider
+) -> None:
+    root_cert = b"asdfasdf"
+
+    grpc_configuration = vector_index_configuration.get_transport_strategy().get_grpc_configuration()
+    grpc_configuration._root_certificates_pem = root_cert  # type: ignore[attr-defined]
+    config = vector_index_configuration.with_transport_strategy(
+        vector_index_configuration.get_transport_strategy().with_grpc_configuration(grpc_configuration)
+    )
+
+    client = PreviewVectorIndexClient(config, credential_provider)
+    list_indexes_response = client.list_indexes()
+    assert isinstance(list_indexes_response, ListIndexes.Error)
+    assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+    search_response = client.search("asdf", [1, 2])
+    assert isinstance(search_response, Search.Error)
+    assert search_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+
+async def test_bad_root_cert_async(
+    vector_index_configuration: VectorIndexConfiguration, credential_provider: CredentialProvider
+) -> None:
+    root_cert = b"asdfasdf"
+
+    grpc_configuration = vector_index_configuration.get_transport_strategy().get_grpc_configuration()
+    grpc_configuration._root_certificates_pem = root_cert  # type: ignore[attr-defined]
+    config = vector_index_configuration.with_transport_strategy(
+        vector_index_configuration.get_transport_strategy().with_grpc_configuration(grpc_configuration)
+    )
+
+    client = PreviewVectorIndexClientAsync(config, credential_provider)
+    list_indexes_response = await client.list_indexes()
+    assert isinstance(list_indexes_response, ListIndexes.Error)
+    assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+    search_response = await client.search("asdf", [1, 2])
+    assert isinstance(search_response, Search.Error)
+    assert search_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE


### PR DESCRIPTION
Adds a `with_root_certificates_pem` to read a certificate pem
file. Exposes a `with_root_certificates_pem` method to the top level
of `VectorIndexConfiguration` for convenience. The clients are
instantiated with either the default ssl channel creds or ones using
the root certificates, if available.
