### PR TITLE
chore: use ruff linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 120
-docstring-convention = google
-exclude =
-  .venv
-per-file-ignores = __init__.py:F401
-ignore = D100,D101,D102,D103,D104,D105,D107

--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -54,14 +54,11 @@ jobs:
         if: matrix.python-version == '3.7'
         run: poetry run mypy src tests
 
-      - name: Run flake8
-        run: poetry run flake8 src tests
+      - name: Run ruff
+        run: poetry run ruff --no-fix src tests
 
       - name: Run black
         run: poetry run black src tests --check --diff
-
-      - name: Run isort
-        run: poetry run isort src tests --check --diff
 
       - name: Run tests
         run: poetry run pytest tests/momento/vector_index_client -p no:sugar -q

--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -39,29 +39,29 @@ jobs:
           curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
 
       - name: Configure poetry
-        run: /Users/runner/.local/bin/poetry config virtualenvs.in-project true
+        run: poetry config virtualenvs.in-project true
 
       - name: Install dependencies
-        run: /Users/runner/.local/bin/poetry install
+        run: poetry install
 
       - name: Install Old Protobuf
         # Exercises the wire types generated against the old protobuf library
         if: matrix.new-python-protobuf == 'false'
-        run: /Users/runner/.local/bin/poetry add "protobuf<3.20"
+        run: poetry add "protobuf<3.20"
 
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator
         if: matrix.python-version == '3.7'
-        run: /Users/runner/.local/bin/poetry run mypy src tests
+        run: poetry run mypy src tests
 
       - name: Run flake8
-        run: /Users/runner/.local/bin/poetry run flake8 src tests
+        run: poetry run flake8 src tests
 
       - name: Run black
-        run: /Users/runner/.local/bin/poetry run black src tests --check --diff
+        run: poetry run black src tests --check --diff
 
       - name: Run isort
-        run: /Users/runner/.local/bin/poetry run isort src tests --check --diff
+        run: poetry run isort src tests --check --diff
 
       - name: Run tests
-        run: /Users/runner/.local/bin/poetry run pytest tests/momento/vector_index_client -p no:sugar -q
+        run: poetry run pytest tests/momento/vector_index_client -p no:sugar -q

--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -37,29 +37,28 @@ jobs:
       - name: Bootstrap poetry
         run: |
           curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
-          export PATH="/Users/runner/.local/bin:$PATH"
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: /Users/runner/.local/bin/poetry config virtualenvs.in-project true
 
       - name: Install dependencies
-        run: poetry install
+        run: /Users/runner/.local/bin/poetry install
 
       - name: Install Old Protobuf
         # Exercises the wire types generated against the old protobuf library
         if: matrix.new-python-protobuf == 'false'
-        run: poetry add "protobuf<3.20"
+        run: /Users/runner/.local/bin/poetry add "protobuf<3.20"
 
       - name: Run mypy
         # mypy has inconsistencies between 3.7 and the rest; default to lowest common denominator
         if: matrix.python-version == '3.7'
-        run: poetry run mypy src tests
+        run: /Users/runner/.local/bin/poetry run mypy src tests
 
       - name: Run ruff
-        run: poetry run ruff --no-fix src tests
+        run: /Users/runner/.local/bin/poetry run ruff --no-fix src tests
 
       - name: Run black
-        run: poetry run black src tests --check --diff
+        run: /Users/runner/.local/bin/poetry run black src tests --check --diff
 
       - name: Run tests
-        run: poetry run pytest tests/momento/vector_index_client -p no:sugar -q
+        run: /Users/runner/.local/bin/poetry run pytest tests/momento/vector_index_client -p no:sugar -q

--- a/.github/workflows/on-pull-request-mvi.yml
+++ b/.github/workflows/on-pull-request-mvi.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Bootstrap poetry
         run: |
           curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
+          export PATH="/Users/runner/.local/bin:$PATH"
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -53,14 +53,11 @@ jobs:
         if: matrix.python-version == '3.7'
         run: poetry run mypy src tests
 
-      - name: Run flake8
-        run: poetry run flake8 src tests
+      - name: Run ruff
+        run: poetry run ruff --no-fix src tests
 
       - name: Run black
         run: poetry run black src tests --check --diff
-
-      - name: Run isort
-        run: poetry run isort src tests --check --diff
 
       - name: Run tests
         run: poetry run pytest -p no:sugar -q --ignore=tests/momento/vector_index_client

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -43,7 +43,6 @@ jobs:
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
       TEST_VECTOR_INDEX_NAME: python-integration-test-vector-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
 
-
     steps:
       - uses: actions/checkout@v3
 
@@ -72,14 +71,11 @@ jobs:
         if: matrix.python-version == '3.7'
         run: poetry run mypy src tests
 
-      - name: Run flake8
-        run: poetry run flake8 src tests
+      - name: Run ruff
+        run: poetry run ruff --no-fix src tests
 
       - name: Run black
         run: poetry run black src tests --check --diff
-
-      - name: Run isort
-        run: poetry run isort src tests --check --diff
 
       - name: Run tests
         run: poetry run pytest -p no:sugar -q --ignore=tests/momento/vector_index_client

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,15 @@ install:
 	@poetry install
 
 .PHONY: format
-## Format the code using black and isort
+## Format the code using black
 format:
 	@poetry run black src tests
-	@poetry run isort src tests
 
 .PHONY: lint
 ## Lint the code using mypy and flake8
 lint:
+	@poetry run ruff src tests
 	@poetry run mypy src tests
-	@poetry run flake8 src tests
 
 .PHONY: do-gen-sync
 do-gen-sync:

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,13 @@ install:
 	@poetry install
 
 .PHONY: format
-## Format the code using black
+## Format the code using black and ruff
 format:
 	@poetry run black src tests
+	@poetry run ruff src tests
 
 .PHONY: lint
-## Lint the code using mypy and flake8
+## Lint the code using ruff and mypy
 lint:
 	@poetry run ruff src tests
 	@poetry run mypy src tests
@@ -45,7 +46,7 @@ do-gen-sync:
 
 .PHONY: gen-sync
 ## Generate synchronous code and tests from asynchronous code.
-gen-sync: do-gen-sync format
+gen-sync: do-gen-sync format lint
 
 .PHONY: test
 ## Run unit and integration tests with pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,38 +77,6 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.6.1"
-files = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
-]
-
-[package.dependencies]
-importlib-metadata = {version = ">=1.1.0,<4.3", markers = "python_version < \"3.8\""}
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
-name = "flake8-docstrings"
-version = "1.7.0"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8_docstrings-1.7.0-py2.py3-none-any.whl", hash = "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75"},
-    {file = "flake8_docstrings-1.7.0.tar.gz", hash = "sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pydocstyle = ">=2.1"
-
-[[package]]
 name = "grpcio"
 version = "1.59.2"
 description = "HTTP/2-based RPC framework"
@@ -205,23 +173,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.11.5"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.7.0"
-files = [
-    {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
-    {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "libcst"
 version = "0.4.10"
 description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs."
@@ -266,17 +217,6 @@ typing-inspect = ">=0.4.0"
 
 [package.extras]
 dev = ["Sphinx (>=5.1.1)", "black (==23.1.0)", "build (>=0.10.0)", "coverage (>=4.5.4)", "fixit (==0.1.1)", "flake8 (>=3.7.8,<5)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jinja2 (==3.1.2)", "jupyter (>=1.0.0)", "maturin (>=0.8.3,<0.14)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "pyre-check (==0.9.10)", "setuptools-rust (>=1.5.2)", "setuptools-scm (>=6.0.1)", "slotscheck (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.1.0)", "usort (==1.0.6)"]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "momento-wire-types"
@@ -425,46 +365,6 @@ files = [
     {file = "protobuf-4.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:9fee5e8aa20ef1b84123bb9232b3f4a5114d9897ed89b4b8142d81924e05d79b"},
     {file = "protobuf-4.24.4-py3-none-any.whl", hash = "sha256:80797ce7424f8c8d2f2547e2d42bfbb6c08230ce5832d6c099a37335c9c90a92"},
     {file = "protobuf-4.24.4.tar.gz", hash = "sha256:5a70731910cd9104762161719c3d883c960151eea077134458503723b60e3667"},
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-
-[[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-importlib-metadata = {version = ">=2.0.0,<5.0.0", markers = "python_version < \"3.8\""}
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 
 [[package]]
@@ -637,17 +537,6 @@ files = [
 ]
 
 [[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
-]
-
-[[package]]
 name = "termcolor"
 version = "2.3.0"
 description = "ANSI color formatting for output in terminal"
@@ -791,4 +680,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "1f76b68911c55ae1248f067264bbc563ac25dd0c0c89888f692c1a74f0df38c6"
+content-hash = "53a2bd4847085fa4019fdc62dcab57375c63b07c408ed3f3c86c6fda7114015f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -611,6 +611,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.1.6"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:88b8cdf6abf98130991cbc9f6438f35f6e8d41a02622cc5ee130a02a0ed28703"},
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c549ed437680b6105a1299d2cd30e4964211606eeb48a0ff7a93ef70b902248"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cf5f701062e294f2167e66d11b092bba7af6a057668ed618a9253e1e90cfd76"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:05991ee20d4ac4bb78385360c684e4b417edd971030ab12a4fbd075ff535050e"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87455a0c1f739b3c069e2f4c43b66479a54dea0276dd5d4d67b091265f6fd1dc"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:683aa5bdda5a48cb8266fcde8eea2a6af4e5700a392c56ea5fb5f0d4bfdc0240"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:137852105586dcbf80c1717facb6781555c4e99f520c9c827bd414fac67ddfb6"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd98138a98d48a1c36c394fd6b84cd943ac92a08278aa8ac8c0fdefcf7138f35"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0cd909d25f227ac5c36d4e7e681577275fb74ba3b11d288aff7ec47e3ae745"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8fd1c62a47aa88a02707b5dd20c5ff20d035d634aa74826b42a1da77861b5ff"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fd89b45d374935829134a082617954120d7a1470a9f0ec0e7f3ead983edc48cc"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:491262006e92f825b145cd1e52948073c56560243b55fb3b4ecb142f6f0e9543"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ea284789861b8b5ca9d5443591a92a397ac183d4351882ab52f6296b4fdd5462"},
+    {file = "ruff-0.1.6-py3-none-win32.whl", hash = "sha256:1610e14750826dfc207ccbcdd7331b6bd285607d4181df9c1c6ae26646d6848a"},
+    {file = "ruff-0.1.6-py3-none-win_amd64.whl", hash = "sha256:4558b3e178145491e9bc3b2ee3c4b42f19d19384eaa5c59d10acf6e8f8b57e33"},
+    {file = "ruff-0.1.6-py3-none-win_arm64.whl", hash = "sha256:03910e81df0d8db0e30050725a5802441c2022ea3ae4fe0609b76081731accbc"},
+    {file = "ruff-0.1.6.tar.gz", hash = "sha256:1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184"},
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -765,4 +791,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "07fce35d7034f7bd79c5466bb4f975d7484607c5b704ce840d1a5233eaee18bd"
+content-hash = "1f76b68911c55ae1248f067264bbc563ac25dd0c0c89888f692c1a74f0df38c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,12 @@ pytest-describe = "^2.0.1"
 pytest-sugar = "^0.9.5"
 
 [tool.poetry.group.lint.dependencies]
-flake8 = "^5.0.4"
 mypy = "^0.971"
 types-setuptools = "^65.3.0"
-flake8-docstrings = "^1.7.0"
 ruff = "^0.1.6"
 
 [tool.poetry.group.format.dependencies]
 black = "^22.8.0"
-isort = "^5.10.1"
 
 
 [tool.poetry.group.codegen.dependencies]
@@ -147,11 +144,6 @@ exclude = """
   | dist
 )
 """
-
-[tool.isort]
-profile = "black"
-src_paths = ["src", "tests"]
-extend_skip_glob = ["src/momento/errors/__init__.py"]
 
 [tool.ruff]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,11 @@ module = [
 disallow_any_expr = false
 
 [[tool.mypy.overrides]]
+# this file has mypy incompatibilities between py37 and later versions
+module = "momento.internal._utilities._momento_version"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 disallow_any_expr = false
 disallow_any_decorated = false
@@ -169,8 +174,9 @@ ignore = [
   "D106", # missing docstring in public nested class
   "D107", # missing docstring in __init__
 ]
-fix = true
+line-length = 120
 target-version = "py37"
+fix = true
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ extend_skip_glob = ["src/momento/errors/__init__.py"]
 
 [tool.ruff]
 select = [
+  "D", # docstring errors
   "E", # pycodestyle errors
   "W", # pycodestyle warnings
   "F", # pyflakes
@@ -167,6 +168,14 @@ ignore = [
   "B024", # abstract class without abstract methods
   "E501", # line too long, handled by black
   "C901", # function too complex
+  "D100", # missing docstring in public module
+  "D101", # missing docstring in public class
+  "D102", # missing docstring in public method
+  "D103", # missing docstring in public function
+  "D104", # missing docstring in public package
+  "D105", # missing docstring in magic method
+  "D106", # missing docstring in public nested class
+  "D107", # missing docstring in __init__
 ]
 fix = true
 target-version = "py37"
@@ -174,6 +183,9 @@ target-version = "py37"
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "src/momento/requests/vector_index/item.py" = ["E721"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ flake8 = "^5.0.4"
 mypy = "^0.971"
 types-setuptools = "^65.3.0"
 flake8-docstrings = "^1.7.0"
+ruff = "^0.1.6"
 
 [tool.poetry.group.format.dependencies]
 black = "^22.8.0"
@@ -151,6 +152,28 @@ exclude = """
 profile = "black"
 src_paths = ["src", "tests"]
 extend_skip_glob = ["src/momento/errors/__init__.py"]
+
+[tool.ruff]
+select = [
+  "E", # pycodestyle errors
+  "W", # pycodestyle warnings
+  "F", # pyflakes
+  "I", # isort
+  "C", # flake8-comprehensions
+  "B", # flake8-bugbear
+]
+ignore = [
+  "B008", # function calls as default arg; collection ttl
+  "B024", # abstract class without abstract methods
+  "E501", # line too long, handled by black
+  "C901", # function too complex
+]
+fix = true
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"src/momento/requests/vector_index/item.py" = ["E721"]
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/src/momento/auth/momento_endpoint_resolver.py
+++ b/src/momento/auth/momento_endpoint_resolver.py
@@ -66,5 +66,5 @@ def _is_base64(value: Union[bytes, str]) -> bool:
         if isinstance(value, str):
             value = value.encode("utf-8")
         return base64.b64encode(base64.b64decode(value)) == value
-    except (Exception,):
+    except Exception:
         return False

--- a/src/momento/config/transport/transport_strategy.py
+++ b/src/momento/config/transport/transport_strategy.py
@@ -62,10 +62,10 @@ class StaticGrpcConfiguration(GrpcConfiguration):
     def with_root_certificates_pem(self, root_certificates_pem_path: Path) -> GrpcConfiguration:
         try:
             root_certificates_pem_bytes = root_certificates_pem_path.read_bytes()
-        except FileNotFoundError:
-            raise FileNotFoundError(f"Root certificate file not found at path: {root_certificates_pem_path}")
-        except PermissionError:
-            raise PermissionError(f"Root certificate file not readable at path: {root_certificates_pem_path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"Root certificate file not found at path: {root_certificates_pem_path}") from e
+        except PermissionError as e:
+            raise PermissionError(f"Root certificate file not readable at path: {root_certificates_pem_path}") from e
         return StaticGrpcConfiguration(self._deadline, root_certificates_pem_bytes)
 
     def get_root_certificates_pem(self) -> Optional[bytes]:

--- a/src/momento/errors/__init__.py
+++ b/src/momento/errors/__init__.py
@@ -30,7 +30,7 @@ from .exceptions import (
 
 # NB: since this module imports from sibling modules, it must be at the bottom
 # to avoid circular imports
-from .error_converter import convert_error
+from .error_converter import convert_error  # isort: skip
 
 __all__ = [
     "MomentoErrorCode",

--- a/src/momento/internal/_utilities/_vector_index_validation.py
+++ b/src/momento/internal/_utilities/_vector_index_validation.py
@@ -11,10 +11,10 @@ def _validate_index_name(cache_name: str) -> None:
 
 
 def _validate_num_dimensions(num_dimensions: int) -> None:
-    if num_dimensions < 1 or type(num_dimensions) != int:
+    if num_dimensions < 1 or not isinstance(num_dimensions, int):
         raise InvalidArgumentException("Number of dimensions must be a positive integer.", Service.INDEX)
 
 
 def _validate_top_k(top_k: int) -> None:
-    if top_k < 1 or type(top_k) != int:
+    if top_k < 1 or not isinstance(top_k, int):
         raise InvalidArgumentException("Top k must be a positive integer.", Service.INDEX)

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -880,9 +880,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheSortedSetFetch.Miss()
             elif type == "found":
-                return CacheSortedSetFetch.Hit(
-                    list((e.value, e.score) for e in response.found.values_with_scores.elements)
-                )
+                return CacheSortedSetFetch.Hit([(e.value, e.score) for e in response.found.values_with_scores.elements])
             else:
                 raise UnknownException(f"Unknown set field in response: {type}")
         except Exception as e:
@@ -932,9 +930,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheSortedSetFetch.Miss()
             elif type == "found":
-                return CacheSortedSetFetch.Hit(
-                    list((e.value, e.score) for e in response.found.values_with_scores.elements)
-                )
+                return CacheSortedSetFetch.Hit([(e.value, e.score) for e in response.found.values_with_scores.elements])
             else:
                 raise UnknownException(f"Unknown set field in response: {type}")
         except Exception as e:

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -9,8 +9,8 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_cache_name, _validate_ttl
-from momento.internal.synchronous._scs_grpc_manager import _ControlGrpcManager
 from momento.internal.services import Service
+from momento.internal.synchronous._scs_grpc_manager import _ControlGrpcManager
 from momento.responses import (
     CacheFlush,
     CacheFlushResponse,

--- a/src/momento/internal/synchronous/_scs_control_client.py
+++ b/src/momento/internal/synchronous/_scs_control_client.py
@@ -9,8 +9,8 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_cache_name, _validate_ttl
-from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _ControlGrpcManager
+from momento.internal.services import Service
 from momento.responses import (
     CacheFlush,
     CacheFlushResponse,

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -878,9 +878,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheSortedSetFetch.Miss()
             elif type == "found":
-                return CacheSortedSetFetch.Hit(
-                    list((e.value, e.score) for e in response.found.values_with_scores.elements)
-                )
+                return CacheSortedSetFetch.Hit([(e.value, e.score) for e in response.found.values_with_scores.elements])
             else:
                 raise UnknownException(f"Unknown set field in response: {type}")
         except Exception as e:
@@ -930,9 +928,7 @@ class _ScsDataClient:
             if type == "missing":
                 return CacheSortedSetFetch.Miss()
             elif type == "found":
-                return CacheSortedSetFetch.Hit(
-                    list((e.value, e.score) for e in response.found.values_with_scores.elements)
-                )
+                return CacheSortedSetFetch.Hit([(e.value, e.score) for e in response.found.values_with_scores.elements])
             else:
                 raise UnknownException(f"Unknown set field in response: {type}")
         except Exception as e:

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -28,9 +28,9 @@ from momento.internal._utilities._data_validation import (
     _validate_sorted_set_name,
     _validate_sorted_set_score,
 )
+from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _DataGrpcManager
 from momento.internal.synchronous._utilities import make_metadata
-from momento.internal.services import Service
 from momento.requests import CollectionTtl, SortOrder
 from momento.responses import (
     CacheDelete,

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -28,9 +28,9 @@ from momento.internal._utilities._data_validation import (
     _validate_sorted_set_name,
     _validate_sorted_set_score,
 )
-from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _DataGrpcManager
 from momento.internal.synchronous._utilities import make_metadata
+from momento.internal.services import Service
 from momento.requests import CollectionTtl, SortOrder
 from momento.responses import (
     CacheDelete,

--- a/src/momento/internal/synchronous/_vector_index_control_client.py
+++ b/src/momento/internal/synchronous/_vector_index_control_client.py
@@ -7,10 +7,10 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import InvalidArgumentException, convert_error
 from momento.internal._utilities import _validate_index_name, _validate_num_dimensions
+from momento.internal.services import Service
 from momento.internal.synchronous._vector_index_grpc_manager import (
     _VectorIndexControlGrpcManager,
 )
-from momento.internal.services import Service
 from momento.requests.vector_index import SimilarityMetric
 from momento.responses.vector_index import (
     CreateIndex,

--- a/src/momento/internal/synchronous/_vector_index_control_client.py
+++ b/src/momento/internal/synchronous/_vector_index_control_client.py
@@ -7,10 +7,10 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import InvalidArgumentException, convert_error
 from momento.internal._utilities import _validate_index_name, _validate_num_dimensions
-from momento.internal.services import Service
 from momento.internal.synchronous._vector_index_grpc_manager import (
     _VectorIndexControlGrpcManager,
 )
+from momento.internal.services import Service
 from momento.requests.vector_index import SimilarityMetric
 from momento.responses.vector_index import (
     CreateIndex,

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -11,10 +11,8 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_index_name, _validate_top_k
+from momento.internal.synchronous._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.internal.services import Service
-from momento.internal.synchronous._vector_index_grpc_manager import (
-    _VectorIndexDataGrpcManager,
-)
 from momento.requests.vector_index import AllMetadata, Item
 from momento.responses.vector_index import (
     DeleteItemBatch,

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -11,8 +11,8 @@ from momento.auth import CredentialProvider
 from momento.config import VectorIndexConfiguration
 from momento.errors import convert_error
 from momento.internal._utilities import _validate_index_name, _validate_top_k
-from momento.internal.synchronous._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.internal.services import Service
+from momento.internal.synchronous._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.requests.vector_index import AllMetadata, Item
 from momento.responses.vector_index import (
     DeleteItemBatch,

--- a/src/momento/logs.py
+++ b/src/momento/logs.py
@@ -45,7 +45,8 @@ def add_logging_level(level_name: str, level_num: int, method_name: Optional[str
         warnings.warn(
             "Logging level {level} or logging method {method} already defined. Skipping.".format(
                 level=level_name, method=method_name
-            )
+            ),
+            stacklevel=1,
         )
         return False
 

--- a/src/momento/requests/vector_index/item.py
+++ b/src/momento/requests/vector_index/item.py
@@ -27,15 +27,15 @@ class Item:
         metadata = []
         if self.metadata is not None:
             for k, v in self.metadata.items():
-                if type(v) == str:
+                if type(v) is str:
                     metadata.append(pb._Metadata(field=k, string_value=v))
-                elif type(v) == int:
+                elif type(v) is int:
                     metadata.append(pb._Metadata(field=k, integer_value=v))
-                elif type(v) == float:
+                elif type(v) is float:
                     metadata.append(pb._Metadata(field=k, double_value=v))
-                elif type(v) == bool:
+                elif type(v) is bool:
                     metadata.append(pb._Metadata(field=k, boolean_value=v))
-                elif type(v) == list and all(type(x) == str for x in v):
+                elif type(v) is list and all(type(x) is str for x in v):
                     list_of_strings = pb._Metadata._ListOfStrings(values=v)
                     metadata.append(pb._Metadata(field=k, list_of_strings_value=list_of_strings))
                 else:

--- a/src/momento/responses/control/signing_key/list.py
+++ b/src/momento/responses/control/signing_key/list.py
@@ -58,8 +58,8 @@ class ListSigningKeys(ABC):
             """Creates a ListSigningKeysResponse from a grpc response.
 
             Args:
-                grpc_list_signing_keys_response (google.protobuf.message.Message):
-                endpoint (str): _description_
+                grpc_list_signing_keys_response (google.protobuf.message.Message): the grpc response
+                endpoint (str): endpoint of the signing key
 
             Returns:
                 ListSigningKeysResponse

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -21,7 +21,7 @@ class Response(ABC):
             appended = False
 
             # To truncate a collection, we must render it as a string all at once to account for the ellipsis
-            if type(value) == list:
+            if isinstance(value, list):
                 if len(value) > max_collection_length:
                     message_parts.append(
                         Response._display_list(attribute, value, max_value_length, max_collection_length)
@@ -29,7 +29,7 @@ class Response(ABC):
                     appended = True
                 else:
                     value = [Response._truncate_value(v_i, max_value_length) for v_i in value]
-            elif type(value) == set:
+            elif isinstance(value, set):
                 if len(value) > max_collection_length:
                     message_parts.append(
                         Response._display_set(attribute, value, max_value_length, max_collection_length)
@@ -37,7 +37,7 @@ class Response(ABC):
                     appended = True
                 else:
                     value = {Response._truncate_value(v_i, max_value_length) for v_i in value}
-            elif type(value) == dict:
+            elif isinstance(value, dict):
                 if len(value) > max_collection_length:
                     message_parts.append(
                         Response._display_dict(attribute, value, max_value_length, max_collection_length)
@@ -90,12 +90,12 @@ class Response(ABC):
     @staticmethod
     @no_type_check
     def _truncate_value(value: Any, max_length: int = 32) -> Any:
-        if type(value) == bytes:
+        if isinstance(value, bytes):
             if len(value) < max_length:
                 return value
 
             return value[:max_length] + b"..."
-        elif type(value) == str:
+        elif isinstance(value, str):
             if len(value) < max_length:
                 return value
 

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -12,9 +12,7 @@ try:
     from momento.internal.synchronous._vector_index_control_client import (
         _VectorIndexControlClient,
     )
-    from momento.internal.synchronous._vector_index_data_client import (
-        _VectorIndexDataClient,
-    )
+    from momento.internal.synchronous._vector_index_data_client import _VectorIndexDataClient
 except ImportError as e:
     if e.name == "cygrpc":
         import sys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from typing import AsyncIterator, Callable, Iterator, List, Optional, Union, cas
 
 import pytest
 import pytest_asyncio
-
 from momento import (
     CacheClient,
     CacheClientAsync,
@@ -41,6 +40,7 @@ from momento.typing import (
     TSortedSetValues,
     TTopicName,
 )
+
 from tests.utils import (
     unique_test_cache_name,
     unique_test_vector_index_name,
@@ -199,7 +199,7 @@ def dictionary_fields() -> TDictionaryFields:
 
 @pytest.fixture
 def dictionary_items() -> TDictionaryItems:
-    return cast(TDictionaryItems, dict([(uuid_str(), uuid_str()), (uuid_bytes(), uuid_bytes())]))
+    return cast(TDictionaryItems, {uuid_str(): uuid_str(), uuid_bytes(): uuid_bytes()})
 
 
 @pytest.fixture
@@ -239,7 +239,7 @@ def sorted_set_score() -> TSortedSetScore:
 
 @pytest.fixture
 def sorted_set_elements() -> TSortedSetElements:
-    return cast(TSortedSetElements, dict([(uuid_str(), random.random()), (uuid_bytes(), random.random())]))
+    return cast(TSortedSetElements, {uuid_str(): random.random(), uuid_bytes(): random.random()})
 
 
 @pytest.fixture

--- a/tests/momento/aio/client_interceptor_test.py
+++ b/tests/momento/aio/client_interceptor_test.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 import grpc.aio
 import pytest
-
 from momento.errors import InvalidArgumentException
 from momento.internal.aio._add_header_client_interceptor import (
     sanitize_client_call_details,

--- a/tests/momento/auth/test_credential_provider.py
+++ b/tests/momento/auth/test_credential_provider.py
@@ -4,9 +4,9 @@ import os
 
 import jwt
 import pytest
-
 from momento.auth.credential_provider import CredentialProvider
 from momento.auth.momento_endpoint_resolver import _Base64DecodedV1Token
+
 from tests.utils import uuid_str
 
 test_email = "user@test.com"

--- a/tests/momento/cache_client/shared_behaviors.py
+++ b/tests/momento/cache_client/shared_behaviors.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from typing_extensions import Protocol
-
 from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
 from momento.typing import TCacheName, TScalarKey
+from typing_extensions import Protocol
+
 from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 

--- a/tests/momento/cache_client/shared_behaviors_async.py
+++ b/tests/momento/cache_client/shared_behaviors_async.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Awaitable
 
-from typing_extensions import Protocol
-
 from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheResponse
 from momento.typing import TCacheName, TScalarKey
+from typing_extensions import Protocol
+
 from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 

--- a/tests/momento/cache_client/test_control.py
+++ b/tests/momento/cache_client/test_control.py
@@ -16,6 +16,7 @@ from momento.responses import (
     ListSigningKeys,
     RevokeSigningKey,
 )
+
 from tests.conftest import TUniqueCacheName
 from tests.utils import uuid_str
 

--- a/tests/momento/cache_client/test_control_async.py
+++ b/tests/momento/cache_client/test_control_async.py
@@ -16,6 +16,7 @@ from momento.responses import (
     ListSigningKeys,
     RevokeSigningKey,
 )
+
 from tests.conftest import TUniqueCacheNameAsync
 from tests.utils import uuid_str
 

--- a/tests/momento/cache_client/test_dictionary.py
+++ b/tests/momento/cache_client/test_dictionary.py
@@ -5,10 +5,6 @@ from functools import partial
 from time import sleep
 from typing import Union, cast
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -36,6 +32,10 @@ from momento.typing import (
     TDictionaryName,
     TDictionaryValue,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_str
 
 from .shared_behaviors import (
@@ -267,7 +267,7 @@ def a_dictionary_setter() -> None:
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
-        items = dict([("one", "1"), ("two", "2"), ("three", "3"), ("four", "4")])
+        items = {"one": "1", "two": "2", "three": "3", "four": "4"}
 
         for field, value in items.items():
             dictionary_setter(client, cache_name, dictionary_name, field, value, ttl=ttl)
@@ -496,7 +496,7 @@ def describe_dictionary_get_fields() -> None:
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> None:
-        dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
+        dictionary_items: dict[str, str] = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
         set_response = client.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 
@@ -517,7 +517,7 @@ def describe_dictionary_get_fields() -> None:
     def it_excludes_misses_from_dictionary(
         client: CacheClient, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
-        dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
+        dictionary_items: dict[str, str] = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
         set_response = client.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 

--- a/tests/momento/cache_client/test_dictionary_async.py
+++ b/tests/momento/cache_client/test_dictionary_async.py
@@ -5,10 +5,6 @@ from functools import partial
 from time import sleep
 from typing import Awaitable, Union, cast
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -36,6 +32,10 @@ from momento.typing import (
     TDictionaryName,
     TDictionaryValue,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_str
 
 from .shared_behaviors_async import (
@@ -267,7 +267,7 @@ def a_dictionary_setter() -> None:
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
-        items = dict([("one", "1"), ("two", "2"), ("three", "3"), ("four", "4")])
+        items = {"one": "1", "two": "2", "three": "3", "four": "4"}
 
         for field, value in items.items():
             await dictionary_setter(client_async, cache_name, dictionary_name, field, value, ttl=ttl)
@@ -500,7 +500,7 @@ def describe_dictionary_get_fields() -> None:
         cache_name: TCacheName,
         dictionary_name: TDictionaryName,
     ) -> None:
-        dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
+        dictionary_items: dict[str, str] = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
         set_response = await client_async.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 
@@ -521,7 +521,7 @@ def describe_dictionary_get_fields() -> None:
     async def it_excludes_misses_from_dictionary(
         client_async: CacheClientAsync, cache_name: TCacheName, dictionary_name: TDictionaryName
     ) -> None:
-        dictionary_items: dict[str, str] = dict([(uuid_str(), uuid_str()), (uuid_str(), uuid_str())])
+        dictionary_items: dict[str, str] = {uuid_str(): uuid_str(), uuid_str(): uuid_str()}
         set_response = await client_async.dictionary_set_fields(cache_name, dictionary_name, dictionary_items)
         assert isinstance(set_response, CacheDictionarySetFields.Success)
 

--- a/tests/momento/cache_client/test_init.py
+++ b/tests/momento/cache_client/test_init.py
@@ -2,7 +2,6 @@ import os
 from datetime import timedelta
 
 import pytest
-
 from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration

--- a/tests/momento/cache_client/test_init_async.py
+++ b/tests/momento/cache_client/test_init_async.py
@@ -2,7 +2,6 @@ import os
 from datetime import timedelta
 
 import pytest
-
 from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration

--- a/tests/momento/cache_client/test_list.py
+++ b/tests/momento/cache_client/test_list.py
@@ -6,10 +6,6 @@ from functools import partial
 from time import sleep
 
 import pytest
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -34,6 +30,10 @@ from momento.typing import (
     TListValuesInput,
     TListValuesInputStr,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors import (
@@ -216,7 +216,7 @@ def a_list_name_validator() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert response.inner_exception.message == "List name must be a string"
         else:
-            assert False
+            raise AssertionError("Expected an ErrorResponseMixin")
 
     def with_empty_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
         response = list_name_validator(list_name="")
@@ -367,7 +367,7 @@ def describe_list_concatenate_back() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["three", "four", "five", "six"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -446,7 +446,7 @@ def describe_list_concatenate_front() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["four", "five", "six", "one"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -652,7 +652,7 @@ def describe_list_push_back() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["2", "3"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -718,7 +718,7 @@ def describe_list_push_front() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["3", "2"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -770,4 +770,4 @@ def describe_list_remove_value() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == expected_values
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")

--- a/tests/momento/cache_client/test_list_async.py
+++ b/tests/momento/cache_client/test_list_async.py
@@ -7,10 +7,6 @@ from time import sleep
 from typing import Awaitable
 
 import pytest
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -35,6 +31,10 @@ from momento.typing import (
     TListValuesInput,
     TListValuesInputStr,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (
@@ -219,7 +219,7 @@ def a_list_name_validator() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert response.inner_exception.message == "List name must be a string"
         else:
-            assert False
+            raise AssertionError("Expected an ErrorResponseMixin")
 
     async def with_empty_list_name_it_returns_invalid(list_name_validator: TListNameValidator) -> None:
         response = await list_name_validator(list_name="")
@@ -370,7 +370,7 @@ def describe_list_concatenate_back() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["three", "four", "five", "six"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -449,7 +449,7 @@ def describe_list_concatenate_front() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["four", "five", "six", "one"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -657,7 +657,7 @@ def describe_list_push_back() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["2", "3"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -723,7 +723,7 @@ def describe_list_push_front() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == ["3", "2"]
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")
 
 
 @behaves_like(
@@ -775,4 +775,4 @@ def describe_list_remove_value() -> None:
         if isinstance(fetch_resp, CacheListFetch.Hit):
             assert fetch_resp.value_list_string == expected_values
         else:
-            assert False
+            raise AssertionError("Expected a CacheListFetch.Hit")

--- a/tests/momento/cache_client/test_scalar.py
+++ b/tests/momento/cache_client/test_scalar.py
@@ -3,16 +3,16 @@ from datetime import timedelta
 from functools import partial
 from typing import Optional
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClient
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheDelete, CacheGet, CacheSet, CacheSetIfNotExists
 from momento.responses.mixins import ErrorResponseMixin
 from momento.responses.response import CacheResponse
 from momento.typing import TCacheName, TScalarKey, TScalarValue
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import str_to_bytes, uuid_bytes, uuid_str
 
 from .shared_behaviors import (
@@ -69,7 +69,7 @@ def a_ttl_setter() -> None:
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "TTL must be a positive amount of time."
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
 
 class TSetter(Protocol):
@@ -85,7 +85,7 @@ def a_setter() -> None:
         if isinstance(set_response, ErrorResponseMixin):
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
     def with_bad_value_throws_exception(setter: TSetter, client: CacheClient, cache_name: str) -> None:
         set_response = setter(cache_name, "foo", 1)  # type:ignore[arg-type]
@@ -93,7 +93,7 @@ def a_setter() -> None:
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "Unsupported type for value: <class 'int'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
 
 def describe_set_and_get() -> None:
@@ -109,7 +109,7 @@ def describe_set_and_get() -> None:
             assert get_resp.value_string == value
             assert get_resp.value_bytes == str_to_bytes(value)
         else:
-            assert False
+            raise AssertionError("Expected a hit response.")
 
     def with_byte_key_values(client: CacheClient, cache_name: str) -> None:
         key = uuid_bytes()
@@ -136,7 +136,7 @@ def describe_set_and_get_eager_connection_client() -> None:
             assert get_resp.value_string == value
             assert get_resp.value_bytes == str_to_bytes(value)
         else:
-            assert False
+            raise AssertionError("Expected a hit response.")
 
     def with_byte_key_values(client_eager_connection: CacheClient, cache_name: str) -> None:
         key = uuid_bytes()

--- a/tests/momento/cache_client/test_scalar_async.py
+++ b/tests/momento/cache_client/test_scalar_async.py
@@ -3,16 +3,16 @@ from datetime import timedelta
 from functools import partial
 from typing import Awaitable, Optional
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClientAsync
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheDelete, CacheGet, CacheSet, CacheSetIfNotExists
 from momento.responses.mixins import ErrorResponseMixin
 from momento.responses.response import CacheResponse
 from momento.typing import TCacheName, TScalarKey, TScalarValue
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import str_to_bytes, uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (
@@ -77,7 +77,7 @@ def a_ttl_setter() -> None:
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "TTL must be a positive amount of time."
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
 
 class TSetter(Protocol):
@@ -95,7 +95,7 @@ def a_setter() -> None:
         if isinstance(set_response, ErrorResponseMixin):
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
     async def with_bad_value_throws_exception(setter: TSetter, client_async: CacheClientAsync, cache_name: str) -> None:
         set_response = await setter(cache_name, "foo", 1)  # type:ignore[arg-type]
@@ -103,7 +103,7 @@ def a_setter() -> None:
             assert set_response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert set_response.inner_exception.message == "Unsupported type for value: <class 'int'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response.")
 
 
 def describe_set_and_get() -> None:
@@ -119,7 +119,7 @@ def describe_set_and_get() -> None:
             assert get_resp.value_string == value
             assert get_resp.value_bytes == str_to_bytes(value)
         else:
-            assert False
+            raise AssertionError("Expected a hit response.")
 
     async def with_byte_key_values(client_async: CacheClientAsync, cache_name: str) -> None:
         key = uuid_bytes()
@@ -146,7 +146,7 @@ def describe_set_and_get_eager_connection_client() -> None:
             assert get_resp.value_string == value
             assert get_resp.value_bytes == str_to_bytes(value)
         else:
-            assert False
+            raise AssertionError("Expected a hit response.")
 
     async def with_byte_key_values(client_async_eager_connection: CacheClientAsync, cache_name: str) -> None:
         key = uuid_bytes()

--- a/tests/momento/cache_client/test_set.py
+++ b/tests/momento/cache_client/test_set.py
@@ -4,10 +4,6 @@ from datetime import timedelta
 from functools import partial
 from time import sleep
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClient
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -23,6 +19,10 @@ from momento.responses import (
 )
 from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TSetElement, TSetElementsInput, TSetName
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors import (
@@ -123,7 +123,7 @@ def a_set_which_takes_an_element() -> None:
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'int'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
     def it_errors_with_none(
         set_which_takes_an_element: TSetWhichTakesAnElement,
@@ -135,7 +135,7 @@ def a_set_which_takes_an_element() -> None:
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'NoneType'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
 
 class TSetNameValidator(Protocol):
@@ -150,7 +150,7 @@ def a_set_name_validator() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert response.inner_exception.message == "Set name must be a string"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
     def with_empty_set_name_it_returns_invalid(set_name_validator: TSetNameValidator) -> None:
         response = set_name_validator(set_name="")

--- a/tests/momento/cache_client/test_set_async.py
+++ b/tests/momento/cache_client/test_set_async.py
@@ -5,10 +5,6 @@ from functools import partial
 from time import sleep
 from typing import Awaitable
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClientAsync
 from momento.auth import CredentialProvider
 from momento.config import Configuration
@@ -24,6 +20,10 @@ from momento.responses import (
 )
 from momento.responses.mixins import ErrorResponseMixin
 from momento.typing import TCacheName, TSetElement, TSetElementsInput, TSetName
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (
@@ -124,7 +124,7 @@ def a_set_which_takes_an_element() -> None:
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'int'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
     async def it_errors_with_none(
         set_which_takes_an_element: TSetWhichTakesAnElement,
@@ -136,7 +136,7 @@ def a_set_which_takes_an_element() -> None:
             assert resp.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert resp.inner_exception.message == "Could not convert the given type to bytes: <class 'NoneType'>"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
 
 class TSetNameValidator(Protocol):
@@ -151,7 +151,7 @@ def a_set_name_validator() -> None:
             assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
             assert response.inner_exception.message == "Set name must be a string"
         else:
-            assert False
+            raise AssertionError("Expected an error response")
 
     async def with_empty_set_name_it_returns_invalid(set_name_validator: TSetNameValidator) -> None:
         response = await set_name_validator(set_name="")

--- a/tests/momento/cache_client/test_sorted_set.py
+++ b/tests/momento/cache_client/test_sorted_set.py
@@ -3,10 +3,6 @@ from functools import partial
 from time import sleep
 from typing import Optional
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Protocol
-
 from momento import CacheClient, CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -32,6 +28,10 @@ from momento.typing import (
     TSortedSetValue,
     TSortedSetValues,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Protocol
+
 from tests.utils import uuid_str
 
 from .shared_behaviors import (
@@ -109,8 +109,8 @@ def a_sorted_set_setter() -> None:
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
-        elements = dict([("one", 1.0), ("two", 2.0), ("three", 3.0), ("four", 4.0)])
-        elements_list = [(value, score) for value, score in sorted(elements.items(), key=lambda item: item[1])]
+        elements = {"one": 1.0, "two": 2.0, "three": 3.0, "four": 4.0}
+        elements_list = sorted(elements.items(), key=lambda item: item[1])
 
         sorted_set_setter(client, cache_name, sorted_set_name, elements, ttl=ttl)
 

--- a/tests/momento/cache_client/test_sorted_set_async.py
+++ b/tests/momento/cache_client/test_sorted_set_async.py
@@ -3,10 +3,6 @@ from functools import partial
 from time import sleep
 from typing import Optional
 
-from pytest import fixture
-from pytest_describe import behaves_like
-from typing_extensions import Awaitable, Protocol
-
 from momento import CacheClientAsync, CredentialProvider
 from momento.config import Configuration
 from momento.errors import MomentoErrorCode
@@ -32,6 +28,10 @@ from momento.typing import (
     TSortedSetValue,
     TSortedSetValues,
 )
+from pytest import fixture
+from pytest_describe import behaves_like
+from typing_extensions import Awaitable, Protocol
+
 from tests.utils import uuid_str
 
 from .shared_behaviors_async import (
@@ -109,8 +109,8 @@ def a_sorted_set_setter() -> None:
     ) -> None:
         ttl_seconds = 1
         ttl = CollectionTtl.of(timedelta(seconds=ttl_seconds))
-        elements = dict([("one", 1.0), ("two", 2.0), ("three", 3.0), ("four", 4.0)])
-        elements_list = [(value, score) for value, score in sorted(elements.items(), key=lambda item: item[1])]
+        elements = {"one": 1.0, "two": 2.0, "three": 3.0, "four": 4.0}
+        elements_list = sorted(elements.items(), key=lambda item: item[1])
 
         await sorted_set_setter(client_async, cache_name, sorted_set_name, elements, ttl=ttl)
 

--- a/tests/momento/cache_client/test_sorted_set_simple.py
+++ b/tests/momento/cache_client/test_sorted_set_simple.py
@@ -27,7 +27,7 @@ def test_sorted_set_fetch_by_score_fetch_all(client: CacheClient, cache_name: st
     scores = _populate_scores(client, cache_name, sorted_set_name)
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()]
+        assert resp.value_list_string == list(scores.items())
 
 
 def test_sorted_set_fetch_by_score_fetch_all_descending(
@@ -36,7 +36,7 @@ def test_sorted_set_fetch_by_score_fetch_all_descending(
     scores = _populate_scores(client, cache_name, sorted_set_name)
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, sort_order=SortOrder.DESCENDING)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()]
+        expected = list(scores.items())
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -70,7 +70,7 @@ def test_sorted_set_fetch_by_score_fetch_all_with_offset(
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][2:]
+        assert resp.value_list_string == list(scores.items())[2:]
 
 
 def test_sorted_set_fetch_by_score_fetch_all_with_offset_descending(
@@ -80,7 +80,7 @@ def test_sorted_set_fetch_by_score_fetch_all_with_offset_descending(
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset=2, sort_order=SortOrder.DESCENDING)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][:2]
+        expected = list(scores.items())[:2]
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -92,7 +92,7 @@ def test_sorted_set_fetch_by_score_fetch_all_with_count(
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, count=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][:2]
+        assert resp.value_list_string == list(scores.items())[:2]
 
 
 def test_sorted_set_fetch_by_score_fetch_all_with_count_descending(
@@ -102,7 +102,7 @@ def test_sorted_set_fetch_by_score_fetch_all_with_count_descending(
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, count=2, sort_order=SortOrder.DESCENDING)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][2:]
+        expected = list(scores.items())[2:]
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -114,7 +114,7 @@ def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count(
     resp = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset=1, count=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][1:3]
+        assert resp.value_list_string == list(scores.items())[1:3]
 
 
 def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count_descending(
@@ -126,6 +126,6 @@ def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count_descending(
     )
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][1:3]
+        expected = list(scores.items())[1:3]
         expected.reverse()
         assert resp.value_list_string == expected

--- a/tests/momento/cache_client/test_sorted_set_simple_async.py
+++ b/tests/momento/cache_client/test_sorted_set_simple_async.py
@@ -29,7 +29,7 @@ async def test_sorted_set_fetch_by_score_fetch_all(
     scores = await _populate_scores(client_async, cache_name, sorted_set_name)
     resp = await client_async.sorted_set_fetch_by_score(cache_name, sorted_set_name)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()]
+        assert resp.value_list_string == list(scores.items())
 
 
 async def test_sorted_set_fetch_by_score_fetch_all_descending(
@@ -38,7 +38,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_descending(
     scores = await _populate_scores(client_async, cache_name, sorted_set_name)
     resp = await client_async.sorted_set_fetch_by_score(cache_name, sorted_set_name, sort_order=SortOrder.DESCENDING)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()]
+        expected = list(scores.items())
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -74,7 +74,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_offset(
     resp = await client_async.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][2:]
+        assert resp.value_list_string == list(scores.items())[2:]
 
 
 async def test_sorted_set_fetch_by_score_fetch_all_with_offset_descending(
@@ -86,7 +86,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_offset_descending(
     )
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][:2]
+        expected = list(scores.items())[:2]
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -98,7 +98,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_count(
     resp = await client_async.sorted_set_fetch_by_score(cache_name, sorted_set_name, count=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][:2]
+        assert resp.value_list_string == list(scores.items())[:2]
 
 
 async def test_sorted_set_fetch_by_score_fetch_all_with_count_descending(
@@ -110,7 +110,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_count_descending(
     )
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][2:]
+        expected = list(scores.items())[2:]
         expected.reverse()
         assert resp.value_list_string == expected
 
@@ -122,7 +122,7 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count(
     resp = await client_async.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset=1, count=2)
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        assert resp.value_list_string == [(k, v) for k, v in scores.items()][1:3]
+        assert resp.value_list_string == list(scores.items())[1:3]
 
 
 async def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count_descending(
@@ -134,6 +134,6 @@ async def test_sorted_set_fetch_by_score_fetch_all_with_offset_and_count_descend
     )
     assert isinstance(resp, CacheSortedSetFetch.Hit)
     if isinstance(resp, CacheSortedSetFetch.Hit):
-        expected = [(k, v) for k, v in scores.items()][1:3]
+        expected = list(scores.items())[1:3]
         expected.reverse()
         assert resp.value_list_string == expected

--- a/tests/momento/config/test_config.py
+++ b/tests/momento/config/test_config.py
@@ -2,12 +2,12 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
-
 from momento import CacheClient, CacheClientAsync, Configurations, CredentialProvider
 from momento.config import Configuration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors import MomentoErrorCode
 from momento.responses import CacheGet, ListCaches
+
 from tests.utils import unique_test_cache_name
 
 

--- a/tests/momento/config/test_vector_index_config.py
+++ b/tests/momento/config/test_vector_index_config.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from momento import (
     CredentialProvider,
     PreviewVectorIndexClient,
@@ -12,6 +11,7 @@ from momento.config import VectorIndexConfiguration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors.error_details import MomentoErrorCode
 from momento.responses.vector_index import ListIndexes, Search
+
 from tests.utils import unique_test_vector_index_name
 
 

--- a/tests/momento/internal/test_codegen.py
+++ b/tests/momento/internal/test_codegen.py
@@ -1,6 +1,5 @@
-import pytest
-
 import momento.internal.codegen as codegen
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/momento/requests/test_collection_ttl.py
+++ b/tests/momento/requests/test_collection_ttl.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from typing import Optional
 
 import pytest
-
 from momento.errors import InvalidArgumentException
 from momento.requests import CollectionTtl
 

--- a/tests/momento/requests/vector_index/test_item.py
+++ b/tests/momento/requests/vector_index/test_item.py
@@ -1,5 +1,4 @@
 import pytest
-
 from momento.errors.exceptions import InvalidArgumentException
 from momento.internal.services import Service
 from momento.requests.vector_index import Item

--- a/tests/momento/responses/test_cache_dictionary_fetch_response.py
+++ b/tests/momento/responses/test_cache_dictionary_fetch_response.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from momento.responses import CacheDictionaryFetch
 
 

--- a/tests/momento/responses/test_cache_get_response.py
+++ b/tests/momento/responses/test_cache_get_response.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from momento.responses import CacheGet
 
 

--- a/tests/momento/responses/test_cache_list_fetch_response.py
+++ b/tests/momento/responses/test_cache_list_fetch_response.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from momento.responses import CacheListFetch
 
 

--- a/tests/momento/responses/test_cache_set_fetch_response.py
+++ b/tests/momento/responses/test_cache_set_fetch_response.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from momento.responses import CacheSetFetch
 
 

--- a/tests/momento/topic_client/shared_behaviors.py
+++ b/tests/momento/topic_client/shared_behaviors.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing_extensions import Protocol
-
 from momento.errors import MomentoErrorCode
 from momento.responses import PubsubResponse
 from momento.typing import TCacheName, TTopicName
+from typing_extensions import Protocol
+
 from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 

--- a/tests/momento/topic_client/shared_behaviors_async.py
+++ b/tests/momento/topic_client/shared_behaviors_async.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Awaitable
 
-from typing_extensions import Protocol
-
 from momento.errors import MomentoErrorCode
 from momento.responses import PubsubResponse
 from momento.typing import TCacheName, TTopicName
+from typing_extensions import Protocol
+
 from tests.asserts import assert_response_is_error
 from tests.utils import uuid_str
 

--- a/tests/momento/topic_client/test_topics.py
+++ b/tests/momento/topic_client/test_topics.py
@@ -1,10 +1,10 @@
 from functools import partial
 
+from momento import CacheClient, TopicClient
+from momento.responses import TopicPublish, TopicSubscribe, TopicSubscriptionItem
 from pytest import fixture
 from pytest_describe import behaves_like
 
-from momento import CacheClient, TopicClient
-from momento.responses import TopicPublish, TopicSubscribe, TopicSubscriptionItem
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors import (

--- a/tests/momento/topic_client/test_topics_async.py
+++ b/tests/momento/topic_client/test_topics_async.py
@@ -1,10 +1,10 @@
 from functools import partial
 
+from momento import CacheClientAsync, TopicClientAsync
+from momento.responses import TopicPublish, TopicSubscribe, TopicSubscriptionItem
 from pytest import fixture
 from pytest_describe import behaves_like
 
-from momento import CacheClientAsync, TopicClientAsync
-from momento.responses import TopicPublish, TopicSubscribe, TopicSubscriptionItem
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (

--- a/tests/momento/vector_index_client/test_control.py
+++ b/tests/momento/vector_index_client/test_control.py
@@ -1,5 +1,4 @@
 import pytest
-
 from momento import CredentialProvider, PreviewVectorIndexClient
 from momento.config import VectorIndexConfiguration
 from momento.errors import MomentoErrorCode
@@ -10,6 +9,7 @@ from momento.responses.vector_index import (
     IndexInfo,
     ListIndexes,
 )
+
 from tests.conftest import TUniqueVectorIndexName
 from tests.utils import unique_test_vector_index_name
 

--- a/tests/momento/vector_index_client/test_control_async.py
+++ b/tests/momento/vector_index_client/test_control_async.py
@@ -1,5 +1,4 @@
 import pytest
-
 from momento import CredentialProvider, PreviewVectorIndexClientAsync
 from momento.config import VectorIndexConfiguration
 from momento.errors import MomentoErrorCode
@@ -10,6 +9,7 @@ from momento.responses.vector_index import (
     IndexInfo,
     ListIndexes,
 )
+
 from tests.conftest import TUniqueVectorIndexNameAsync
 from tests.utils import unique_test_vector_index_name
 

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Optional
 
 import pytest
-
 from momento import PreviewVectorIndexClient
 from momento.errors import MomentoErrorCode
 from momento.requests.vector_index import ALL_METADATA, Item, SimilarityMetric
@@ -15,6 +14,7 @@ from momento.responses.vector_index import (
     SearchHit,
     UpsertItemBatch,
 )
+
 from tests.conftest import TUniqueVectorIndexName
 from tests.utils import sleep, when_fetching_vectors_apply_vectors_to_hits
 

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Optional
 
 import pytest
-
 from momento import PreviewVectorIndexClientAsync
 from momento.errors import MomentoErrorCode
 from momento.requests.vector_index import ALL_METADATA, Item, SimilarityMetric
@@ -15,6 +14,7 @@ from momento.responses.vector_index import (
     SearchHit,
     UpsertItemBatch,
 )
+
 from tests.conftest import TUniqueVectorIndexNameAsync
 from tests.utils import sleep_async, when_fetching_vectors_apply_vectors_to_hits
 


### PR DESCRIPTION
[Ruff](https://github.com/astral-sh/ruff) is a drop in replacement for flake8, isort, black, and their various plugins. This simplifies the toolchain, is much faster to run, and does much more comprehensive static analysis.

In this PR we've added ruff and corrected errors.