### PR TITLE
chore: bump protos and consume mvi searchhit update

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -280,13 +280,13 @@ files = [
 
 [[package]]
 name = "momento-wire-types"
-version = "0.91.1"
+version = "0.94.1"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.91.1-py3-none-any.whl", hash = "sha256:93c812d8fa5971ed7b609283958cbc7925120665c687338c44a60a4149c25d82"},
-    {file = "momento_wire_types-0.91.1.tar.gz", hash = "sha256:2bb5364ee9df7ff490a9705c710a919cc96218eeeb3d7a45cccd4695c10451f4"},
+    {file = "momento_wire_types-0.94.1-py3-none-any.whl", hash = "sha256:9df6860b9f09308bf36cb702fb85bfc83583bf9f36bb8ac63aef8f2d485827a8"},
+    {file = "momento_wire_types-0.94.1.tar.gz", hash = "sha256:1ca589e0ed26b112dbf25ad71f11910ce35dde1e931783b8ce0a0a484bf6dff2"},
 ]
 
 [package.dependencies]
@@ -371,13 +371,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "4.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
+    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
 
 [package.dependencies]
@@ -765,4 +765,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b8835e2d6b140f0d116b96bcb6f7fdf5ee10c7ef111c62ef4762ba988a90b936"
+content-hash = "efb734e3c47e170fcc71f0987bcee7267e645c66a7684e4112a16d07d49240d4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.91.1"
+momento-wire-types = "^0.94.1"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/responses/vector_index/data/search.py
+++ b/src/momento/responses/vector_index/data/search.py
@@ -30,7 +30,7 @@ class SearchHit:
     @staticmethod
     def from_proto(hit: vectorindex_pb._SearchHit) -> SearchHit:
         metadata = pb_metadata_to_dict(hit.metadata)
-        return SearchHit(id=hit.id, score=hit.distance, metadata=metadata)
+        return SearchHit(id=hit.id, score=hit.score, metadata=metadata)
 
 
 class Search(ABC):

--- a/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
+++ b/src/momento/responses/vector_index/data/search_and_fetch_vectors.py
@@ -33,9 +33,7 @@ class SearchAndFetchVectorsHit(SearchHit):
     @staticmethod
     def from_proto(hit: vectorindex_pb._SearchAndFetchVectorsHit) -> SearchAndFetchVectorsHit:
         metadata = pb_metadata_to_dict(hit.metadata)
-        return SearchAndFetchVectorsHit(
-            id=hit.id, score=hit.distance, metadata=metadata, vector=list(hit.vector.elements)
-        )
+        return SearchAndFetchVectorsHit(id=hit.id, score=hit.score, metadata=metadata, vector=list(hit.vector.elements))
 
 
 class SearchAndFetchVectors(ABC):


### PR DESCRIPTION
Bumps `momento-wire-types` and updates backend to read `score` from `SearchHit` and `SearchAndFetchVectorsHit`.
