### PR TITLE
ci: fix example clobbering

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -78,6 +78,10 @@ jobs:
             package: py310
           - python-version: "3.11"
             package: py310
+      # For simplicity, the examples use a cache called "test-cache"
+      # Therefore we cannot run them in parallel or else we could prematurely delete
+      # the cache for one job in another job.
+      max-parallel: 1
 
     env:
       # TODO: remove token stored as secret in favor of using a


### PR DESCRIPTION
The examples use a cache called `test-cache`. This is hard-coded and
easy to read for a nice user experience. Because of this, we need to
run the examples sequentially or else one job may delete the cache
while another job is still working.
