### PR TITLE
refactor: prefer `values` accessor over `hits`

### DIFF
--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -200,7 +200,7 @@ class _VectorIndexDataClient:
             _validate_index_name(index_name)
 
             if len(ids) == 0:
-                return GetItemBatch.Success(hits={})
+                return GetItemBatch.Success(values={})
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
@@ -227,7 +227,7 @@ class _VectorIndexDataClient:
             _validate_index_name(index_name)
 
             if len(ids) == 0:
-                return GetItemMetadataBatch.Success(hits={})
+                return GetItemMetadataBatch.Success(values={})
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -200,7 +200,7 @@ class _VectorIndexDataClient:
             _validate_index_name(index_name)
 
             if len(ids) == 0:
-                return GetItemBatch.Success(hits={})
+                return GetItemBatch.Success(values={})
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
@@ -227,7 +227,7 @@ class _VectorIndexDataClient:
             _validate_index_name(index_name)
 
             if len(ids) == 0:
-                return GetItemMetadataBatch.Success(hits={})
+                return GetItemMetadataBatch.Success(values={})
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,

--- a/src/momento/responses/vector_index/data/get_item_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_batch.py
@@ -31,24 +31,24 @@ class GetItemBatch(ABC):
     class Success(GetItemBatchResponse):
         """Contains the result of a `get_item_batch` request."""
 
-        hits: dict[str, Item]
+        values: dict[str, Item]
         """The items that were found."""
 
         @staticmethod
         def from_proto(response: pb._GetItemBatchResponse) -> "GetItemBatch.Success":
             """Converts a proto hit to a `GetItemBatch.Success`."""
-            hits = {}
+            values = {}
             for item in response.item_response:
                 type = item.WhichOneof("response")
                 if type == "hit":
                     id_, metadata = item.hit.id, pb_metadata_to_dict(item.hit.metadata)
-                    hits[id_] = Item(id=id_, vector=list(item.hit.vector.elements), metadata=metadata)
+                    values[id_] = Item(id=id_, vector=list(item.hit.vector.elements), metadata=metadata)
                 elif type == "miss":
                     pass
                 else:
                     raise UnknownException(f"Unknown response type {type!r}.")
 
-            return GetItemBatch.Success(hits=hits)
+            return GetItemBatch.Success(values=values)
 
     class Error(GetItemBatchResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request.

--- a/src/momento/responses/vector_index/data/get_item_metadata_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_metadata_batch.py
@@ -31,23 +31,23 @@ class GetItemMetadataBatch(ABC):
     class Success(GetItemMetadataBatchResponse):
         """Contains the result of a `get_item_metadata_batch` request."""
 
-        hits: dict[str, Metadata]
+        values: dict[str, Metadata]
         """The metadata of the items that were found."""
 
         @staticmethod
         def from_proto(response: pb._GetItemMetadataBatchResponse) -> "GetItemMetadataBatch.Success":
             """Converts a proto hit to a `GetItemMetadataBatch.Success`."""
-            hits = {}
+            values = {}
             for item in response.item_metadata_response:
                 type = item.WhichOneof("response")
                 if type == "hit":
-                    hits[item.hit.id] = pb_metadata_to_dict(item.hit.metadata)
+                    values[item.hit.id] = pb_metadata_to_dict(item.hit.metadata)
                 elif type == "miss":
                     pass
                 else:
                     raise UnknownException(f"Unknown response type {type!r}.")
 
-            return GetItemMetadataBatch.Success(hits=hits)
+            return GetItemMetadataBatch.Success(values=values)
 
     class Error(GetItemMetadataBatchResponse, ErrorResponseMixin):
         """Contains information about an error returned from a request.

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -653,7 +653,7 @@ def test_delete_deletes_ids(
         "get_item_method_name",
         "ids",
         "expected_get_item_response",
-        "expected_get_item_hits",
+        "expected_get_item_values",
     ],
     [
         ("get_item_batch", [], GetItemBatch.Success, {}),
@@ -700,7 +700,7 @@ def test_get_items_by_id(
     get_item_method_name: str,
     ids: list[str],
     expected_get_item_response: type[GetItemMetadataBatch.Success] | type[GetItemBatch.Success],
-    expected_get_item_hits: dict[str, Metadata] | dict[str, Item],
+    expected_get_item_values: dict[str, Metadata] | dict[str, Item],
 ) -> None:
     index_name = unique_vector_index_name(vector_index_client)
     create_response = vector_index_client.create_index(index_name, num_dimensions=2)
@@ -722,4 +722,4 @@ def test_get_items_by_id(
     get_item = getattr(vector_index_client, get_item_method_name)
     get_item_response = get_item(index_name, ids)
     assert isinstance(get_item_response, expected_get_item_response)
-    assert get_item_response.values == expected_get_item_hits
+    assert get_item_response.values == expected_get_item_values

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -722,4 +722,4 @@ def test_get_items_by_id(
     get_item = getattr(vector_index_client, get_item_method_name)
     get_item_response = get_item(index_name, ids)
     assert isinstance(get_item_response, expected_get_item_response)
-    assert get_item_response.hits == expected_get_item_hits
+    assert get_item_response.values == expected_get_item_hits

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -657,7 +657,7 @@ async def test_delete_deletes_ids(
         "get_item_method_name",
         "ids",
         "expected_get_item_response",
-        "expected_get_item_hits",
+        "expected_get_item_values",
     ],
     [
         ("get_item_batch", [], GetItemBatch.Success, {}),
@@ -704,7 +704,7 @@ async def test_get_items_by_id(
     get_item_method_name: str,
     ids: list[str],
     expected_get_item_response: type[GetItemMetadataBatch.Success] | type[GetItemBatch.Success],
-    expected_get_item_hits: dict[str, Metadata] | dict[str, Item],
+    expected_get_item_values: dict[str, Metadata] | dict[str, Item],
 ) -> None:
     index_name = unique_vector_index_name_async(vector_index_client_async)
     create_response = await vector_index_client_async.create_index(index_name, num_dimensions=2)
@@ -726,4 +726,4 @@ async def test_get_items_by_id(
     get_item = getattr(vector_index_client_async, get_item_method_name)
     get_item_response = await get_item(index_name, ids)
     assert isinstance(get_item_response, expected_get_item_response)
-    assert get_item_response.values == expected_get_item_hits
+    assert get_item_response.values == expected_get_item_values

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -726,4 +726,4 @@ async def test_get_items_by_id(
     get_item = getattr(vector_index_client_async, get_item_method_name)
     get_item_response = await get_item(index_name, ids)
     assert isinstance(get_item_response, expected_get_item_response)
-    assert get_item_response.hits == expected_get_item_hits
+    assert get_item_response.values == expected_get_item_hits


### PR DESCRIPTION
We reserve `values` for getters, consistent with the cache
usage. `hits` is standard for search results though.
