### PR TITLE
feat: allow custom root certificates in cache client

### DIFF
--- a/src/momento/config/configuration.py
+++ b/src/momento/config/configuration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
+from pathlib import Path
 
 from momento.retry import RetryStrategy
 
@@ -9,7 +10,6 @@ from .transport.transport_strategy import TransportStrategy
 
 
 class ConfigurationBase(ABC):
-
     # TODO: Middlewares
     @abstractmethod
     def get_retry_strategy(self) -> RetryStrategy:
@@ -29,6 +29,10 @@ class ConfigurationBase(ABC):
 
     @abstractmethod
     def with_client_timeout(self, client_timeout: timedelta) -> Configuration:
+        pass
+
+    @abstractmethod
+    def with_root_certificates_pem(self, root_certificate_path: Path) -> Configuration:
         pass
 
 
@@ -94,3 +98,18 @@ class Configuration(ConfigurationBase):
             Configuration: the new Configuration.
         """
         return Configuration(self._transport_strategy.with_client_timeout(client_timeout), self._retry_strategy)
+
+    def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> Configuration:
+        """Copies the Configuration and sets the new root certificates in the copy's TransportStrategy.
+
+        Args:
+            root_certificates_pem_path (Path): the new root certificates.
+
+        Returns:
+            ConfigurationBase: the new Configuration.
+        """
+        grpc_configuration = self._transport_strategy.get_grpc_configuration().with_root_certificates_pem(
+            root_certificates_pem_path
+        )
+        transport_strategy = self._transport_strategy.with_grpc_configuration(grpc_configuration)
+        return self.with_transport_strategy(transport_strategy)

--- a/src/momento/config/transport/transport_strategy.py
+++ b/src/momento/config/transport/transport_strategy.py
@@ -83,4 +83,4 @@ class StaticTransportStrategy(TransportStrategy):
         return StaticTransportStrategy(grpc_configuration)
 
     def with_client_timeout(self, client_timeout: timedelta) -> TransportStrategy:
-        return StaticTransportStrategy(self._grpc_configuration.with_deadline(client_timeout))
+        return self.with_grpc_configuration(self._grpc_configuration.with_deadline(client_timeout))

--- a/src/momento/config/vector_index_configuration.py
+++ b/src/momento/config/vector_index_configuration.py
@@ -65,7 +65,7 @@ class VectorIndexConfiguration(VectorIndexConfigurationBase):
         Return:
             Configuration: the new Configuration.
         """
-        return VectorIndexConfiguration(self._transport_strategy.with_client_timeout(client_timeout))
+        return self.with_transport_strategy(self._transport_strategy.with_client_timeout(client_timeout))
 
     def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> VectorIndexConfiguration:
         """Copies the Configuration and sets the new root certificates in the copy's TransportStrategy.

--- a/src/momento/internal/_utilities/_channel_credentials.py
+++ b/src/momento/internal/_utilities/_channel_credentials.py
@@ -2,17 +2,20 @@
 
 Note that this isn't in the _utilities init to avoid a circular import.
 """
+from __future__ import annotations
 
 import grpc
 
-from momento.config import VectorIndexConfiguration
+from momento.config import Configuration, VectorIndexConfiguration
 
 
-def vector_credentials_from_root_certs_or_default(config: VectorIndexConfiguration) -> grpc.ChannelCredentials:
+def channel_credentials_from_root_certs_or_default(
+    config: Configuration | VectorIndexConfiguration,
+) -> grpc.ChannelCredentials:
     """Create gRPC channel credentials from the root certificates or the default credentials.
 
     Args:
-        config (VectorIndexConfiguration): the configuration to use.
+        config (Configuration): the configuration to use.
 
     Returns:
         grpc.ChannelCredentials: the gRPC channel credentials.

--- a/src/momento/internal/aio/_vector_index_grpc_manager.py
+++ b/src/momento/internal/aio/_vector_index_grpc_manager.py
@@ -8,7 +8,7 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
 from momento.internal._utilities._channel_credentials import (
-    vector_credentials_from_root_certs_or_default,
+    channel_credentials_from_root_certs_or_default,
 )
 
 from ._add_header_client_interceptor import AddHeaderClientInterceptor, Header
@@ -22,7 +22,7 @@ class _VectorIndexControlGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
             target=credential_provider.control_endpoint,
-            credentials=vector_credentials_from_root_certs_or_default(configuration),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
             interceptors=_interceptors(credential_provider.auth_token),
         )
 
@@ -41,7 +41,7 @@ class _VectorIndexDataGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.aio.secure_channel(
             target=credential_provider.vector_endpoint,
-            credentials=vector_credentials_from_root_certs_or_default(configuration),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
             interceptors=_interceptors(credential_provider.auth_token),
         )
 

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -12,6 +12,9 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration, TopicConfiguration
 from momento.internal._utilities import momento_version
+from momento.internal._utilities._channel_credentials import (
+    channel_credentials_from_root_certs_or_default,
+)
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
     AddHeaderStreamingClientInterceptor,
@@ -29,7 +32,7 @@ class _ControlGrpcManager:
     def __init__(self, configuration: Configuration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.control_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
         )
         intercept_channel = grpc.intercept_channel(
             self._secure_channel, *_interceptors(credential_provider.auth_token, configuration.get_retry_strategy())
@@ -52,7 +55,7 @@ class _DataGrpcManager:
         self._logger = logs.logger
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.cache_endpoint,
-            credentials=grpc.ssl_channel_credentials(),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
         )
 
         intercept_channel = grpc.intercept_channel(

--- a/src/momento/internal/synchronous/_vector_index_grpc_manager.py
+++ b/src/momento/internal/synchronous/_vector_index_grpc_manager.py
@@ -8,7 +8,7 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.internal._utilities import momento_version
 from momento.internal._utilities._channel_credentials import (
-    vector_credentials_from_root_certs_or_default,
+    channel_credentials_from_root_certs_or_default,
 )
 from momento.internal.synchronous._add_header_client_interceptor import (
     AddHeaderClientInterceptor,
@@ -24,7 +24,7 @@ class _VectorIndexControlGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.control_endpoint,
-            credentials=vector_credentials_from_root_certs_or_default(configuration),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
         )
         intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = control_client.ScsControlStub(intercept_channel)  # type: ignore[no-untyped-call]
@@ -44,7 +44,7 @@ class _VectorIndexDataGrpcManager:
     def __init__(self, configuration: VectorIndexConfiguration, credential_provider: CredentialProvider):
         self._secure_channel = grpc.secure_channel(
             target=credential_provider.vector_endpoint,
-            credentials=vector_credentials_from_root_certs_or_default(configuration),
+            credentials=channel_credentials_from_root_certs_or_default(configuration),
         )
         intercept_channel = grpc.intercept_channel(self._secure_channel, *_interceptors(credential_provider.auth_token))
         self._stub = vector_index_client.VectorIndexStub(intercept_channel)  # type: ignore[no-untyped-call]

--- a/tests/momento/config/test_config.py
+++ b/tests/momento/config/test_config.py
@@ -1,6 +1,13 @@
 from datetime import timedelta
+from pathlib import Path
 
+import pytest
+
+from momento import CacheClient, CacheClientAsync, Configurations, CredentialProvider
 from momento.config import Configuration
+from momento.config.transport.transport_strategy import StaticGrpcConfiguration
+from momento.errors import MomentoErrorCode
+from momento.responses import CacheGet, ListCaches
 
 
 def test_configuration_client_timeout_copy_constructor(configuration: Configuration) -> None:
@@ -11,3 +18,49 @@ def test_configuration_client_timeout_copy_constructor(configuration: Configurat
     assert original_deadline.total_seconds() == 15
     configuration = configuration.with_client_timeout(timedelta(seconds=600))
     assert snag_deadline(configuration).total_seconds() == 600
+
+
+def _with_root_cert(config: Configuration, root_cert: bytes) -> Configuration:
+    grpc_configuration = StaticGrpcConfiguration(
+        config.get_transport_strategy().get_grpc_configuration().get_deadline(), root_cert
+    )
+    new_config = config.with_transport_strategy(
+        config.get_transport_strategy().with_grpc_configuration(grpc_configuration)
+    )
+    return new_config
+
+
+def test_missing_root_cert() -> None:
+    path = Path("bad")
+    with pytest.raises(FileNotFoundError) as e:
+        Configurations.Laptop.latest().with_root_certificates_pem(path)
+
+    assert f"Root certificate file not found at path: {path}" in str(e.value)
+
+
+def test_bad_root_cert(configuration: Configuration, credential_provider: CredentialProvider) -> None:
+    root_cert = b"asdfasdf"
+
+    config = _with_root_cert(configuration, root_cert)
+    client = CacheClient(config, credential_provider, timedelta(seconds=60))
+    list_indexes_response = client.list_caches()
+    assert isinstance(list_indexes_response, ListCaches.Error)
+    assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+    get_response = client.get("asdf", "key")
+    assert isinstance(get_response, CacheGet.Error)
+    assert get_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+
+async def test_bad_root_cert_async(configuration: Configuration, credential_provider: CredentialProvider) -> None:
+    root_cert = b"asdfasdf"
+
+    config = _with_root_cert(configuration, root_cert)
+    client = CacheClientAsync(config, credential_provider, timedelta(seconds=60))
+    list_indexes_response = await client.list_caches()
+    assert isinstance(list_indexes_response, ListCaches.Error)
+    assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+    get_response = await client.get("asdf", "key")
+    assert isinstance(get_response, CacheGet.Error)
+    assert get_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE

--- a/tests/momento/config/test_config.py
+++ b/tests/momento/config/test_config.py
@@ -8,6 +8,7 @@ from momento.config import Configuration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheGet, ListCaches
+from tests.utils import unique_test_cache_name
 
 
 def test_configuration_client_timeout_copy_constructor(configuration: Configuration) -> None:
@@ -47,7 +48,7 @@ def test_bad_root_cert(configuration: Configuration, credential_provider: Creden
     assert isinstance(list_indexes_response, ListCaches.Error)
     assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
-    get_response = client.get("asdf", "key")
+    get_response = client.get(unique_test_cache_name(), "key")
     assert isinstance(get_response, CacheGet.Error)
     assert get_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
@@ -61,6 +62,34 @@ async def test_bad_root_cert_async(configuration: Configuration, credential_prov
     assert isinstance(list_indexes_response, ListCaches.Error)
     assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
-    get_response = await client.get("asdf", "key")
+    get_response = await client.get(unique_test_cache_name(), "key")
     assert isinstance(get_response, CacheGet.Error)
     assert get_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+
+# def test_good_root_cert(configuration: Configuration, credential_provider: CredentialProvider) -> None:
+#     # On my machine, this is the path to the root certificates pem file that is cached by the grpc library.
+#     root_cert_path = Path("./.venv/lib/python3.11/site-packages/grpc/_cython/_credentials/roots.pem")
+#     config = configuration.with_root_certificates_pem(root_cert_path)
+
+#     client = CacheClient(config, credential_provider, timedelta(seconds=60))
+#     list_indexes_response = client.list_caches()
+#     assert isinstance(list_indexes_response, ListCaches.Success)
+
+#     get_response = client.get(unique_test_cache_name(), "key")
+#     assert isinstance(get_response, CacheGet.Error)
+#     assert get_response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+
+
+# async def test_good_root_cert_async(configuration: Configuration, credential_provider: CredentialProvider) -> None:
+#     # On my machine, this is the path to the root certificates pem file that is cached by the grpc library.
+#     root_cert_path = Path("./.venv/lib/python3.11/site-packages/grpc/_cython/_credentials/roots.pem")
+#     config = configuration.with_root_certificates_pem(root_cert_path)
+
+#     client = CacheClientAsync(config, credential_provider, timedelta(seconds=60))
+#     list_indexes_response = await client.list_caches()
+#     assert isinstance(list_indexes_response, ListCaches.Success)
+
+#     get_response = await client.get(unique_test_cache_name(), "key")
+#     assert isinstance(get_response, CacheGet.Error)
+#     assert get_response.error_code == MomentoErrorCode.NOT_FOUND_ERROR

--- a/tests/momento/config/test_vector_index_config.py
+++ b/tests/momento/config/test_vector_index_config.py
@@ -12,6 +12,7 @@ from momento.config import VectorIndexConfiguration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors.error_details import MomentoErrorCode
 from momento.responses.vector_index import ListIndexes, Search
+from tests.utils import unique_test_vector_index_name
 
 
 def _with_root_cert(config: VectorIndexConfiguration, root_cert: bytes) -> VectorIndexConfiguration:
@@ -43,7 +44,7 @@ def test_bad_root_cert(
     assert isinstance(list_indexes_response, ListIndexes.Error)
     assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
-    search_response = client.search("asdf", [1, 2])
+    search_response = client.search(unique_test_vector_index_name(), [1, 2])
     assert isinstance(search_response, Search.Error)
     assert search_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
@@ -59,6 +60,38 @@ async def test_bad_root_cert_async(
     assert isinstance(list_indexes_response, ListIndexes.Error)
     assert list_indexes_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
 
-    search_response = await client.search("asdf", [1, 2])
+    search_response = await client.search(unique_test_vector_index_name(), [1, 2])
     assert isinstance(search_response, Search.Error)
     assert search_response.error_code == MomentoErrorCode.SERVER_UNAVAILABLE
+
+
+# def test_good_root_cert(
+#     vector_index_configuration: VectorIndexConfiguration, credential_provider: CredentialProvider
+# ) -> None:
+#     # On my machine, this is the path to the root certificates pem file that is cached by the grpc library.
+#     root_cert_path = Path("./.venv/lib/python3.11/site-packages/grpc/_cython/_credentials/roots.pem")
+#     config = vector_index_configuration.with_root_certificates_pem(root_cert_path)
+
+#     client = PreviewVectorIndexClient(config, credential_provider)
+#     list_indexes_response = client.list_indexes()
+#     assert isinstance(list_indexes_response, ListIndexes.Success)
+
+#     search_response = client.search(unique_test_vector_index_name(), [1, 2])
+#     assert isinstance(search_response, Search.Error)
+#     assert search_response.error_code == MomentoErrorCode.NOT_FOUND_ERROR
+
+
+# async def test_good_root_cert_async(
+#     vector_index_configuration: VectorIndexConfiguration, credential_provider: CredentialProvider
+# ) -> None:
+#     # On my machine, this is the path to the root certificates pem file that is cached by the grpc library.
+#     root_cert_path = Path("./.venv/lib/python3.11/site-packages/grpc/_cython/_credentials/roots.pem")
+#     config = vector_index_configuration.with_root_certificates_pem(root_cert_path)
+
+#     client = PreviewVectorIndexClientAsync(config, credential_provider)
+#     list_indexes_response = await client.list_indexes()
+#     assert isinstance(list_indexes_response, ListIndexes.Success)
+
+#     search_response = await client.search(unique_test_vector_index_name(), [1, 2])
+#     assert isinstance(search_response, Search.Error)
+#     assert search_response.error_code == MomentoErrorCode.NOT_FOUND_ERROR


### PR DESCRIPTION
Like the previous PR for the vector client, this adds the ability to
set the root certificate for the cache client. We add methods to the
top level configuration for convenience. Unit and integration tests
exercise the happy and error paths.

The integration tests for the happy path also exercise when a custom root
certificate is added. Because this reuses a cached certs, we
comment out the tests. They serve as documentation to reproduce good
behavior.

A future PR will add this to the topics client.
