### PR TITLE
refactor: mvi list indexes response to contain index info detail

### DIFF
--- a/src/momento/responses/vector_index/control/list.py
+++ b/src/momento/responses/vector_index/control/list.py
@@ -64,7 +64,7 @@ class ListIndexes(ABC):
                 grpc_list_index_response: Protobuf based response returned by Scs.
             """
             return ListIndexes.Success(
-                indexes=[IndexInfo(index_name) for index_name in grpc_list_index_response.index_names]  # type: ignore[misc]
+                indexes=[IndexInfo(index_name) for index_name in grpc_list_index_response.index_names]  # type: ignore[misc]  # noqa: E501
             )
 
     class Error(ListIndexesResponse, ErrorResponseMixin):

--- a/src/momento/responses/vector_index/control/list.py
+++ b/src/momento/responses/vector_index/control/list.py
@@ -39,6 +39,13 @@ class ListIndexesResponse(ControlResponse):
     """
 
 
+@dataclass
+class IndexInfo:
+    """Contains a Momento index's info."""
+
+    name: str
+
+
 class ListIndexes(ABC):
     """Groups all `ListIndexesResponse` derived types under a common namespace."""
 
@@ -46,7 +53,7 @@ class ListIndexes(ABC):
     class Success(ListIndexesResponse):
         """Indicates the request was successful."""
 
-        index_names: list[str]
+        indexes: list[IndexInfo]
         """The list of indexes available to the user."""
 
         @staticmethod
@@ -57,7 +64,7 @@ class ListIndexes(ABC):
                 grpc_list_index_response: Protobuf based response returned by Scs.
             """
             return ListIndexes.Success(
-                index_names=[index_name for index_name in grpc_list_index_response.index_names]  # type: ignore[misc]
+                indexes=[IndexInfo(index_name) for index_name in grpc_list_index_response.index_names]  # type: ignore[misc]
             )
 
     class Error(ListIndexesResponse, ErrorResponseMixin):

--- a/tests/momento/vector_index_client/test_control.py
+++ b/tests/momento/vector_index_client/test_control.py
@@ -18,7 +18,7 @@ def test_create_index_list_indexes_and_delete_index(
 
     list_indexes_response = vector_index_client.list_indexes()
     assert isinstance(list_indexes_response, ListIndexes.Success)
-    assert any(index_name == new_index_name for index_name in list_indexes_response.index_names)
+    assert any(index.name == new_index_name for index in list_indexes_response.indexes)
 
     delete_index_response = vector_index_client.delete_index(new_index_name)
     assert isinstance(delete_index_response, DeleteIndex.Success)
@@ -143,7 +143,7 @@ def test_list_indexes_succeeds(vector_index_client: PreviewVectorIndexClient) ->
     initial_response = vector_index_client.list_indexes()
     assert isinstance(initial_response, ListIndexes.Success)
 
-    index_names = [index_name for index_name in initial_response.index_names]
+    index_names = [index.name for index in initial_response.indexes]
     assert index_name not in index_names
 
     try:
@@ -153,7 +153,7 @@ def test_list_indexes_succeeds(vector_index_client: PreviewVectorIndexClient) ->
         list_cache_resp = vector_index_client.list_indexes()
         assert isinstance(list_cache_resp, ListIndexes.Success)
 
-        index_names = [index_name for index_name in list_cache_resp.index_names]
+        index_names = [index.name for index in list_cache_resp.indexes]
         assert index_name in index_names
     finally:
         delete_response = vector_index_client.delete_index(index_name)

--- a/tests/momento/vector_index_client/test_control_async.py
+++ b/tests/momento/vector_index_client/test_control_async.py
@@ -20,7 +20,7 @@ async def test_create_index_list_indexes_and_delete_index(
 
     list_indexes_response = await vector_index_client_async.list_indexes()
     assert isinstance(list_indexes_response, ListIndexes.Success)
-    assert any(index_name == new_index_name for index_name in list_indexes_response.index_names)
+    assert any(index.name == new_index_name for index in list_indexes_response.indexes)
 
     delete_index_response = await vector_index_client_async.delete_index(new_index_name)
     assert isinstance(delete_index_response, DeleteIndex.Success)
@@ -149,7 +149,7 @@ async def test_list_indexes_succeeds(vector_index_client_async: PreviewVectorInd
     initial_response = await vector_index_client_async.list_indexes()
     assert isinstance(initial_response, ListIndexes.Success)
 
-    index_names = [index_name for index_name in initial_response.index_names]
+    index_names = [index.name for index in initial_response.indexes]
     assert index_name not in index_names
 
     try:
@@ -159,7 +159,7 @@ async def test_list_indexes_succeeds(vector_index_client_async: PreviewVectorInd
         list_cache_resp = await vector_index_client_async.list_indexes()
         assert isinstance(list_cache_resp, ListIndexes.Success)
 
-        index_names = [index_name for index_name in list_cache_resp.index_names]
+        index_names = [index.name for index in list_cache_resp.indexes]
         assert index_name in index_names
     finally:
         delete_response = await vector_index_client_async.delete_index(index_name)


### PR DESCRIPTION
Previously a list indexes success response only contained a list of
index names. We refactor this to contain a list of VectorIndexInfo
objects, each of which can contain encapsulate many details. To start
we only include the index name.

We update the integration tests and indexes along with this.