### PR TITLE
chore: temporarily add score alias for langchain compatibility

### DIFF
--- a/src/momento/responses/vector_index/data/search.py
+++ b/src/momento/responses/vector_index/data/search.py
@@ -27,6 +27,11 @@ class SearchHit:
     score: float
     metadata: dict[str, str | int | float | bool | list[str]] = field(default_factory=dict)
 
+    @property
+    def distance(self) -> float:
+        """Alias for `score`."""
+        return self.score
+
     @staticmethod
     def from_proto(hit: vectorindex_pb._SearchHit) -> SearchHit:
         metadata = pb_metadata_to_dict(hit.metadata)


### PR DESCRIPTION
Until the langchain update is approved, we will have the distance
property as an alias for score.
