### PR TITLE
feat: mvi filter expressions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -170,13 +170,13 @@ dev = ["Sphinx (>=5.1.1)", "black (==23.1.0)", "build (>=0.10.0)", "coverage (>=
 
 [[package]]
 name = "momento-wire-types"
-version = "0.97.1"
+version = "0.98.0"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.97.1-py3-none-any.whl", hash = "sha256:de56563db12e53c6511927e1b1277e1a6c53c64d3fe89402d81e373f16bd291f"},
-    {file = "momento_wire_types-0.97.1.tar.gz", hash = "sha256:b02e9d41072919432ba94e4123903208a87b6223f459d2cc47157bcc8e891b92"},
+    {file = "momento_wire_types-0.98.0-py3-none-any.whl", hash = "sha256:903be2f0d64f228725beb3a703a3518e0b1ea57715d19a3223f749cbf0f8eba0"},
+    {file = "momento_wire_types-0.98.0.tar.gz", hash = "sha256:18b29962bd0b9ac77bbab2db04eb009ad6bcbb499cb75486a6d02f0c249a77ec"},
 ]
 
 [package.dependencies]
@@ -605,4 +605,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "6ffe5b3af9004601a730152f3755cba8d5e610459d4dc2fcf387275aec95259e"
+content-hash = "5565bbea48a8a3d13a3b6812e278d738c3f7d76ceca728923345ec182b1b97d5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,69 +27,69 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "grpcio"
-version = "1.59.3"
+version = "1.60.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "grpcio-1.59.3-cp310-cp310-linux_armv7l.whl", hash = "sha256:aca028a6c7806e5b61e5f9f4232432c52856f7fcb98e330b20b6bc95d657bdcc"},
-    {file = "grpcio-1.59.3-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:19ad26a7967f7999c8960d2b9fe382dae74c55b0c508c613a6c2ba21cddf2354"},
-    {file = "grpcio-1.59.3-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:72b71dad2a3d1650e69ad42a5c4edbc59ee017f08c32c95694172bc501def23c"},
-    {file = "grpcio-1.59.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0f0a11d82d0253656cc42e04b6a149521e02e755fe2e4edd21123de610fd1d4"},
-    {file = "grpcio-1.59.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60cddafb70f9a2c81ba251b53b4007e07cca7389e704f86266e22c4bffd8bf1d"},
-    {file = "grpcio-1.59.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6c75a1fa0e677c1d2b6d4196ad395a5c381dfb8385f07ed034ef667cdcdbcc25"},
-    {file = "grpcio-1.59.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e1d8e01438d5964a11167eec1edb5f85ed8e475648f36c834ed5db4ffba24ac8"},
-    {file = "grpcio-1.59.3-cp310-cp310-win32.whl", hash = "sha256:c4b0076f0bf29ee62335b055a9599f52000b7941f577daa001c7ef961a1fbeab"},
-    {file = "grpcio-1.59.3-cp310-cp310-win_amd64.whl", hash = "sha256:b1f00a3e6e0c3dccccffb5579fc76ebfe4eb40405ba308505b41ef92f747746a"},
-    {file = "grpcio-1.59.3-cp311-cp311-linux_armv7l.whl", hash = "sha256:3996aaa21231451161dc29df6a43fcaa8b332042b6150482c119a678d007dd86"},
-    {file = "grpcio-1.59.3-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:cb4e9cbd9b7388fcb06412da9f188c7803742d06d6f626304eb838d1707ec7e3"},
-    {file = "grpcio-1.59.3-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:8022ca303d6c694a0d7acfb2b472add920217618d3a99eb4b14edc7c6a7e8fcf"},
-    {file = "grpcio-1.59.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b36683fad5664283755a7f4e2e804e243633634e93cd798a46247b8e54e3cb0d"},
-    {file = "grpcio-1.59.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8239b853226e4824e769517e1b5232e7c4dda3815b200534500338960fcc6118"},
-    {file = "grpcio-1.59.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:0511af8653fbda489ff11d542a08505d56023e63cafbda60e6e00d4e0bae86ea"},
-    {file = "grpcio-1.59.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e78dc982bda74cef2ddfce1c91d29b96864c4c680c634e279ed204d51e227473"},
-    {file = "grpcio-1.59.3-cp311-cp311-win32.whl", hash = "sha256:6a5c3a96405966c023e139c3bcccb2c7c776a6f256ac6d70f8558c9041bdccc3"},
-    {file = "grpcio-1.59.3-cp311-cp311-win_amd64.whl", hash = "sha256:ed26826ee423b11477297b187371cdf4fa1eca874eb1156422ef3c9a60590dd9"},
-    {file = "grpcio-1.59.3-cp312-cp312-linux_armv7l.whl", hash = "sha256:45dddc5cb5227d30fa43652d8872dc87f086d81ab4b500be99413bad0ae198d7"},
-    {file = "grpcio-1.59.3-cp312-cp312-macosx_10_10_universal2.whl", hash = "sha256:1736496d74682e53dd0907fd515f2694d8e6a96c9a359b4080b2504bf2b2d91b"},
-    {file = "grpcio-1.59.3-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:ddbd1a16138e52e66229047624de364f88a948a4d92ba20e4e25ad7d22eef025"},
-    {file = "grpcio-1.59.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fcfa56f8d031ffda902c258c84c4b88707f3a4be4827b4e3ab8ec7c24676320d"},
-    {file = "grpcio-1.59.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2eb8f0c7c0c62f7a547ad7a91ba627a5aa32a5ae8d930783f7ee61680d7eb8d"},
-    {file = "grpcio-1.59.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8d993399cc65e3a34f8fd48dd9ad7a376734564b822e0160dd18b3d00c1a33f9"},
-    {file = "grpcio-1.59.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c0bd141f4f41907eb90bda74d969c3cb21c1c62779419782a5b3f5e4b5835718"},
-    {file = "grpcio-1.59.3-cp312-cp312-win32.whl", hash = "sha256:33b8fd65d4e97efa62baec6171ce51f9cf68f3a8ba9f866f4abc9d62b5c97b79"},
-    {file = "grpcio-1.59.3-cp312-cp312-win_amd64.whl", hash = "sha256:0e735ed002f50d4f3cb9ecfe8ac82403f5d842d274c92d99db64cfc998515e07"},
-    {file = "grpcio-1.59.3-cp37-cp37m-linux_armv7l.whl", hash = "sha256:ea40ce4404e7cca0724c91a7404da410f0144148fdd58402a5942971e3469b94"},
-    {file = "grpcio-1.59.3-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:83113bcc393477b6f7342b9f48e8a054330c895205517edc66789ceea0796b53"},
-    {file = "grpcio-1.59.3-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:73afbac602b8f1212a50088193601f869b5073efa9855b3e51aaaec97848fc8a"},
-    {file = "grpcio-1.59.3-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:575d61de1950b0b0699917b686b1ca108690702fcc2df127b8c9c9320f93e069"},
-    {file = "grpcio-1.59.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cd76057b5c9a4d68814610ef9226925f94c1231bbe533fdf96f6181f7d2ff9e"},
-    {file = "grpcio-1.59.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:95d6fd804c81efe4879e38bfd84d2b26e339a0a9b797e7615e884ef4686eb47b"},
-    {file = "grpcio-1.59.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0d42048b8a3286ea4134faddf1f9a59cf98192b94aaa10d910a25613c5eb5bfb"},
-    {file = "grpcio-1.59.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4619fea15c64bcdd9d447cdbdde40e3d5f1da3a2e8ae84103d94a9c1df210d7e"},
-    {file = "grpcio-1.59.3-cp38-cp38-linux_armv7l.whl", hash = "sha256:95b5506e70284ac03b2005dd9ffcb6708c9ae660669376f0192a710687a22556"},
-    {file = "grpcio-1.59.3-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:9e17660947660ccfce56c7869032910c179a5328a77b73b37305cd1ee9301c2e"},
-    {file = "grpcio-1.59.3-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:00912ce19914d038851be5cd380d94a03f9d195643c28e3ad03d355cc02ce7e8"},
-    {file = "grpcio-1.59.3-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e58b3cadaa3c90f1efca26ba33e0d408b35b497307027d3d707e4bcd8de862a6"},
-    {file = "grpcio-1.59.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d787ecadea865bdf78f6679f6f5bf4b984f18f659257ba612979df97a298b3c3"},
-    {file = "grpcio-1.59.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0814942ba1bba269db4e760a34388640c601dece525c6a01f3b4ff030cc0db69"},
-    {file = "grpcio-1.59.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fb111aa99d3180c361a35b5ae1e2c63750220c584a1344229abc139d5c891881"},
-    {file = "grpcio-1.59.3-cp38-cp38-win32.whl", hash = "sha256:eb8ba504c726befe40a356ecbe63c6c3c64c9a439b3164f5a718ec53c9874da0"},
-    {file = "grpcio-1.59.3-cp38-cp38-win_amd64.whl", hash = "sha256:cdbc6b32fadab9bebc6f49d3e7ec4c70983c71e965497adab7f87de218e84391"},
-    {file = "grpcio-1.59.3-cp39-cp39-linux_armv7l.whl", hash = "sha256:c82ca1e4be24a98a253d6dbaa216542e4163f33f38163fc77964b0f0d255b552"},
-    {file = "grpcio-1.59.3-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:36636babfda14f9e9687f28d5b66d349cf88c1301154dc71c6513de2b6c88c59"},
-    {file = "grpcio-1.59.3-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:5f9b2e591da751ac7fdd316cc25afafb7a626dededa9b414f90faad7f3ccebdb"},
-    {file = "grpcio-1.59.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a93a82876a4926bf451db82ceb725bd87f42292bacc94586045261f501a86994"},
-    {file = "grpcio-1.59.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce31fa0bfdd1f2bb15b657c16105c8652186eab304eb512e6ae3b99b2fdd7d13"},
-    {file = "grpcio-1.59.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:16da0e40573962dab6cba16bec31f25a4f468e6d05b658e589090fe103b03e3d"},
-    {file = "grpcio-1.59.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1d1a17372fd425addd5812049fa7374008ffe689585f27f802d0935522cf4b7"},
-    {file = "grpcio-1.59.3-cp39-cp39-win32.whl", hash = "sha256:52cc38a7241b5f7b4a91aaf9000fdd38e26bb00d5e8a71665ce40cfcee716281"},
-    {file = "grpcio-1.59.3-cp39-cp39-win_amd64.whl", hash = "sha256:b491e5bbcad3020a96842040421e508780cade35baba30f402df9d321d1c423e"},
-    {file = "grpcio-1.59.3.tar.gz", hash = "sha256:7800f99568a74a06ebdccd419dd1b6e639b477dcaf6da77ea702f8fb14ce5f80"},
+    {file = "grpcio-1.60.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:d020cfa595d1f8f5c6b343530cd3ca16ae5aefdd1e832b777f9f0eb105f5b139"},
+    {file = "grpcio-1.60.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:b98f43fcdb16172dec5f4b49f2fece4b16a99fd284d81c6bbac1b3b69fcbe0ff"},
+    {file = "grpcio-1.60.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:20e7a4f7ded59097c84059d28230907cd97130fa74f4a8bfd1d8e5ba18c81491"},
+    {file = "grpcio-1.60.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:452ca5b4afed30e7274445dd9b441a35ece656ec1600b77fff8c216fdf07df43"},
+    {file = "grpcio-1.60.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43e636dc2ce9ece583b3e2ca41df5c983f4302eabc6d5f9cd04f0562ee8ec1ae"},
+    {file = "grpcio-1.60.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6e306b97966369b889985a562ede9d99180def39ad42c8014628dd3cc343f508"},
+    {file = "grpcio-1.60.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f897c3b127532e6befdcf961c415c97f320d45614daf84deba0a54e64ea2457b"},
+    {file = "grpcio-1.60.0-cp310-cp310-win32.whl", hash = "sha256:b87efe4a380887425bb15f220079aa8336276398dc33fce38c64d278164f963d"},
+    {file = "grpcio-1.60.0-cp310-cp310-win_amd64.whl", hash = "sha256:a9c7b71211f066908e518a2ef7a5e211670761651039f0d6a80d8d40054047df"},
+    {file = "grpcio-1.60.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:fb464479934778d7cc5baf463d959d361954d6533ad34c3a4f1d267e86ee25fd"},
+    {file = "grpcio-1.60.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:4b44d7e39964e808b071714666a812049765b26b3ea48c4434a3b317bac82f14"},
+    {file = "grpcio-1.60.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:90bdd76b3f04bdb21de5398b8a7c629676c81dfac290f5f19883857e9371d28c"},
+    {file = "grpcio-1.60.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91229d7203f1ef0ab420c9b53fe2ca5c1fbeb34f69b3bc1b5089466237a4a134"},
+    {file = "grpcio-1.60.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b36a2c6d4920ba88fa98075fdd58ff94ebeb8acc1215ae07d01a418af4c0253"},
+    {file = "grpcio-1.60.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:297eef542156d6b15174a1231c2493ea9ea54af8d016b8ca7d5d9cc65cfcc444"},
+    {file = "grpcio-1.60.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:87c9224acba0ad8bacddf427a1c2772e17ce50b3042a789547af27099c5f751d"},
+    {file = "grpcio-1.60.0-cp311-cp311-win32.whl", hash = "sha256:95ae3e8e2c1b9bf671817f86f155c5da7d49a2289c5cf27a319458c3e025c320"},
+    {file = "grpcio-1.60.0-cp311-cp311-win_amd64.whl", hash = "sha256:467a7d31554892eed2aa6c2d47ded1079fc40ea0b9601d9f79204afa8902274b"},
+    {file = "grpcio-1.60.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:a7152fa6e597c20cb97923407cf0934e14224af42c2b8d915f48bc3ad2d9ac18"},
+    {file = "grpcio-1.60.0-cp312-cp312-macosx_10_10_universal2.whl", hash = "sha256:7db16dd4ea1b05ada504f08d0dca1cd9b926bed3770f50e715d087c6f00ad748"},
+    {file = "grpcio-1.60.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:b0571a5aef36ba9177e262dc88a9240c866d903a62799e44fd4aae3f9a2ec17e"},
+    {file = "grpcio-1.60.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fd9584bf1bccdfff1512719316efa77be235469e1e3295dce64538c4773840b"},
+    {file = "grpcio-1.60.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6a478581b1a1a8fdf3318ecb5f4d0cda41cacdffe2b527c23707c9c1b8fdb55"},
+    {file = "grpcio-1.60.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:77c8a317f0fd5a0a2be8ed5cbe5341537d5c00bb79b3bb27ba7c5378ba77dbca"},
+    {file = "grpcio-1.60.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1c30bb23a41df95109db130a6cc1b974844300ae2e5d68dd4947aacba5985aa5"},
+    {file = "grpcio-1.60.0-cp312-cp312-win32.whl", hash = "sha256:2aef56e85901c2397bd557c5ba514f84de1f0ae5dd132f5d5fed042858115951"},
+    {file = "grpcio-1.60.0-cp312-cp312-win_amd64.whl", hash = "sha256:e381fe0c2aa6c03b056ad8f52f8efca7be29fb4d9ae2f8873520843b6039612a"},
+    {file = "grpcio-1.60.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:92f88ca1b956eb8427a11bb8b4a0c0b2b03377235fc5102cb05e533b8693a415"},
+    {file = "grpcio-1.60.0-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:e278eafb406f7e1b1b637c2cf51d3ad45883bb5bd1ca56bc05e4fc135dfdaa65"},
+    {file = "grpcio-1.60.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:a48edde788b99214613e440fce495bbe2b1e142a7f214cce9e0832146c41e324"},
+    {file = "grpcio-1.60.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de2ad69c9a094bf37c1102b5744c9aec6cf74d2b635558b779085d0263166454"},
+    {file = "grpcio-1.60.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:073f959c6f570797272f4ee9464a9997eaf1e98c27cb680225b82b53390d61e6"},
+    {file = "grpcio-1.60.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c826f93050c73e7769806f92e601e0efdb83ec8d7c76ddf45d514fee54e8e619"},
+    {file = "grpcio-1.60.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9e30be89a75ee66aec7f9e60086fadb37ff8c0ba49a022887c28c134341f7179"},
+    {file = "grpcio-1.60.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b0fb2d4801546598ac5cd18e3ec79c1a9af8b8f2a86283c55a5337c5aeca4b1b"},
+    {file = "grpcio-1.60.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:9073513ec380434eb8d21970e1ab3161041de121f4018bbed3146839451a6d8e"},
+    {file = "grpcio-1.60.0-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:74d7d9fa97809c5b892449b28a65ec2bfa458a4735ddad46074f9f7d9550ad13"},
+    {file = "grpcio-1.60.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:1434ca77d6fed4ea312901122dc8da6c4389738bf5788f43efb19a838ac03ead"},
+    {file = "grpcio-1.60.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e61e76020e0c332a98290323ecfec721c9544f5b739fab925b6e8cbe1944cf19"},
+    {file = "grpcio-1.60.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675997222f2e2f22928fbba640824aebd43791116034f62006e19730715166c0"},
+    {file = "grpcio-1.60.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5208a57eae445ae84a219dfd8b56e04313445d146873117b5fa75f3245bc1390"},
+    {file = "grpcio-1.60.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:428d699c8553c27e98f4d29fdc0f0edc50e9a8a7590bfd294d2edb0da7be3629"},
+    {file = "grpcio-1.60.0-cp38-cp38-win32.whl", hash = "sha256:83f2292ae292ed5a47cdcb9821039ca8e88902923198f2193f13959360c01860"},
+    {file = "grpcio-1.60.0-cp38-cp38-win_amd64.whl", hash = "sha256:705a68a973c4c76db5d369ed573fec3367d7d196673fa86614b33d8c8e9ebb08"},
+    {file = "grpcio-1.60.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:c193109ca4070cdcaa6eff00fdb5a56233dc7610216d58fb81638f89f02e4968"},
+    {file = "grpcio-1.60.0-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:676e4a44e740deaba0f4d95ba1d8c5c89a2fcc43d02c39f69450b1fa19d39590"},
+    {file = "grpcio-1.60.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:5ff21e000ff2f658430bde5288cb1ac440ff15c0d7d18b5fb222f941b46cb0d2"},
+    {file = "grpcio-1.60.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c86343cf9ff7b2514dd229bdd88ebba760bd8973dac192ae687ff75e39ebfab"},
+    {file = "grpcio-1.60.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fd3b3968ffe7643144580f260f04d39d869fcc2cddb745deef078b09fd2b328"},
+    {file = "grpcio-1.60.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:30943b9530fe3620e3b195c03130396cd0ee3a0d10a66c1bee715d1819001eaf"},
+    {file = "grpcio-1.60.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b10241250cb77657ab315270b064a6c7f1add58af94befa20687e7c8d8603ae6"},
+    {file = "grpcio-1.60.0-cp39-cp39-win32.whl", hash = "sha256:79a050889eb8d57a93ed21d9585bb63fca881666fc709f5d9f7f9372f5e7fd03"},
+    {file = "grpcio-1.60.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a97a681e82bc11a42d4372fe57898d270a2707f36c45c6676e49ce0d5c41353"},
+    {file = "grpcio-1.60.0.tar.gz", hash = "sha256:2199165a1affb666aa24adf0c97436686d0a61bc5fc113c037701fb7c7fceb96"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.59.3)"]
+protobuf = ["grpcio-tools (>=1.60.0)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -170,13 +170,13 @@ dev = ["Sphinx (>=5.1.1)", "black (==23.1.0)", "build (>=0.10.0)", "coverage (>=
 
 [[package]]
 name = "momento-wire-types"
-version = "0.98.0"
+version = "0.98.1"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.98.0-py3-none-any.whl", hash = "sha256:903be2f0d64f228725beb3a703a3518e0b1ea57715d19a3223f749cbf0f8eba0"},
-    {file = "momento_wire_types-0.98.0.tar.gz", hash = "sha256:18b29962bd0b9ac77bbab2db04eb009ad6bcbb499cb75486a6d02f0c249a77ec"},
+    {file = "momento_wire_types-0.98.1-py3-none-any.whl", hash = "sha256:3e6a3955acecc8284cb53cf8f1d5b54fc15298a5076520e5234ab7acdca224b5"},
+    {file = "momento_wire_types-0.98.1.tar.gz", hash = "sha256:e84bd948ffb3bd4e37c6e9124ce8564fd9e160cd8721ecbd9f9b47d6f40a91fc"},
 ]
 
 [package.dependencies]
@@ -437,28 +437,28 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.1.6"
+version = "0.1.8"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:88b8cdf6abf98130991cbc9f6438f35f6e8d41a02622cc5ee130a02a0ed28703"},
-    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c549ed437680b6105a1299d2cd30e4964211606eeb48a0ff7a93ef70b902248"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cf5f701062e294f2167e66d11b092bba7af6a057668ed618a9253e1e90cfd76"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:05991ee20d4ac4bb78385360c684e4b417edd971030ab12a4fbd075ff535050e"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87455a0c1f739b3c069e2f4c43b66479a54dea0276dd5d4d67b091265f6fd1dc"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:683aa5bdda5a48cb8266fcde8eea2a6af4e5700a392c56ea5fb5f0d4bfdc0240"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:137852105586dcbf80c1717facb6781555c4e99f520c9c827bd414fac67ddfb6"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd98138a98d48a1c36c394fd6b84cd943ac92a08278aa8ac8c0fdefcf7138f35"},
-    {file = "ruff-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0cd909d25f227ac5c36d4e7e681577275fb74ba3b11d288aff7ec47e3ae745"},
-    {file = "ruff-0.1.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8fd1c62a47aa88a02707b5dd20c5ff20d035d634aa74826b42a1da77861b5ff"},
-    {file = "ruff-0.1.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fd89b45d374935829134a082617954120d7a1470a9f0ec0e7f3ead983edc48cc"},
-    {file = "ruff-0.1.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:491262006e92f825b145cd1e52948073c56560243b55fb3b4ecb142f6f0e9543"},
-    {file = "ruff-0.1.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ea284789861b8b5ca9d5443591a92a397ac183d4351882ab52f6296b4fdd5462"},
-    {file = "ruff-0.1.6-py3-none-win32.whl", hash = "sha256:1610e14750826dfc207ccbcdd7331b6bd285607d4181df9c1c6ae26646d6848a"},
-    {file = "ruff-0.1.6-py3-none-win_amd64.whl", hash = "sha256:4558b3e178145491e9bc3b2ee3c4b42f19d19384eaa5c59d10acf6e8f8b57e33"},
-    {file = "ruff-0.1.6-py3-none-win_arm64.whl", hash = "sha256:03910e81df0d8db0e30050725a5802441c2022ea3ae4fe0609b76081731accbc"},
-    {file = "ruff-0.1.6.tar.gz", hash = "sha256:1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184"},
+    {file = "ruff-0.1.8-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7de792582f6e490ae6aef36a58d85df9f7a0cfd1b0d4fe6b4fb51803a3ac96fa"},
+    {file = "ruff-0.1.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c8e3255afd186c142eef4ec400d7826134f028a85da2146102a1172ecc7c3696"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff78a7583020da124dd0deb835ece1d87bb91762d40c514ee9b67a087940528b"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd8ee69b02e7bdefe1e5da2d5b6eaaddcf4f90859f00281b2333c0e3a0cc9cd6"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a05b0ddd7ea25495e4115a43125e8a7ebed0aa043c3d432de7e7d6e8e8cd6448"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e6f08ca730f4dc1b76b473bdf30b1b37d42da379202a059eae54ec7fc1fbcfed"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f35960b02df6b827c1b903091bb14f4b003f6cf102705efc4ce78132a0aa5af3"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7d076717c67b34c162da7c1a5bda16ffc205e0e0072c03745275e7eab888719f"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6a21ab023124eafb7cef6d038f835cb1155cd5ea798edd8d9eb2f8b84be07d9"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ce697c463458555027dfb194cb96d26608abab920fa85213deb5edf26e026664"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db6cedd9ffed55548ab313ad718bc34582d394e27a7875b4b952c2d29c001b26"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:05ffe9dbd278965271252704eddb97b4384bf58b971054d517decfbf8c523f05"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5daaeaf00ae3c1efec9742ff294b06c3a2a9db8d3db51ee4851c12ad385cda30"},
+    {file = "ruff-0.1.8-py3-none-win32.whl", hash = "sha256:e49fbdfe257fa41e5c9e13c79b9e79a23a79bd0e40b9314bc53840f520c2c0b3"},
+    {file = "ruff-0.1.8-py3-none-win_amd64.whl", hash = "sha256:f41f692f1691ad87f51708b823af4bb2c5c87c9248ddd3191c8f088e66ce590a"},
+    {file = "ruff-0.1.8-py3-none-win_arm64.whl", hash = "sha256:aa8ee4f8440023b0a6c3707f76cadce8657553655dcbb5fc9b2f9bb9bee389f6"},
+    {file = "ruff-0.1.8.tar.gz", hash = "sha256:f7ee467677467526cfe135eab86a40a0e8db43117936ac4f9b469ce9cdb3fb62"},
 ]
 
 [[package]]
@@ -605,4 +605,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "5565bbea48a8a3d13a3b6812e278d738c3f7d76ceca728923345ec182b1b97d5"
+content-hash = "b408389456bdcf14b8781c0f88aa0d44c6b8cb42207bf99a267b07d6c7c25e34"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ fix = true
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "src/momento/common_data/vector_index/item.py" = ["E721"]
+"src/momento/requests/vector_index/filters.py" = ["E721"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.98.0"
+momento-wire-types = "^0.98.1"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.97.1"
+momento-wire-types = "^0.98.0"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -113,7 +113,7 @@ class _VectorIndexDataClient:
 
     @staticmethod
     def __build_filter_expression(
-        filter_expression: Optional[FilterExpression]
+        filter_expression: Optional[FilterExpression],
     ) -> Optional[vectorindex_pb._FilterExpression]:
         if filter_expression is None:
             return None

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -13,7 +13,7 @@ from momento.errors import convert_error
 from momento.internal._utilities import _validate_index_name, _validate_top_k
 from momento.internal.aio._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.internal.services import Service
-from momento.requests.vector_index import AllMetadata, Item
+from momento.requests.vector_index import AllMetadata, FilterExpression, Item
 from momento.responses.vector_index import (
     DeleteItemBatch,
     DeleteItemBatchResponse,
@@ -96,6 +96,29 @@ class _VectorIndexDataClient:
             self._log_request_error("delete", e)
             return DeleteItemBatch.Error(convert_error(e, Service.INDEX))
 
+    @staticmethod
+    def __build_metadata_request(metadata_fields: Optional[list[str]] | AllMetadata) -> vectorindex_pb._MetadataRequest:
+        if isinstance(metadata_fields, AllMetadata):
+            return vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
+        else:
+            return vectorindex_pb._MetadataRequest(
+                some=vectorindex_pb._MetadataRequest.Some(fields=metadata_fields if metadata_fields else [])
+            )
+
+    @staticmethod
+    def __build_no_score_threshold(score_threshold: Optional[float]) -> Optional[vectorindex_pb._NoScoreThreshold]:
+        if score_threshold is None:
+            return vectorindex_pb._NoScoreThreshold()
+        return None
+
+    @staticmethod
+    def __build_filter_expression(
+        filter_expression: Optional[FilterExpression]
+    ) -> Optional[vectorindex_pb._FilterExpression]:
+        if filter_expression is None:
+            return None
+        return filter_expression.to_filter_expression_proto()
+
     async def search(
         self,
         index_name: str,
@@ -103,6 +126,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         try:
             self._log_issuing_request("Search", {"index_name": index_name})
@@ -110,18 +134,9 @@ class _VectorIndexDataClient:
             _validate_top_k(top_k)
 
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
-            if isinstance(metadata_fields, AllMetadata):
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
-            else:
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(
-                    some=vectorindex_pb._MetadataRequest.Some(
-                        fields=metadata_fields if metadata_fields is not None else []
-                    )
-                )
-
-            no_score_threshold = None
-            if score_threshold is None:
-                no_score_threshold = vectorindex_pb._NoScoreThreshold()
+            metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
+            no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
 
             request = vectorindex_pb._SearchRequest(
                 index_name=index_name,
@@ -130,6 +145,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
+                filter_expression=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchResponse = await self._build_stub().Search(
@@ -150,6 +166,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         try:
             self._log_issuing_request("SearchAndFetchVectors", {"index_name": index_name})
@@ -157,18 +174,9 @@ class _VectorIndexDataClient:
             _validate_top_k(top_k)
 
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
-            if isinstance(metadata_fields, AllMetadata):
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
-            else:
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(
-                    some=vectorindex_pb._MetadataRequest.Some(
-                        fields=metadata_fields if metadata_fields is not None else []
-                    )
-                )
-
-            no_score_threshold = None
-            if score_threshold is None:
-                no_score_threshold = vectorindex_pb._NoScoreThreshold()
+            metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
+            no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
 
             request = vectorindex_pb._SearchAndFetchVectorsRequest(
                 index_name=index_name,
@@ -177,6 +185,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
+                filter_expression=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchAndFetchVectorsResponse = await self._build_stub().SearchAndFetchVectors(

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -113,7 +113,7 @@ class _VectorIndexDataClient:
 
     @staticmethod
     def __build_filter_expression(
-        filter_expression: Optional[FilterExpression]
+        filter_expression: Optional[FilterExpression],
     ) -> Optional[vectorindex_pb._FilterExpression]:
         if filter_expression is None:
             return None

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -13,7 +13,7 @@ from momento.errors import convert_error
 from momento.internal._utilities import _validate_index_name, _validate_top_k
 from momento.internal.services import Service
 from momento.internal.synchronous._vector_index_grpc_manager import _VectorIndexDataGrpcManager
-from momento.requests.vector_index import AllMetadata, Item
+from momento.requests.vector_index import AllMetadata, FilterExpression, Item
 from momento.responses.vector_index import (
     DeleteItemBatch,
     DeleteItemBatchResponse,
@@ -96,6 +96,29 @@ class _VectorIndexDataClient:
             self._log_request_error("delete", e)
             return DeleteItemBatch.Error(convert_error(e, Service.INDEX))
 
+    @staticmethod
+    def __build_metadata_request(metadata_fields: Optional[list[str]] | AllMetadata) -> vectorindex_pb._MetadataRequest:
+        if isinstance(metadata_fields, AllMetadata):
+            return vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
+        else:
+            return vectorindex_pb._MetadataRequest(
+                some=vectorindex_pb._MetadataRequest.Some(fields=metadata_fields if metadata_fields else [])
+            )
+
+    @staticmethod
+    def __build_no_score_threshold(score_threshold: Optional[float]) -> Optional[vectorindex_pb._NoScoreThreshold]:
+        if score_threshold is None:
+            return vectorindex_pb._NoScoreThreshold()
+        return None
+
+    @staticmethod
+    def __build_filter_expression(
+        filter_expression: Optional[FilterExpression]
+    ) -> Optional[vectorindex_pb._FilterExpression]:
+        if filter_expression is None:
+            return None
+        return filter_expression.to_filter_expression_proto()
+
     def search(
         self,
         index_name: str,
@@ -103,6 +126,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         try:
             self._log_issuing_request("Search", {"index_name": index_name})
@@ -110,18 +134,9 @@ class _VectorIndexDataClient:
             _validate_top_k(top_k)
 
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
-            if isinstance(metadata_fields, AllMetadata):
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
-            else:
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(
-                    some=vectorindex_pb._MetadataRequest.Some(
-                        fields=metadata_fields if metadata_fields is not None else []
-                    )
-                )
-
-            no_score_threshold = None
-            if score_threshold is None:
-                no_score_threshold = vectorindex_pb._NoScoreThreshold()
+            metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
+            no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
 
             request = vectorindex_pb._SearchRequest(
                 index_name=index_name,
@@ -130,6 +145,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
+                filter_expression=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchResponse = self._build_stub().Search(
@@ -150,6 +166,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         try:
             self._log_issuing_request("SearchAndFetchVectors", {"index_name": index_name})
@@ -157,18 +174,9 @@ class _VectorIndexDataClient:
             _validate_top_k(top_k)
 
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
-            if isinstance(metadata_fields, AllMetadata):
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All())
-            else:
-                metadata_fields_pb = vectorindex_pb._MetadataRequest(
-                    some=vectorindex_pb._MetadataRequest.Some(
-                        fields=metadata_fields if metadata_fields is not None else []
-                    )
-                )
-
-            no_score_threshold = None
-            if score_threshold is None:
-                no_score_threshold = vectorindex_pb._NoScoreThreshold()
+            metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
+            no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
 
             request = vectorindex_pb._SearchAndFetchVectorsRequest(
                 index_name=index_name,
@@ -177,6 +185,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
+                filter_expression=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchAndFetchVectorsResponse = self._build_stub().SearchAndFetchVectors(

--- a/src/momento/requests/vector_index/__init__.py
+++ b/src/momento/requests/vector_index/__init__.py
@@ -1,6 +1,7 @@
 from momento.common_data.vector_index.item import Item
 
+from .filters import Field, FilterExpression
 from .search import ALL_METADATA, AllMetadata
 from .similarity_metric import SimilarityMetric
 
-__all__ = ["Item", "AllMetadata", "ALL_METADATA", "SimilarityMetric"]
+__all__ = ["Item", "AllMetadata", "ALL_METADATA", "Field", "FilterExpression", "SimilarityMetric"]

--- a/src/momento/requests/vector_index/__init__.py
+++ b/src/momento/requests/vector_index/__init__.py
@@ -1,6 +1,7 @@
 from momento.common_data.vector_index.item import Item
 
-from .filters import Field, FilterExpression
+from .filter_field import Field
+from .filters import FilterExpression
 from .search import ALL_METADATA, AllMetadata
 from .similarity_metric import SimilarityMetric
 

--- a/src/momento/requests/vector_index/filter_field.py
+++ b/src/momento/requests/vector_index/filter_field.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import momento_wire_types.vectorindex_pb2 as vectorindex_pb
+from momento_wire_types import vectorindex_pb2 as vectorindex_pb
 
 from . import filters as F
 

--- a/src/momento/requests/vector_index/filter_field.py
+++ b/src/momento/requests/vector_index/filter_field.py
@@ -1,0 +1,71 @@
+"""Field class for filter expressions.
+
+This class is used to create filter expressions in a more readable way::
+
+        from momento.requests.vector_index.filters import Field
+
+        Field("name") == "foo"
+        Field("age") >= 18
+        Field("tags").list_contains("books")
+        (Field("year") > 2000) | (Field("year") < 1990)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import momento_wire_types.vectorindex_pb2 as vectorindex_pb
+
+from . import filters as F
+
+
+@dataclass
+class Field:
+    """Represents a field in a filter expression.
+
+    Can be used to create filter expressions in a more readable way::
+
+        from momento.requests.vector_index.filters import Field
+
+        Field("name") == "foo"
+        Field("age") >= 18
+        Field("tags").list_contains("books")
+        (Field("year") > 2000) | (Field("year") < 1990)
+    """
+
+    name: str
+    """The name of the field."""
+
+    def to_filter_expression_proto(self) -> vectorindex_pb._FilterExpression:
+        """Converts the field to a protobuf filter expression.
+
+        A bare field is equivalent to the field in a boolean context.
+
+        Returns:
+            vectorindex_pb._FilterExpression: The protobuf filter expression.
+        """
+        return F.Equals(self.name, True).to_filter_expression_proto()
+
+    def __eq__(self, other: str | int | float | bool) -> F.Equals:  # type: ignore
+        return F.Equals(self.name, other)
+
+    def __invert__(self) -> F.Equals:
+        return F.Equals(self.name, False)
+
+    def __ne__(self, other: str | int | float | bool) -> F.Not:  # type: ignore
+        return F.Not(F.Equals(self.name, other))
+
+    def __gt__(self, other: int | float) -> F.GreaterThan:
+        return F.GreaterThan(self.name, other)
+
+    def __ge__(self, other: int | float) -> F.GreaterThanOrEqual:
+        return F.GreaterThanOrEqual(self.name, other)
+
+    def __lt__(self, other: int | float) -> F.LessThan:
+        return F.LessThan(self.name, other)
+
+    def __le__(self, other: int | float) -> F.LessThanOrEqual:
+        return F.LessThanOrEqual(self.name, other)
+
+    def list_contains(self, value: str) -> F.ListContains:
+        return F.ListContains(self.name, value)

--- a/src/momento/requests/vector_index/filters.py
+++ b/src/momento/requests/vector_index/filters.py
@@ -169,13 +169,13 @@ class GreaterThanOrEqual(FilterExpression):
     """The value to test greater than or equal with."""
 
     def to_filter_expression_proto(self) -> vectorindex_pb._FilterExpression:
-        return vectorindex_pb._FilterExpression(greater_or_equal_expression=self.to_proto())
+        return vectorindex_pb._FilterExpression(greater_than_or_equal_expression=self.to_proto())
 
-    def to_proto(self) -> vectorindex_pb._GreaterOrEqualExpression:
+    def to_proto(self) -> vectorindex_pb._GreaterThanOrEqualExpression:
         if type(self.value) is int:
-            return vectorindex_pb._GreaterOrEqualExpression(field=self.field, integer_value=self.value)
+            return vectorindex_pb._GreaterThanOrEqualExpression(field=self.field, integer_value=self.value)
         elif type(self.value) is float:
-            return vectorindex_pb._GreaterOrEqualExpression(field=self.field, float_value=self.value)
+            return vectorindex_pb._GreaterThanOrEqualExpression(field=self.field, float_value=self.value)
         else:
             raise InvalidArgumentException(
                 f"Invalid type for value: {type(self.value)} in greater than or equal expression. Must be one of int, float.",
@@ -217,13 +217,13 @@ class LessThanOrEqual(FilterExpression):
     """The value to test less than or equal with."""
 
     def to_filter_expression_proto(self) -> vectorindex_pb._FilterExpression:
-        return vectorindex_pb._FilterExpression(less_or_equal_expression=self.to_proto())
+        return vectorindex_pb._FilterExpression(less_than_or_equal_expression=self.to_proto())
 
-    def to_proto(self) -> vectorindex_pb._LessOrEqualExpression:
+    def to_proto(self) -> vectorindex_pb._LessThanOrEqualExpression:
         if type(self.value) is int:
-            return vectorindex_pb._LessOrEqualExpression(field=self.field, integer_value=self.value)
+            return vectorindex_pb._LessThanOrEqualExpression(field=self.field, integer_value=self.value)
         elif type(self.value) is float:
-            return vectorindex_pb._LessOrEqualExpression(field=self.field, float_value=self.value)
+            return vectorindex_pb._LessThanOrEqualExpression(field=self.field, float_value=self.value)
         else:
             raise InvalidArgumentException(
                 f"Invalid type for value: {type(self.value)} in less than or equal expression. Must be one of int, float.",
@@ -245,7 +245,7 @@ class ListContains(FilterExpression):
 
     def to_proto(self) -> vectorindex_pb._ListContainsExpression:
         # todo should make oneof defensively
-        return vectorindex_pb._ListContainsExpression(field=self.field, value=self.value)
+        return vectorindex_pb._ListContainsExpression(field=self.field, string_value=self.value)
 
 
 @dataclass

--- a/src/momento/requests/vector_index/filters.py
+++ b/src/momento/requests/vector_index/filters.py
@@ -265,8 +265,21 @@ class Field:
     name: str
     """The name of the field."""
 
+    def to_filter_expression_proto(self) -> vectorindex_pb._FilterExpression:
+        """Converts the field to a protobuf filter expression.
+
+        A bare field is equivalent to the field in a boolean context.
+
+        Returns:
+            vectorindex_pb._FilterExpression: The protobuf filter expression.
+        """
+        return Equals(self.name, True).to_filter_expression_proto()
+
     def __eq__(self, other: str | int | float | bool) -> Equals:  # type: ignore
         return Equals(self.name, other)
+
+    def __invert__(self) -> Equals:
+        return Equals(self.name, False)
 
     def __ne__(self, other: str | int | float | bool) -> Not:  # type: ignore
         return Not(Equals(self.name, other))

--- a/src/momento/requests/vector_index/filters.py
+++ b/src/momento/requests/vector_index/filters.py
@@ -285,6 +285,3 @@ class Field:
 
     def list_contains(self, value: str) -> ListContains:
         return ListContains(self.name, value)
-
-
-print((Field("name") == "foo") & (Field("year") >= 2000) & ~Field("tags").list_contains("books"))

--- a/src/momento/requests/vector_index/filters.py
+++ b/src/momento/requests/vector_index/filters.py
@@ -1,3 +1,15 @@
+"""Filter expressions for the vector index request.
+
+The filter expressions are used to filter the results of a vector index request.
+This module contains the base class for all filter expressions, as well as
+implementations for all the different types of filter expressions::
+    And(Equals("foo", "bar"), GreaterThan("age", 18))
+    Or(Equals("foo", "bar"), LessThan("age", 18))
+    Not(Equals("foo", "bar"))
+
+The `Field` class is used to create filter expressions in a more idiomatic way.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -246,55 +258,3 @@ class ListContains(FilterExpression):
     def to_proto(self) -> vectorindex_pb._ListContainsExpression:
         # todo should make oneof defensively
         return vectorindex_pb._ListContainsExpression(field=self.field, string_value=self.value)
-
-
-@dataclass
-class Field:
-    """Represents a field in a filter expression.
-
-    Can be used to create filter expressions in a more readable way::
-
-        from momento.requests.vector_index.filters import Field
-
-        Field("name") == "foo"
-        Field("age") >= 18
-        Field("tags").list_contains("books")
-        (Field("year") > 2000) | (Field("year") < 1990)
-    """
-
-    name: str
-    """The name of the field."""
-
-    def to_filter_expression_proto(self) -> vectorindex_pb._FilterExpression:
-        """Converts the field to a protobuf filter expression.
-
-        A bare field is equivalent to the field in a boolean context.
-
-        Returns:
-            vectorindex_pb._FilterExpression: The protobuf filter expression.
-        """
-        return Equals(self.name, True).to_filter_expression_proto()
-
-    def __eq__(self, other: str | int | float | bool) -> Equals:  # type: ignore
-        return Equals(self.name, other)
-
-    def __invert__(self) -> Equals:
-        return Equals(self.name, False)
-
-    def __ne__(self, other: str | int | float | bool) -> Not:  # type: ignore
-        return Not(Equals(self.name, other))
-
-    def __gt__(self, other: int | float) -> GreaterThan:
-        return GreaterThan(self.name, other)
-
-    def __ge__(self, other: int | float) -> GreaterThanOrEqual:
-        return GreaterThanOrEqual(self.name, other)
-
-    def __lt__(self, other: int | float) -> LessThan:
-        return LessThan(self.name, other)
-
-    def __le__(self, other: int | float) -> LessThanOrEqual:
-        return LessThanOrEqual(self.name, other)
-
-    def list_contains(self, value: str) -> ListContains:
-        return ListContains(self.name, value)

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -34,7 +34,7 @@ except ImportError as e:
         print("-".join("" for _ in range(99)), file=sys.stderr)
     raise e
 
-from momento.requests.vector_index import AllMetadata, Item, SimilarityMetric
+from momento.requests.vector_index import AllMetadata, FilterExpression, Item, SimilarityMetric
 from momento.responses.vector_index import (
     CreateIndexResponse,
     DeleteIndexResponse,
@@ -201,6 +201,7 @@ class PreviewVectorIndexClient:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -218,11 +219,15 @@ class PreviewVectorIndexClient:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+            filter_expression (Optional[FilterExpression]): A filter expression to filter
+                results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
-        return self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold)
+        return self._data_client.search(
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
+        )
 
     def search_and_fetch_vectors(
         self,
@@ -231,6 +236,7 @@ class PreviewVectorIndexClient:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -249,12 +255,14 @@ class PreviewVectorIndexClient:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+            filter_expression (Optional[FilterExpression]): A filter expression to filter
+                results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
         return self._data_client.search_and_fetch_vectors(
-            index_name, query_vector, top_k, metadata_fields, score_threshold
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
         )
 
     def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -34,7 +34,7 @@ except ImportError as e:
         print("-".join("" for _ in range(99)), file=sys.stderr)
     raise e
 
-from momento.requests.vector_index import AllMetadata, Item, SimilarityMetric
+from momento.requests.vector_index import AllMetadata, FilterExpression, Item, SimilarityMetric
 from momento.responses.vector_index import (
     CreateIndexResponse,
     DeleteIndexResponse,
@@ -201,6 +201,7 @@ class PreviewVectorIndexClientAsync:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -218,11 +219,15 @@ class PreviewVectorIndexClientAsync:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+            filter_expression (Optional[FilterExpression]): A filter expression to filter
+                results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
-        return await self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold)
+        return await self._data_client.search(
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
+        )
 
     async def search_and_fetch_vectors(
         self,
@@ -231,6 +236,7 @@ class PreviewVectorIndexClientAsync:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
+        filter_expression: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -249,12 +255,14 @@ class PreviewVectorIndexClientAsync:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
+            filter_expression (Optional[FilterExpression]): A filter expression to filter
+                results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
         return await self._data_client.search_and_fetch_vectors(
-            index_name, query_vector, top_k, metadata_fields, score_threshold
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
         )
 
     async def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:

--- a/tests/momento/requests/vector_index/test_filters.py
+++ b/tests/momento/requests/vector_index/test_filters.py
@@ -18,6 +18,11 @@ from momento_wire_types import vectorindex_pb2 as pb
             pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", boolean_value=True)),
         ),
         (
+            ~Field("foo"),
+            F.Equals("foo", False),
+            pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", boolean_value=False)),
+        ),
+        (
             Field("foo") == 5.5,
             F.Equals("foo", 5.5),
             pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", float_value=5.5)),
@@ -127,5 +132,5 @@ def test_field_shorthand(
     field_based_expression: FilterExpression, full_expression: FilterExpression, protobuf: pb._FilterExpression
 ) -> None:
     assert field_based_expression == full_expression
-    if protobuf is not None:
-        assert full_expression.to_filter_expression_proto() == protobuf
+    assert field_based_expression.to_filter_expression_proto() == protobuf
+    assert full_expression.to_filter_expression_proto() == protobuf

--- a/tests/momento/requests/vector_index/test_filters.py
+++ b/tests/momento/requests/vector_index/test_filters.py
@@ -1,0 +1,131 @@
+import pytest
+from momento.requests.vector_index import Field, FilterExpression
+from momento.requests.vector_index import filters as F
+from momento_wire_types import vectorindex_pb2 as pb
+
+
+@pytest.mark.parametrize(
+    ["field_based_expression", "full_expression", "protobuf"],
+    [
+        (
+            Field("foo") == "bar",
+            F.Equals("foo", "bar"),
+            pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", string_value="bar")),
+        ),
+        (
+            Field("foo"),
+            F.Equals("foo", True),
+            pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", boolean_value=True)),
+        ),
+        (
+            Field("foo") == 5.5,
+            F.Equals("foo", 5.5),
+            pb._FilterExpression(equals_expression=pb._EqualsExpression(field="foo", float_value=5.5)),
+        ),
+        (
+            Field("foo") != "bar",
+            F.Not(F.Equals("foo", "bar")),
+            pb._FilterExpression(
+                not_expression=pb._NotExpression(
+                    expression_to_negate=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="foo", string_value="bar")
+                    )
+                )
+            ),
+        ),
+        (
+            ~(Field("foo") == "bar"),
+            F.Not(F.Equals("foo", "bar")),
+            pb._FilterExpression(
+                not_expression=pb._NotExpression(
+                    expression_to_negate=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="foo", string_value="bar")
+                    )
+                )
+            ),
+        ),
+        (
+            Field("foo") > 5,
+            F.GreaterThan("foo", 5),
+            pb._FilterExpression(greater_than_expression=pb._GreaterThanExpression(field="foo", integer_value=5)),
+        ),
+        (
+            Field("foo") > 5.5,
+            F.GreaterThan("foo", 5.5),
+            pb._FilterExpression(greater_than_expression=pb._GreaterThanExpression(field="foo", float_value=5.5)),
+        ),
+        (
+            Field("foo") >= 5,
+            F.GreaterThanOrEqual("foo", 5),
+            pb._FilterExpression(
+                greater_or_equal_expression=pb._GreaterOrEqualExpression(field="foo", integer_value=5)
+            ),
+        ),
+        (
+            Field("foo") >= 5.5,
+            F.GreaterThanOrEqual("foo", 5.5),
+            pb._FilterExpression(
+                greater_or_equal_expression=pb._GreaterOrEqualExpression(field="foo", float_value=5.5)
+            ),
+        ),
+        (
+            Field("foo") < 5,
+            F.LessThan("foo", 5),
+            pb._FilterExpression(less_than_expression=pb._LessThanExpression(field="foo", integer_value=5)),
+        ),
+        (
+            Field("foo") < 5.5,
+            F.LessThan("foo", 5.5),
+            pb._FilterExpression(less_than_expression=pb._LessThanExpression(field="foo", float_value=5.5)),
+        ),
+        (
+            Field("foo") <= 5,
+            F.LessThanOrEqual("foo", 5),
+            pb._FilterExpression(less_or_equal_expression=pb._LessOrEqualExpression(field="foo", integer_value=5)),
+        ),
+        (
+            Field("foo") <= 5.5,
+            F.LessThanOrEqual("foo", 5.5),
+            pb._FilterExpression(less_or_equal_expression=pb._LessOrEqualExpression(field="foo", float_value=5.5)),
+        ),
+        (
+            Field("foo").list_contains("bar"),
+            F.ListContains("foo", "bar"),
+            pb._FilterExpression(list_contains_expression=pb._ListContainsExpression(field="foo", value="bar")),
+        ),
+        (
+            (Field("foo") == "bar") & (Field("baz") == 5),
+            F.And(F.Equals("foo", "bar"), F.Equals("baz", 5)),
+            pb._FilterExpression(
+                and_expression=pb._AndExpression(
+                    first_expression=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="foo", string_value="bar")
+                    ),
+                    second_expression=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="baz", integer_value=5)
+                    ),
+                )
+            ),
+        ),
+        (
+            (Field("foo") == "bar") | (Field("baz") == 5),
+            F.Or(F.Equals("foo", "bar"), F.Equals("baz", 5)),
+            pb._FilterExpression(
+                or_expression=pb._OrExpression(
+                    first_expression=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="foo", string_value="bar")
+                    ),
+                    second_expression=pb._FilterExpression(
+                        equals_expression=pb._EqualsExpression(field="baz", integer_value=5)
+                    ),
+                )
+            ),
+        ),
+    ],
+)
+def test_field_shorthand(
+    field_based_expression: FilterExpression, full_expression: FilterExpression, protobuf: pb._FilterExpression
+) -> None:
+    assert field_based_expression == full_expression
+    if protobuf is not None:
+        assert full_expression.to_filter_expression_proto() == protobuf

--- a/tests/momento/requests/vector_index/test_filters.py
+++ b/tests/momento/requests/vector_index/test_filters.py
@@ -63,14 +63,14 @@ from momento_wire_types import vectorindex_pb2 as pb
             Field("foo") >= 5,
             F.GreaterThanOrEqual("foo", 5),
             pb._FilterExpression(
-                greater_or_equal_expression=pb._GreaterOrEqualExpression(field="foo", integer_value=5)
+                greater_than_or_equal_expression=pb._GreaterThanOrEqualExpression(field="foo", integer_value=5)
             ),
         ),
         (
             Field("foo") >= 5.5,
             F.GreaterThanOrEqual("foo", 5.5),
             pb._FilterExpression(
-                greater_or_equal_expression=pb._GreaterOrEqualExpression(field="foo", float_value=5.5)
+                greater_than_or_equal_expression=pb._GreaterThanOrEqualExpression(field="foo", float_value=5.5)
             ),
         ),
         (
@@ -86,17 +86,21 @@ from momento_wire_types import vectorindex_pb2 as pb
         (
             Field("foo") <= 5,
             F.LessThanOrEqual("foo", 5),
-            pb._FilterExpression(less_or_equal_expression=pb._LessOrEqualExpression(field="foo", integer_value=5)),
+            pb._FilterExpression(
+                less_than_or_equal_expression=pb._LessThanOrEqualExpression(field="foo", integer_value=5)
+            ),
         ),
         (
             Field("foo") <= 5.5,
             F.LessThanOrEqual("foo", 5.5),
-            pb._FilterExpression(less_or_equal_expression=pb._LessOrEqualExpression(field="foo", float_value=5.5)),
+            pb._FilterExpression(
+                less_than_or_equal_expression=pb._LessThanOrEqualExpression(field="foo", float_value=5.5)
+            ),
         ),
         (
             Field("foo").list_contains("bar"),
             F.ListContains("foo", "bar"),
-            pb._FilterExpression(list_contains_expression=pb._ListContainsExpression(field="foo", value="bar")),
+            pb._FilterExpression(list_contains_expression=pb._ListContainsExpression(field="foo", string_value="bar")),
         ),
         (
             (Field("foo") == "bar") & (Field("baz") == 5),

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, cast
 
 import pytest
 from momento import PreviewVectorIndexClient
 from momento.common_data.vector_index.item import Metadata
 from momento.errors import MomentoErrorCode
-from momento.requests.vector_index import ALL_METADATA, Item, SimilarityMetric
+from momento.requests.vector_index import ALL_METADATA, Field, FilterExpression, Item, SimilarityMetric
 from momento.responses.vector_index import (
     CreateIndex,
     DeleteItemBatch,
@@ -593,6 +593,91 @@ def test_search_score_threshold_happy_path(
     search_response3 = search(index_name, query_vector=query_vector, top_k=3, score_threshold=thresholds[2])
     assert isinstance(search_response3, response)
     assert search_response3.hits == []
+
+
+def test_search_with_filter_expression(
+    vector_index_client: PreviewVectorIndexClient,
+    unique_vector_index_name: TUniqueVectorIndexName,
+) -> None:
+    index_name = unique_vector_index_name(vector_index_client)
+    num_dimensions = 2
+    create_response = vector_index_client.create_index(
+        index_name, num_dimensions=num_dimensions, similarity_metric=SimilarityMetric.INNER_PRODUCT
+    )
+    assert isinstance(create_response, CreateIndex.Success)
+    items = [
+        Item(
+            id="test_item_1",
+            vector=[1.0, 1.0],
+            metadata={"str": "value1", "int": 0, "float": 0.0, "bool": True, "tags": ["a", "b", "c"]},
+        ),
+        Item(
+            id="test_item_2",
+            vector=[-1.0, 1.0],
+            metadata={"str": "value2", "int": 5, "float": 5.0, "bool": False, "tags": ["a", "b"]},
+        ),
+        Item(
+            id="test_item_3",
+            vector=[-1.0, -1.0],
+            metadata={"str": "value3", "int": 10, "float": 10.0, "bool": True, "tags": ["a", "d"]},
+        ),
+    ]
+    upsert_response = vector_index_client.upsert_item_batch(
+        index_name,
+        items=items,
+    )
+    assert isinstance(upsert_response, UpsertItemBatch.Success)
+    sleep(2)
+
+    # Writing the test cases here instead of as a parameterized test because:
+    # 1. The search data is the same across tests, so no need to reindex each time.
+    # 2. It is 10x faster to run the tests this way.
+    for filter_expression, expected_ids, test_case_name in [
+        (Field("str") == "value1", ["test_item_1"], "string equality"),
+        (Field("str") != "value1", ["test_item_2", "test_item_3"], "string inequality"),
+        (Field("int") == 0, ["test_item_1"], "int equality"),
+        (Field("float") == 0.0, ["test_item_1"], "float equality"),
+        (Field("bool"), ["test_item_1", "test_item_3"], "bool equality"),
+        (~Field("bool"), ["test_item_2"], "bool inequality"),
+        (Field("int") > 5, ["test_item_3"], "int greater than"),
+        (Field("int") >= 5, ["test_item_2", "test_item_3"], "int greater than or equal to"),
+        (Field("float") > 5.0, ["test_item_3"], "float greater than"),
+        (Field("float") >= 5.0, ["test_item_2", "test_item_3"], "float greater than or equal to"),
+        (Field("int") < 5, ["test_item_1"], "int less than"),
+        (Field("int") <= 5, ["test_item_1", "test_item_2"], "int less than or equal to"),
+        (Field("float") < 5.0, ["test_item_1"], "float less than"),
+        (Field("float") <= 5.0, ["test_item_1", "test_item_2"], "float less than or equal to"),
+        (Field("tags").list_contains("a"), ["test_item_1", "test_item_2", "test_item_3"], "list contains a"),
+        (Field("tags").list_contains("b"), ["test_item_1", "test_item_2"], "list contains b"),
+        (Field("tags").list_contains("m"), [], "list contains m"),
+        ((Field("tags").list_contains("b")) & (Field("int") > 1), ["test_item_2"], "list contains b and int > 1"),
+        (
+            (Field("tags").list_contains("b")) | (Field("int") > 1),
+            ["test_item_1", "test_item_2", "test_item_3"],
+            "list contains b or int > 1",
+        ),
+    ]:
+        filter_expression = cast(FilterExpression, filter_expression)
+        search_response = vector_index_client.search(
+            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
+        )
+        assert isinstance(
+            search_response, Search.Success
+        ), f"Expected search {test_case_name!r} to succeed but got {search_response!r}"
+        assert (
+            [hit.id for hit in search_response.hits] == expected_ids
+        ), f"Expected search {test_case_name!r} to return {expected_ids!r} but got {search_response.hits!r}"
+
+        search_and_fetch_vectors_response = vector_index_client.search_and_fetch_vectors(
+            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
+        )
+        assert isinstance(
+            search_and_fetch_vectors_response, SearchAndFetchVectors.Success
+        ), f"Expected search {test_case_name!r} to succeed but got {search_and_fetch_vectors_response!r}"
+        assert [hit.id for hit in search_and_fetch_vectors_response.hits] == expected_ids, (
+            f"Expected search {test_case_name!r} to return {expected_ids!r} "
+            f"but got {search_and_fetch_vectors_response.hits!r}"
+        )
 
 
 def test_delete_validates_index_name(vector_index_client: PreviewVectorIndexClient) -> None:


### PR DESCRIPTION
Implements filter expressions for MVI. Filter expressions are additional "where" clauses on metadata fields. The search results are ordered based on query-content vector similarity; and an item is subject to inclusion if the item satisfies the field expression.