### PR TITLE
feat: add mvi search and fetch vectors method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,8 @@ module = [
   "momento.internal.aio._utilities",
   "momento.responses.control.signing_key.*",
   "momento.responses.vector_index.data.search",
+  "momento.responses.vector_index.data.search_and_fetch_vectors",
+  "momento.responses.vector_index.data.utils",
 ]
 disallow_any_expr = false
 

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -19,12 +19,12 @@ from momento.responses.vector_index import (
     DeleteItemBatchResponse,
     Search,
     SearchAndFetchVectors,
-    SearchResponse,
+    SearchAndFetchVectorsHit,
     SearchAndFetchVectorsResponse,
+    SearchHit,
+    SearchResponse,
     UpsertItemBatch,
     UpsertItemBatchResponse,
-    SearchHit,
-    SearchAndFetchVectorsHit,
 )
 
 

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -18,11 +18,14 @@ from momento.responses.vector_index import (
     DeleteItemBatch,
     DeleteItemBatchResponse,
     Search,
+    SearchAndFetchVectors,
     SearchResponse,
+    SearchAndFetchVectorsResponse,
     UpsertItemBatch,
     UpsertItemBatchResponse,
+    SearchHit,
+    SearchAndFetchVectorsHit,
 )
-from momento.responses.vector_index.data.search import SearchHit
 
 
 class _VectorIndexDataClient:
@@ -135,6 +138,53 @@ class _VectorIndexDataClient:
         except Exception as e:
             self._log_request_error("search", e)
             return Search.Error(convert_error(e, Service.INDEX))
+
+    async def search_and_fetch_vectors(
+        self,
+        index_name: str,
+        query_vector: list[float],
+        top_k: int,
+        metadata_fields: Optional[list[str]] | AllMetadata = None,
+        score_threshold: Optional[float] = None,
+    ) -> SearchAndFetchVectorsResponse:
+        try:
+            self._log_issuing_request("SearchAndFetchVectors", {"index_name": index_name})
+            _validate_index_name(index_name)
+            _validate_top_k(top_k)
+
+            query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
+            if isinstance(metadata_fields, AllMetadata):
+                metadata_fields_pb = vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
+            else:
+                metadata_fields_pb = vectorindex_pb._MetadataRequest(
+                    some=vectorindex_pb._MetadataRequest.Some(
+                        fields=metadata_fields if metadata_fields is not None else []
+                    )
+                )
+
+            no_score_threshold = None
+            if score_threshold is None:
+                no_score_threshold = vectorindex_pb._NoScoreThreshold()
+
+            request = vectorindex_pb._SearchAndFetchVectorsRequest(
+                index_name=index_name,
+                query_vector=query_vector_pb,
+                top_k=top_k,
+                metadata_fields=metadata_fields_pb,
+                score_threshold=score_threshold,
+                no_score_threshold=no_score_threshold,
+            )
+
+            response: vectorindex_pb._SearchAndFetchVectorsResponse = await self._build_stub().SearchAndFetchVectors(
+                request, timeout=self._default_deadline_seconds
+            )
+
+            hits = [SearchAndFetchVectorsHit.from_proto(hit) for hit in response.hits]
+            self._log_received_response("SearchAndFetchVectors", {"index_name": index_name})
+            return SearchAndFetchVectors.Success(hits=hits)
+        except Exception as e:
+            self._log_request_error("search_and_fetch_vectors", e)
+            return SearchAndFetchVectors.Error(convert_error(e, Service.INDEX))
 
     # TODO these were copied from the data client. Shouldn't use interpolation here for perf?
     def _log_received_response(self, request_type: str, request_args: dict[str, str]) -> None:

--- a/src/momento/responses/vector_index/__init__.py
+++ b/src/momento/responses/vector_index/__init__.py
@@ -3,6 +3,11 @@ from .control.delete import DeleteIndex, DeleteIndexResponse
 from .control.list import ListIndexes, ListIndexesResponse
 from .data.delete_item_batch import DeleteItemBatch, DeleteItemBatchResponse
 from .data.search import Search, SearchHit, SearchResponse
+from .data.search_and_fetch_vectors import (
+    SearchAndFetchVectors,
+    SearchAndFetchVectorsHit,
+    SearchAndFetchVectorsResponse,
+)
 from .data.upsert_item_batch import UpsertItemBatch, UpsertItemBatchResponse
 from .response import VectorIndexResponse
 
@@ -15,7 +20,9 @@ __all__ = [
     "ListIndexesResponse",
     "SearchHit",
     "Search",
+    "SearchAndFetchVectors",
     "SearchResponse",
+    "SearchAndFetchVectorsResponse",
     "UpsertItemBatch",
     "UpsertItemBatchResponse",
     "DeleteItemBatch",

--- a/src/momento/responses/vector_index/data/search.py
+++ b/src/momento/responses/vector_index/data/search.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 
 from momento_wire_types import vectorindex_pb2 as vectorindex_pb
 
-from momento.errors import UnknownException
-
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse
 from .utils import pb_metadata_to_dict

--- a/src/momento/responses/vector_index/data/search.py
+++ b/src/momento/responses/vector_index/data/search.py
@@ -9,6 +9,7 @@ from momento.errors import UnknownException
 
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse
+from .utils import pb_metadata_to_dict
 
 
 class SearchResponse(VectorIndexResponse):
@@ -30,22 +31,7 @@ class SearchHit:
 
     @staticmethod
     def from_proto(hit: vectorindex_pb._SearchHit) -> SearchHit:
-        metadata = {}
-        for item in hit.metadata:
-            type = item.WhichOneof("value")
-            field = item.field
-            if type == "string_value":
-                metadata[field] = item.string_value
-            elif type == "integer_value":
-                metadata[field] = item.integer_value
-            elif type == "double_value":
-                metadata[field] = item.double_value
-            elif type == "boolean_value":
-                metadata[field] = item.boolean_value
-            elif type == "list_of_strings_value":
-                metadata[field] = item.list_of_strings_value.values
-            else:
-                raise UnknownException(f"Unknown metadata value: {type}")
+        metadata = pb_metadata_to_dict(hit.metadata)
         return SearchHit(id=hit.id, distance=hit.distance, metadata=metadata)
 
 

--- a/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
+++ b/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass, field
+
+from momento_wire_types import vectorindex_pb2 as vectorindex_pb
+
+from momento.errors import UnknownException
+
+from ...mixins import ErrorResponseMixin
+from ..response import VectorIndexResponse
+from .search import SearchHit
+from .utils import pb_metadata_to_dict
+
+
+class SearchAndFetchVectorsResponse(VectorIndexResponse):
+    """Parent response type for a vector index `search_and_fetch_vectors` request.
+
+    Its subtypes are:
+    - `SearchAndFetchVectors.Success`
+    - `SearchAndFetchVectors.Error`
+
+    See `VectorIndexClient` for how to work with responses.
+    """
+
+
+@dataclass
+class SearchAndFetchVectorsHit(SearchHit):
+    vector: list[float] = field(default_factory=list)
+
+    @staticmethod
+    def from_search_hit(hit: SearchHit, vector: list[float]) -> SearchAndFetchVectorsHit:
+        return SearchAndFetchVectorsHit(id=hit.id, distance=hit.distance, metadata=hit.metadata, vector=vector)
+
+    @staticmethod
+    def from_proto(hit: vectorindex_pb._SearchAndFetchVectorsHit) -> SearchAndFetchVectorsHit:
+        metadata = pb_metadata_to_dict(hit.metadata)
+        return SearchAndFetchVectorsHit(
+            id=hit.id, distance=hit.distance, metadata=metadata, vector=list(hit.vector.elements)
+        )
+
+
+class SearchAndFetchVectors(ABC):
+    """Groups all `SearchAndFetchVectorsResponse` derived types under a common namespace."""
+
+    @dataclass
+    class Success(SearchAndFetchVectorsResponse):
+        """Indicates the request was successful."""
+
+        hits: list[SearchAndFetchVectorsHit]
+
+    class Error(SearchAndFetchVectorsResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request.
+
+        This includes:
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """

--- a/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
+++ b/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 
 from momento_wire_types import vectorindex_pb2 as vectorindex_pb
 
-from momento.errors import UnknownException
-
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse
 from .search import SearchHit

--- a/src/momento/responses/vector_index/data/utils.py
+++ b/src/momento/responses/vector_index/data/utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Iterable
+from momento_wire_types import vectorindex_pb2 as vectorindex_pb
+from momento.errors import UnknownException
+
+
+def pb_metadata_to_dict(
+    pb_metadata: Iterable[vectorindex_pb._Metadata],
+) -> dict[str, str | int | float | bool | list[str]]:
+    metadata: dict[str, str | int | float | bool | list[str]] = {}
+    for item in pb_metadata:
+        type = item.WhichOneof("value")
+        field = item.field
+        if type == "string_value":
+            metadata[field] = item.string_value
+        elif type == "integer_value":
+            metadata[field] = item.integer_value
+        elif type == "double_value":
+            metadata[field] = item.double_value
+        elif type == "boolean_value":
+            metadata[field] = item.boolean_value
+        elif type == "list_of_strings_value":
+            metadata[field] = list(item.list_of_strings_value.values)
+        else:
+            raise UnknownException(f"Unknown metadata value: {type}")
+    return metadata

--- a/src/momento/responses/vector_index/data/utils.py
+++ b/src/momento/responses/vector_index/data/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from typing import Iterable
+
 from momento_wire_types import vectorindex_pb2 as vectorindex_pb
+
 from momento.errors import UnknownException
 
 

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -42,6 +42,7 @@ from momento.responses.vector_index import (
     DeleteIndexResponse,
     DeleteItemBatchResponse,
     ListIndexesResponse,
+    SearchAndFetchVectorsResponse,
     SearchResponse,
     UpsertItemBatchResponse,
 )
@@ -222,5 +223,38 @@ class PreviewVectorIndexClient:
             SearchResponse: The result of a search operation.
         """
         return self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold)
+
+    def search_and_fetch_vectors(
+        self,
+        index_name: str,
+        query_vector: list[float],
+        top_k: int = 10,
+        metadata_fields: Optional[list[str]] | AllMetadata = None,
+        score_threshold: Optional[float] = None,
+    ) -> SearchAndFetchVectorsResponse:
+        """Searches for the most similar vectors to the query vector in the index.
+
+        Ranks the results using the similarity metric specified when the index was created.
+        Also returns the vectors associated with each result.
+
+        Args:
+            index_name (str): Name of the index to search in.
+            query_vector (list[float]): The vector to search for.
+            top_k (int): The number of results to return. Defaults to 10.
+            metadata_fields (Optional[list[str]] | AllMetadata): A list of metadata fields
+                to return with each result. If not provided, no metadata is returned.
+                If the special value `ALL_METADATA` is provided, all metadata is returned.
+                Defaults to None.
+            score_threshold (Optional[float]): A score threshold to filter results by.
+                For cosine similarity and inner product, scores lower than the threshold
+                are excluded. For euclidean similarity, scores higher than the threshold
+                are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+
+        Returns:
+            SearchResponse: The result of a search operation.
+        """
+        return self._data_client.search_and_fetch_vectors(
+            index_name, query_vector, top_k, metadata_fields, score_threshold
+        )
 
     # TODO: repr

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -41,6 +41,7 @@ from momento.responses.vector_index import (
     DeleteItemBatchResponse,
     ListIndexesResponse,
     SearchResponse,
+    SearchAndFetchVectorsResponse,
     UpsertItemBatchResponse,
 )
 
@@ -220,5 +221,37 @@ class PreviewVectorIndexClientAsync:
             SearchResponse: The result of a search operation.
         """
         return await self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold)
+
+    async def search_and_fetch_vectors(
+        self,
+        index_name: str,
+        query_vector: list[float],
+        top_k: int = 10,
+        metadata_fields: Optional[list[str]] | AllMetadata = None,
+        score_threshold: Optional[float] = None,
+    ) -> SearchAndFetchVectorsResponse:
+        """Searches for the most similar vectors to the query vector in the index.
+
+        Ranks the results using the similarity metric specified when the index was created.
+
+        Args:
+            index_name (str): Name of the index to search in.
+            query_vector (list[float]): The vector to search for.
+            top_k (int): The number of results to return. Defaults to 10.
+            metadata_fields (Optional[list[str]] | AllMetadata): A list of metadata fields
+                to return with each result. If not provided, no metadata is returned.
+                If the special value `ALL_METADATA` is provided, all metadata is returned.
+                Defaults to None.
+            score_threshold (Optional[float]): A score threshold to filter results by.
+                For cosine similarity and inner product, scores lower than the threshold
+                are excluded. For euclidean similarity, scores higher than the threshold
+                are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+
+        Returns:
+            SearchResponse: The result of a search operation.
+        """
+        return await self._data_client.search_and_fetch_vectors(
+            index_name, query_vector, top_k, metadata_fields, score_threshold
+        )
 
     # TODO: repr

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -40,8 +40,8 @@ from momento.responses.vector_index import (
     DeleteIndexResponse,
     DeleteItemBatchResponse,
     ListIndexesResponse,
-    SearchResponse,
     SearchAndFetchVectorsResponse,
+    SearchResponse,
     UpsertItemBatchResponse,
 )
 
@@ -233,6 +233,7 @@ class PreviewVectorIndexClientAsync:
         """Searches for the most similar vectors to the query vector in the index.
 
         Ranks the results using the similarity metric specified when the index was created.
+        Also returns the vectors associated with each result.
 
         Args:
             index_name (str): Name of the index to search in.

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -11,11 +11,12 @@ from momento.responses.vector_index import (
     CreateIndex,
     DeleteItemBatch,
     Search,
+    SearchAndFetchVectors,
     SearchHit,
     UpsertItemBatch,
 )
 from tests.conftest import TUniqueVectorIndexName
-from tests.utils import sleep
+from tests.utils import sleep, when_fetching_vectors_apply_vectors_to_hits
 
 
 def test_create_index_with_inner_product_upsert_item_search_happy_path(
@@ -141,9 +142,15 @@ def test_create_index_upsert_multiple_items_search_happy_path(
     ]
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 def test_create_index_upsert_multiple_items_search_with_top_k_happy_path(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(
@@ -151,31 +158,38 @@ def test_create_index_upsert_multiple_items_search_with_top_k_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0]),
+        Item(id="test_item_2", vector=[3.0, 4.0]),
+        Item(id="test_item_3", vector=[5.0, 6.0]),
+    ]
     upsert_response = vector_index_client.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0]),
-            Item(id="test_item_2", vector=[3.0, 4.0]),
-            Item(id="test_item_3", vector=[5.0, 6.0]),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     sleep(2)
 
-    search_response = vector_index_client.search(index_name, query_vector=[1.0, 2.0], top_k=2)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=2)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 2
 
-    assert search_response.hits == [
-        SearchHit(id="test_item_3", distance=17.0),
-        SearchHit(id="test_item_2", distance=11.0),
-    ]
+    hits = [SearchHit(id="test_item_3", distance=17.0), SearchHit(id="test_item_2", distance=11.0)]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 def test_upsert_and_search_with_metadata_happy_path(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(
@@ -183,49 +197,57 @@ def test_upsert_and_search_with_metadata_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
+        Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
+        Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
+    ]
     upsert_response = vector_index_client.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
-            Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
-            Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     sleep(2)
 
-    search_response = vector_index_client.search(index_name, query_vector=[1.0, 2.0], top_k=3)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=3)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0),
         SearchHit(id="test_item_2", distance=11.0),
         SearchHit(id="test_item_1", distance=5.0),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = vector_index_client.search(index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1"])
-    assert isinstance(search_response, Search.Success)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1"])
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = vector_index_client.search(
+    search_response = search(
         index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1", "key2", "key3", "key4"]
     )
-    assert isinstance(search_response, Search.Success)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3", "key3": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={"key2": "value2"}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
 def test_upsert_with_bad_metadata(vector_index_client: PreviewVectorIndexClient) -> None:
@@ -241,9 +263,15 @@ def test_upsert_with_bad_metadata(vector_index_client: PreviewVectorIndexClient)
     )
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 def test_upsert_and_search_with_all_metadata_happy_path(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(
@@ -251,44 +279,60 @@ def test_upsert_and_search_with_all_metadata_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
+        Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
+        Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
+    ]
     upsert_response = vector_index_client.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
-            Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
-            Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     sleep(2)
 
-    search_response = vector_index_client.search(index_name, query_vector=[1.0, 2.0], top_k=3)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=3)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0),
         SearchHit(id="test_item_2", distance=11.0),
         SearchHit(id="test_item_1", distance=5.0),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = vector_index_client.search(
-        index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=ALL_METADATA
-    )
-    assert isinstance(search_response, Search.Success)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=ALL_METADATA)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3", "key3": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={"key2": "value2"}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [
+        ("search", Search.Success),
+        (
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+    ],
+)
 def test_upsert_and_search_with_diverse_metadata_happy_path(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(
@@ -304,29 +348,22 @@ def test_upsert_and_search_with_diverse_metadata_happy_path(
         "list": ["a", "b", "c"],
         "empty_list": [],
     }
-    upsert_response = vector_index_client.upsert_item_batch(
-        index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata=metadata),
-        ],
-    )
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata=metadata),
+    ]
+    upsert_response = vector_index_client.upsert_item_batch(index_name, items=items)
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     sleep(2)
 
-    search_response = vector_index_client.search(
-        index_name, query_vector=[1.0, 2.0], top_k=1, metadata_fields=ALL_METADATA
-    )
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=[1.0, 2.0], top_k=1, metadata_fields=ALL_METADATA)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 1
 
-    assert search_response.hits == [
-        SearchHit(
-            id="test_item_1",
-            metadata=metadata,
-            distance=5.0,
-        ),
-    ]
+    hits = [SearchHit(id="test_item_1", metadata=metadata, distance=5.0)]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
 def test_upsert_replaces_existing_items(
@@ -396,9 +433,15 @@ def test_create_index_upsert_item_dimensions_different_than_num_dimensions_error
     assert upsert_response.inner_exception.message == expected_inner_ex_message
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
 def test_create_index_upsert_multiple_items_search_with_top_k_query_vector_dimensions_incorrect(
     vector_index_client: PreviewVectorIndexClient,
     unique_vector_index_name: TUniqueVectorIndexName,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(
@@ -416,8 +459,9 @@ def test_create_index_upsert_multiple_items_search_with_top_k_query_vector_dimen
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
-    search_response = vector_index_client.search(index_name, query_vector=[1.0, 2.0, 3.0], top_k=2)
-    assert isinstance(search_response, Search.Error)
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=[1.0, 2.0, 3.0], top_k=2)
+    assert isinstance(search_response, error_type)
 
     expected_inner_ex_message = "invalid parameter: query_vector, query vector dimension must match the index dimension"
     expected_resp_message = f"Invalid argument passed to Momento client: {expected_inner_ex_message}"
@@ -432,30 +476,69 @@ def test_upsert_validates_index_name(vector_index_client: PreviewVectorIndexClie
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-def test_search_validates_index_name(vector_index_client: PreviewVectorIndexClient) -> None:
-    response = vector_index_client.search(index_name="", query_vector=[1.0, 2.0])
-    assert isinstance(response, Search.Error)
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
+def test_search_validates_index_name(
+    vector_index_client: PreviewVectorIndexClient,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
+) -> None:
+    search = getattr(vector_index_client, search_method_name)
+    response = search(index_name="", query_vector=[1.0, 2.0])
+    assert isinstance(response, error_type)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-def test_search_validates_top_k(vector_index_client: PreviewVectorIndexClient) -> None:
-    response = vector_index_client.search(index_name="test_index", query_vector=[1.0, 2.0], top_k=0)
-    assert isinstance(response, Search.Error)
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
+def test_search_validates_top_k(
+    vector_index_client: PreviewVectorIndexClient,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
+) -> None:
+    search = getattr(vector_index_client, search_method_name)
+    response = search(index_name="test_index", query_vector=[1.0, 2.0], top_k=0)
+    assert isinstance(response, error_type)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert response.inner_exception.message == "Top k must be a positive integer."
 
 
 @pytest.mark.parametrize(
-    ["similarity_metric", "distances", "thresholds"],
+    ["similarity_metric", "distances", "thresholds", "search_method_name", "response"],
     [
         # Distances are the distance to the same 3 data vectors from the same query vector.
         # Thresholds are those that should:
         # 1. exclude lowest two matches
         # 2. keep all matches
         # 3. exclude all matches
-        (SimilarityMetric.COSINE_SIMILARITY, [1.0, 0.0, -1.0], [0.5, -1.01, 1.0]),
-        (SimilarityMetric.INNER_PRODUCT, [4.0, 0.0, -4.0], [0.0, -4.01, 4.0]),
-        (SimilarityMetric.EUCLIDEAN_SIMILARITY, [2, 10, 18], [3, 20, -0.01]),
+        (SimilarityMetric.COSINE_SIMILARITY, [1.0, 0.0, -1.0], [0.5, -1.01, 1.0], "search", Search.Success),
+        (
+            SimilarityMetric.COSINE_SIMILARITY,
+            [1.0, 0.0, -1.0],
+            [0.5, -1.01, 1.0],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+        (SimilarityMetric.INNER_PRODUCT, [4.0, 0.0, -4.0], [0.0, -4.01, 4.0], "search", Search.Success),
+        (
+            SimilarityMetric.INNER_PRODUCT,
+            [4.0, 0.0, -4.0],
+            [0.0, -4.01, 4.0],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+        (SimilarityMetric.EUCLIDEAN_SIMILARITY, [2, 10, 18], [3, 20, -0.01], "search", Search.Success),
+        (
+            SimilarityMetric.EUCLIDEAN_SIMILARITY,
+            [2, 10, 18],
+            [3, 20, -0.01],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
     ],
 )
 def test_search_score_threshold_happy_path(
@@ -464,6 +547,8 @@ def test_search_score_threshold_happy_path(
     similarity_metric: SimilarityMetric,
     distances: list[float],
     thresholds: list[float],
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     num_dimensions = 2
@@ -472,13 +557,14 @@ def test_search_score_threshold_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 1.0]),
+        Item(id="test_item_2", vector=[-1.0, 1.0]),
+        Item(id="test_item_3", vector=[-1.0, -1.0]),
+    ]
     upsert_response = vector_index_client.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 1.0]),
-            Item(id="test_item_2", vector=[-1.0, 1.0]),
-            Item(id="test_item_3", vector=[-1.0, -1.0]),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
@@ -487,22 +573,17 @@ def test_search_score_threshold_happy_path(
     query_vector = [2.0, 2.0]
     search_hits = [SearchHit(id=f"test_item_{i+1}", distance=distance) for i, distance in enumerate(distances)]
 
-    search_response = vector_index_client.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[0]
-    )
-    assert isinstance(search_response, Search.Success)
-    assert search_response.hits == [search_hits[0]]
+    search = getattr(vector_index_client, search_method_name)
+    search_response = search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[0])
+    assert isinstance(search_response, response)
+    assert search_response.hits == when_fetching_vectors_apply_vectors_to_hits(search_response, [search_hits[0]], items)
 
-    search_response2 = vector_index_client.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[1]
-    )
-    assert isinstance(search_response2, Search.Success)
-    assert search_response2.hits == search_hits
+    search_response2 = search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[1])
+    assert isinstance(search_response2, response)
+    assert search_response2.hits == when_fetching_vectors_apply_vectors_to_hits(search_response, search_hits, items)
 
-    search_response3 = vector_index_client.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[2]
-    )
-    assert isinstance(search_response3, Search.Success)
+    search_response3 = search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[2])
+    assert isinstance(search_response3, response)
     assert search_response3.hits == []
 
 

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -142,6 +142,11 @@ def test_create_index_upsert_multiple_items_search_happy_path(
     ]
 
 
+# A note on the parameterized search tests:
+# The search tests are parameterized to test both the search and search_and_fetch_vectors methods.
+# We pass both the name of the specific search method and the response type.
+# The tests will run for both search methods, and the response type will be used to assert the type of the response.
+# The vectors are attached to the hits if the response type is SearchAndFetchVectors.Success.
 @pytest.mark.parametrize(
     ["search_method_name", "response"],
     [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -144,6 +144,11 @@ async def test_create_index_upsert_multiple_items_search_happy_path(
     ]
 
 
+# A note on the parameterized search tests:
+# The search tests are parameterized to test both the search and search_and_fetch_vectors methods.
+# We pass both the name of the specific search method and the response type.
+# The tests will run for both search methods, and the response type will be used to assert the type of the response.
+# The vectors are attached to the hits if the response type is SearchAndFetchVectors.Success.
 @pytest.mark.parametrize(
     ["search_method_name", "response"],
     [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -11,11 +11,12 @@ from momento.responses.vector_index import (
     CreateIndex,
     DeleteItemBatch,
     Search,
+    SearchAndFetchVectors,
     SearchHit,
     UpsertItemBatch,
 )
 from tests.conftest import TUniqueVectorIndexNameAsync
-from tests.utils import sleep_async
+from tests.utils import sleep_async, when_fetching_vectors_apply_vectors_to_hits
 
 
 async def test_create_index_with_inner_product_upsert_item_search_happy_path(
@@ -143,9 +144,15 @@ async def test_create_index_upsert_multiple_items_search_happy_path(
     ]
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 async def test_create_index_upsert_multiple_items_search_with_top_k_happy_path(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(
@@ -153,31 +160,38 @@ async def test_create_index_upsert_multiple_items_search_with_top_k_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0]),
+        Item(id="test_item_2", vector=[3.0, 4.0]),
+        Item(id="test_item_3", vector=[5.0, 6.0]),
+    ]
     upsert_response = await vector_index_client_async.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0]),
-            Item(id="test_item_2", vector=[3.0, 4.0]),
-            Item(id="test_item_3", vector=[5.0, 6.0]),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     await sleep_async(2)
 
-    search_response = await vector_index_client_async.search(index_name, query_vector=[1.0, 2.0], top_k=2)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=2)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 2
 
-    assert search_response.hits == [
-        SearchHit(id="test_item_3", distance=17.0),
-        SearchHit(id="test_item_2", distance=11.0),
-    ]
+    hits = [SearchHit(id="test_item_3", distance=17.0), SearchHit(id="test_item_2", distance=11.0)]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 async def test_upsert_and_search_with_metadata_happy_path(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(
@@ -185,51 +199,57 @@ async def test_upsert_and_search_with_metadata_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
+        Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
+        Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
+    ]
     upsert_response = await vector_index_client_async.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
-            Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
-            Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     await sleep_async(2)
 
-    search_response = await vector_index_client_async.search(index_name, query_vector=[1.0, 2.0], top_k=3)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=3)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0),
         SearchHit(id="test_item_2", distance=11.0),
         SearchHit(id="test_item_1", distance=5.0),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = await vector_index_client_async.search(
-        index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1"]
-    )
-    assert isinstance(search_response, Search.Success)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1"])
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = await vector_index_client_async.search(
+    search_response = await search(
         index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=["key1", "key2", "key3", "key4"]
     )
-    assert isinstance(search_response, Search.Success)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3", "key3": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={"key2": "value2"}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
 async def test_upsert_with_bad_metadata(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
@@ -245,9 +265,15 @@ async def test_upsert_with_bad_metadata(vector_index_client_async: PreviewVector
     )
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [("search", Search.Success), ("search_and_fetch_vectors", SearchAndFetchVectors.Success)],
+)
 async def test_upsert_and_search_with_all_metadata_happy_path(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(
@@ -255,44 +281,60 @@ async def test_upsert_and_search_with_all_metadata_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
+        Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
+        Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
+    ]
     upsert_response = await vector_index_client_async.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata={"key1": "value1"}),
-            Item(id="test_item_2", vector=[3.0, 4.0], metadata={"key2": "value2"}),
-            Item(id="test_item_3", vector=[5.0, 6.0], metadata={"key1": "value3", "key3": "value3"}),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     await sleep_async(2)
 
-    search_response = await vector_index_client_async.search(index_name, query_vector=[1.0, 2.0], top_k=3)
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=3)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0),
         SearchHit(id="test_item_2", distance=11.0),
         SearchHit(id="test_item_1", distance=5.0),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
-    search_response = await vector_index_client_async.search(
-        index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=ALL_METADATA
-    )
-    assert isinstance(search_response, Search.Success)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=3, metadata_fields=ALL_METADATA)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 3
 
-    assert search_response.hits == [
+    hits = [
         SearchHit(id="test_item_3", distance=17.0, metadata={"key1": "value3", "key3": "value3"}),
         SearchHit(id="test_item_2", distance=11.0, metadata={"key2": "value2"}),
         SearchHit(id="test_item_1", distance=5.0, metadata={"key1": "value1"}),
     ]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "response"],
+    [
+        ("search", Search.Success),
+        (
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+    ],
+)
 async def test_upsert_and_search_with_diverse_metadata_happy_path(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(
@@ -308,29 +350,22 @@ async def test_upsert_and_search_with_diverse_metadata_happy_path(
         "list": ["a", "b", "c"],
         "empty_list": [],
     }
-    upsert_response = await vector_index_client_async.upsert_item_batch(
-        index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 2.0], metadata=metadata),
-        ],
-    )
+    items = [
+        Item(id="test_item_1", vector=[1.0, 2.0], metadata=metadata),
+    ]
+    upsert_response = await vector_index_client_async.upsert_item_batch(index_name, items=items)
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
     await sleep_async(2)
 
-    search_response = await vector_index_client_async.search(
-        index_name, query_vector=[1.0, 2.0], top_k=1, metadata_fields=ALL_METADATA
-    )
-    assert isinstance(search_response, Search.Success)
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=[1.0, 2.0], top_k=1, metadata_fields=ALL_METADATA)
+    assert isinstance(search_response, response)
     assert len(search_response.hits) == 1
 
-    assert search_response.hits == [
-        SearchHit(
-            id="test_item_1",
-            metadata=metadata,
-            distance=5.0,
-        ),
-    ]
+    hits = [SearchHit(id="test_item_1", metadata=metadata, distance=5.0)]
+    hits = when_fetching_vectors_apply_vectors_to_hits(search_response, hits, items)
+    assert search_response.hits == hits
 
 
 async def test_upsert_replaces_existing_items(
@@ -400,9 +435,15 @@ async def test_create_index_upsert_item_dimensions_different_than_num_dimensions
     assert upsert_response.inner_exception.message == expected_inner_ex_message
 
 
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
 async def test_create_index_upsert_multiple_items_search_with_top_k_query_vector_dimensions_incorrect(
     vector_index_client_async: PreviewVectorIndexClientAsync,
     unique_vector_index_name_async: TUniqueVectorIndexNameAsync,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(
@@ -420,8 +461,9 @@ async def test_create_index_upsert_multiple_items_search_with_top_k_query_vector
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
-    search_response = await vector_index_client_async.search(index_name, query_vector=[1.0, 2.0, 3.0], top_k=2)
-    assert isinstance(search_response, Search.Error)
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=[1.0, 2.0, 3.0], top_k=2)
+    assert isinstance(search_response, error_type)
 
     expected_inner_ex_message = "invalid parameter: query_vector, query vector dimension must match the index dimension"
     expected_resp_message = f"Invalid argument passed to Momento client: {expected_inner_ex_message}"
@@ -438,30 +480,69 @@ async def test_upsert_validates_index_name(vector_index_client_async: PreviewVec
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-async def test_search_validates_index_name(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
-    response = await vector_index_client_async.search(index_name="", query_vector=[1.0, 2.0])
-    assert isinstance(response, Search.Error)
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
+async def test_search_validates_index_name(
+    vector_index_client_async: PreviewVectorIndexClientAsync,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
+) -> None:
+    search = getattr(vector_index_client_async, search_method_name)
+    response = await search(index_name="", query_vector=[1.0, 2.0])
+    assert isinstance(response, error_type)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
 
-async def test_search_validates_top_k(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
-    response = await vector_index_client_async.search(index_name="test_index", query_vector=[1.0, 2.0], top_k=0)
-    assert isinstance(response, Search.Error)
+@pytest.mark.parametrize(
+    ["search_method_name", "error_type"],
+    [("search", Search.Error), ("search_and_fetch_vectors", SearchAndFetchVectors.Error)],
+)
+async def test_search_validates_top_k(
+    vector_index_client_async: PreviewVectorIndexClientAsync,
+    search_method_name: str,
+    error_type: type[Search.Error] | type[SearchAndFetchVectors.Error],
+) -> None:
+    search = getattr(vector_index_client_async, search_method_name)
+    response = await search(index_name="test_index", query_vector=[1.0, 2.0], top_k=0)
+    assert isinstance(response, error_type)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
     assert response.inner_exception.message == "Top k must be a positive integer."
 
 
 @pytest.mark.parametrize(
-    ["similarity_metric", "distances", "thresholds"],
+    ["similarity_metric", "distances", "thresholds", "search_method_name", "response"],
     [
         # Distances are the distance to the same 3 data vectors from the same query vector.
         # Thresholds are those that should:
         # 1. exclude lowest two matches
         # 2. keep all matches
         # 3. exclude all matches
-        (SimilarityMetric.COSINE_SIMILARITY, [1.0, 0.0, -1.0], [0.5, -1.01, 1.0]),
-        (SimilarityMetric.INNER_PRODUCT, [4.0, 0.0, -4.0], [0.0, -4.01, 4.0]),
-        (SimilarityMetric.EUCLIDEAN_SIMILARITY, [2, 10, 18], [3, 20, -0.01]),
+        (SimilarityMetric.COSINE_SIMILARITY, [1.0, 0.0, -1.0], [0.5, -1.01, 1.0], "search", Search.Success),
+        (
+            SimilarityMetric.COSINE_SIMILARITY,
+            [1.0, 0.0, -1.0],
+            [0.5, -1.01, 1.0],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+        (SimilarityMetric.INNER_PRODUCT, [4.0, 0.0, -4.0], [0.0, -4.01, 4.0], "search", Search.Success),
+        (
+            SimilarityMetric.INNER_PRODUCT,
+            [4.0, 0.0, -4.0],
+            [0.0, -4.01, 4.0],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
+        (SimilarityMetric.EUCLIDEAN_SIMILARITY, [2, 10, 18], [3, 20, -0.01], "search", Search.Success),
+        (
+            SimilarityMetric.EUCLIDEAN_SIMILARITY,
+            [2, 10, 18],
+            [3, 20, -0.01],
+            "search_and_fetch_vectors",
+            SearchAndFetchVectors.Success,
+        ),
     ],
 )
 async def test_search_score_threshold_happy_path(
@@ -470,6 +551,8 @@ async def test_search_score_threshold_happy_path(
     similarity_metric: SimilarityMetric,
     distances: list[float],
     thresholds: list[float],
+    search_method_name: str,
+    response: type[Search.Success] | type[SearchAndFetchVectors.Success],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     num_dimensions = 2
@@ -478,13 +561,14 @@ async def test_search_score_threshold_happy_path(
     )
     assert isinstance(create_response, CreateIndex.Success)
 
+    items = [
+        Item(id="test_item_1", vector=[1.0, 1.0]),
+        Item(id="test_item_2", vector=[-1.0, 1.0]),
+        Item(id="test_item_3", vector=[-1.0, -1.0]),
+    ]
     upsert_response = await vector_index_client_async.upsert_item_batch(
         index_name,
-        items=[
-            Item(id="test_item_1", vector=[1.0, 1.0]),
-            Item(id="test_item_2", vector=[-1.0, 1.0]),
-            Item(id="test_item_3", vector=[-1.0, -1.0]),
-        ],
+        items=items,
     )
     assert isinstance(upsert_response, UpsertItemBatch.Success)
 
@@ -493,22 +577,17 @@ async def test_search_score_threshold_happy_path(
     query_vector = [2.0, 2.0]
     search_hits = [SearchHit(id=f"test_item_{i+1}", distance=distance) for i, distance in enumerate(distances)]
 
-    search_response = await vector_index_client_async.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[0]
-    )
-    assert isinstance(search_response, Search.Success)
-    assert search_response.hits == [search_hits[0]]
+    search = getattr(vector_index_client_async, search_method_name)
+    search_response = await search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[0])
+    assert isinstance(search_response, response)
+    assert search_response.hits == when_fetching_vectors_apply_vectors_to_hits(search_response, [search_hits[0]], items)
 
-    search_response2 = await vector_index_client_async.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[1]
-    )
-    assert isinstance(search_response2, Search.Success)
-    assert search_response2.hits == search_hits
+    search_response2 = await search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[1])
+    assert isinstance(search_response2, response)
+    assert search_response2.hits == when_fetching_vectors_apply_vectors_to_hits(search_response, search_hits, items)
 
-    search_response3 = await vector_index_client_async.search(
-        index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[2]
-    )
-    assert isinstance(search_response3, Search.Success)
+    search_response3 = await search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[2])
+    assert isinstance(search_response3, response)
     assert search_response3.hits == []
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from typing import cast
 
 from momento.requests.vector_index import Item
 from momento.responses.vector_index import Search, SearchAndFetchVectors

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,6 +65,6 @@ def when_fetching_vectors_apply_vectors_to_hits(
     items: list[Item],
 ) -> list[SearchHit]:
     if isinstance(response, Search.Success):
-        return cast(list[SearchHit], hits)
+        return hits  # type: ignore
     item_index = {item.id: item for item in items}
     return [SearchAndFetchVectorsHit.from_search_hit(hit, item_index[hit.id].vector) for hit in hits]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
+
 import asyncio
 import time
 import uuid
+from typing import cast
 
 from momento.requests.vector_index import Item
 from momento.responses.vector_index import Search, SearchAndFetchVectors
 from momento.responses.vector_index.data.search import SearchHit
-from momento.responses.vector_index.data.search_and_fetch_vectors import SearchAndFetchVectorsHit
-from typing import cast
+from momento.responses.vector_index.data.search_and_fetch_vectors import (
+    SearchAndFetchVectorsHit,
+)
 
 
 def unique_test_cache_name() -> str:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
 import asyncio
 import time
 import uuid
+
+from momento.requests.vector_index import Item
+from momento.responses.vector_index import Search, SearchAndFetchVectors
+from momento.responses.vector_index.data.search import SearchHit
+from momento.responses.vector_index.data.search_and_fetch_vectors import SearchAndFetchVectorsHit
+from typing import cast
 
 
 def unique_test_cache_name() -> str:
@@ -47,3 +54,14 @@ def sleep(seconds: int) -> None:
 
 async def sleep_async(seconds: int) -> None:
     await asyncio.sleep(seconds)
+
+
+def when_fetching_vectors_apply_vectors_to_hits(
+    response: Search.Success | SearchAndFetchVectors.Success,
+    hits: list[SearchHit] | list[SearchAndFetchVectorsHit],
+    items: list[Item],
+) -> list[SearchHit]:
+    if isinstance(response, Search.Success):
+        return cast(list[SearchHit], hits)
+    item_index = {item.id: item for item in items}
+    return [SearchAndFetchVectorsHit.from_search_hit(hit, item_index[hit.id].vector) for hit in hits]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,6 +63,24 @@ def when_fetching_vectors_apply_vectors_to_hits(
     hits: list[SearchHit] | list[SearchAndFetchVectorsHit],
     items: list[Item],
 ) -> list[SearchHit]:
+    """Normalizes the search hits according to the response.
+
+    The tests will use this function to normalize the expected search hits
+    according to the response type. This allows us to specify one set of expected
+    search hits for both `search` and `search_and_fetch_vectors` requests.
+
+    This method will augment the search hits with the original vectors when
+    the response is `SearchAndFetchVectors.Success`. Otherwise, it will return
+    the search hits as-is.
+
+    Args:
+        response (Search.Success | SearchAndFetchVectors.Success): The search response.
+        hits (list[SearchHit] | list[SearchAndFetchVectorsHit]): The search hits.
+        items (list[Item]): The items that were indexed, used to fetch the original vectors.
+
+    Returns:
+        list[SearchHit]: The normalized search hits.
+    """
     if isinstance(response, Search.Success):
         return hits  # type: ignore
     item_index = {item.id: item for item in items}


### PR DESCRIPTION
Add MVI `search_and_fetch_vectors` method and integration tests. This new method performs a `search` as usual, but returns the vectors associated with the search hits. That is, the only change in behavior comes down to the response. 

Because of this, we refactor the search tests to work against both `search` and `search_and_fetch_vectors`. We make use of pytest's parameterized test feature to do this.