### PR TITLE
refactor: mvi filter expression arg rename

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -171,13 +171,13 @@ dev = ["Sphinx (>=5.1.1)", "black (==23.1.0)", "build (>=0.10.0)", "coverage (>=
 
 [[package]]
 name = "momento-wire-types"
-version = "0.105.1"
+version = "0.105.3"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.105.1-py3-none-any.whl", hash = "sha256:b27260c9745a93d919ca0de2791c1dfe46b2f021f6532cf8a3dd15f54c23b305"},
-    {file = "momento_wire_types-0.105.1.tar.gz", hash = "sha256:1db1b86b7c9b26a542041ae634974294d51e1adc7ed1912f4286e0fb1d441ecb"},
+    {file = "momento_wire_types-0.105.3-py3-none-any.whl", hash = "sha256:156c704eec560b9a102c16aa08283981f23fa6d8e61ddbb05b6206b979733672"},
+    {file = "momento_wire_types-0.105.3.tar.gz", hash = "sha256:12a785c7950b8cf62c8516061bfa8b9124619e097f82c16d110e770385ad16bc"},
 ]
 
 [package.dependencies]
@@ -617,4 +617,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "c77cae9d0aa0f8a51a272111bb0f3629c55572d151b4928a988609ebbb472079"
+content-hash = "7a1a7a6bb6d7e6608f2d6daff22c9db84b9f30efdcf34c350b67dafc76616af0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.105.1"
+momento-wire-types = "^0.105.3"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -149,7 +149,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         try:
             self._log_issuing_request("Search", {"index_name": index_name})
@@ -159,7 +159,7 @@ class _VectorIndexDataClient:
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
             metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
             no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
-            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter)
 
             request = vectorindex_pb._SearchRequest(
                 index_name=index_name,
@@ -168,7 +168,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
-                filter_expression=filter_expression_pb,
+                filter=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchResponse = await self._build_stub().Search(
@@ -189,7 +189,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         try:
             self._log_issuing_request("SearchAndFetchVectors", {"index_name": index_name})
@@ -199,7 +199,7 @@ class _VectorIndexDataClient:
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
             metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
             no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
-            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter)
 
             request = vectorindex_pb._SearchAndFetchVectorsRequest(
                 index_name=index_name,
@@ -208,7 +208,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
-                filter_expression=filter_expression_pb,
+                filter=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchAndFetchVectorsResponse = await self._build_stub().SearchAndFetchVectors(

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -149,7 +149,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         try:
             self._log_issuing_request("Search", {"index_name": index_name})
@@ -159,7 +159,7 @@ class _VectorIndexDataClient:
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
             metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
             no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
-            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter)
 
             request = vectorindex_pb._SearchRequest(
                 index_name=index_name,
@@ -168,7 +168,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
-                filter_expression=filter_expression_pb,
+                filter=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchResponse = self._build_stub().Search(
@@ -189,7 +189,7 @@ class _VectorIndexDataClient:
         top_k: int,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         try:
             self._log_issuing_request("SearchAndFetchVectors", {"index_name": index_name})
@@ -199,7 +199,7 @@ class _VectorIndexDataClient:
             query_vector_pb = vectorindex_pb._Vector(elements=query_vector)
             metadata_fields_pb = _VectorIndexDataClient.__build_metadata_request(metadata_fields)
             no_score_threshold = _VectorIndexDataClient.__build_no_score_threshold(score_threshold)
-            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter_expression)
+            filter_expression_pb = _VectorIndexDataClient.__build_filter_expression(filter)
 
             request = vectorindex_pb._SearchAndFetchVectorsRequest(
                 index_name=index_name,
@@ -208,7 +208,7 @@ class _VectorIndexDataClient:
                 metadata_fields=metadata_fields_pb,
                 score_threshold=score_threshold,
                 no_score_threshold=no_score_threshold,
-                filter_expression=filter_expression_pb,
+                filter=filter_expression_pb,
             )
 
             response: vectorindex_pb._SearchAndFetchVectorsResponse = self._build_stub().SearchAndFetchVectors(

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -215,7 +215,7 @@ class PreviewVectorIndexClient:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -233,15 +233,13 @@ class PreviewVectorIndexClient:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
-            filter_expression (Optional[FilterExpression]): A filter expression to filter
+            filter (Optional[FilterExpression]): A filter expression to filter
                 results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
-        return self._data_client.search(
-            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
-        )
+        return self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold, filter)
 
     def search_and_fetch_vectors(
         self,
@@ -250,7 +248,7 @@ class PreviewVectorIndexClient:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -269,14 +267,14 @@ class PreviewVectorIndexClient:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
-            filter_expression (Optional[FilterExpression]): A filter expression to filter
+            filter (Optional[FilterExpression]): A filter expression to filter
                 results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
         return self._data_client.search_and_fetch_vectors(
-            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter
         )
 
     def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -215,7 +215,7 @@ class PreviewVectorIndexClientAsync:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -233,15 +233,13 @@ class PreviewVectorIndexClientAsync:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
-            filter_expression (Optional[FilterExpression]): A filter expression to filter
+            filter (Optional[FilterExpression]): A filter expression to filter
                 results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
-        return await self._data_client.search(
-            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
-        )
+        return await self._data_client.search(index_name, query_vector, top_k, metadata_fields, score_threshold, filter)
 
     async def search_and_fetch_vectors(
         self,
@@ -250,7 +248,7 @@ class PreviewVectorIndexClientAsync:
         top_k: int = 10,
         metadata_fields: Optional[list[str]] | AllMetadata = None,
         score_threshold: Optional[float] = None,
-        filter_expression: Optional[FilterExpression] = None,
+        filter: Optional[FilterExpression] = None,
     ) -> SearchAndFetchVectorsResponse:
         """Searches for the most similar vectors to the query vector in the index.
 
@@ -269,14 +267,14 @@ class PreviewVectorIndexClientAsync:
                 For cosine similarity and inner product, scores lower than the threshold
                 are excluded. For euclidean similarity, scores higher than the threshold
                 are excluded. The threshold is exclusive. Defaults to None, ie no threshold.
-            filter_expression (Optional[FilterExpression]): A filter expression to filter
+            filter (Optional[FilterExpression]): A filter expression to filter
                 results by. Defaults to None, ie no filter.
 
         Returns:
             SearchResponse: The result of a search operation.
         """
         return await self._data_client.search_and_fetch_vectors(
-            index_name, query_vector, top_k, metadata_fields, score_threshold, filter_expression
+            index_name, query_vector, top_k, metadata_fields, score_threshold, filter
         )
 
     async def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -633,7 +633,7 @@ def test_search_with_filter_expression(
     # Writing the test cases here instead of as a parameterized test because:
     # 1. The search data is the same across tests, so no need to reindex each time.
     # 2. It is 10x faster to run the tests this way.
-    for filter_expression, expected_ids, test_case_name in [
+    for filter, expected_ids, test_case_name in [
         (Field("str") == "value1", ["test_item_1"], "string equality"),
         (Field("str") != "value1", ["test_item_2", "test_item_3"], "string inequality"),
         (Field("int") == 0, ["test_item_1"], "int equality"),
@@ -661,10 +661,8 @@ def test_search_with_filter_expression(
         (filters.IdInSet({"not there"}), [], "id in set not there"),
         (filters.IdInSet({"test_item_1", "test_item_3"}), ["test_item_1", "test_item_3"], "id in set"),
     ]:
-        filter_expression = cast(FilterExpression, filter_expression)
-        search_response = vector_index_client.search(
-            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
-        )
+        filter = cast(FilterExpression, filter)
+        search_response = vector_index_client.search(index_name, query_vector=[2.0, 2.0], filter=filter)
         assert isinstance(
             search_response, Search.Success
         ), f"Expected search {test_case_name!r} to succeed but got {search_response!r}"
@@ -673,7 +671,7 @@ def test_search_with_filter_expression(
         ), f"Expected search {test_case_name!r} to return {expected_ids!r} but got {search_response.hits!r}"
 
         search_and_fetch_vectors_response = vector_index_client.search_and_fetch_vectors(
-            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
+            index_name, query_vector=[2.0, 2.0], filter=filter
         )
         assert isinstance(
             search_and_fetch_vectors_response, SearchAndFetchVectors.Success

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -637,7 +637,7 @@ async def test_search_with_filter_expression(
     # Writing the test cases here instead of as a parameterized test because:
     # 1. The search data is the same across tests, so no need to reindex each time.
     # 2. It is 10x faster to run the tests this way.
-    for filter_expression, expected_ids, test_case_name in [
+    for filter, expected_ids, test_case_name in [
         (Field("str") == "value1", ["test_item_1"], "string equality"),
         (Field("str") != "value1", ["test_item_2", "test_item_3"], "string inequality"),
         (Field("int") == 0, ["test_item_1"], "int equality"),
@@ -665,10 +665,8 @@ async def test_search_with_filter_expression(
         (filters.IdInSet({"not there"}), [], "id in set not there"),
         (filters.IdInSet({"test_item_1", "test_item_3"}), ["test_item_1", "test_item_3"], "id in set"),
     ]:
-        filter_expression = cast(FilterExpression, filter_expression)
-        search_response = await vector_index_client_async.search(
-            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
-        )
+        filter = cast(FilterExpression, filter)
+        search_response = await vector_index_client_async.search(index_name, query_vector=[2.0, 2.0], filter=filter)
         assert isinstance(
             search_response, Search.Success
         ), f"Expected search {test_case_name!r} to succeed but got {search_response!r}"
@@ -677,7 +675,7 @@ async def test_search_with_filter_expression(
         ), f"Expected search {test_case_name!r} to return {expected_ids!r} but got {search_response.hits!r}"
 
         search_and_fetch_vectors_response = await vector_index_client_async.search_and_fetch_vectors(
-            index_name, query_vector=[2.0, 2.0], filter_expression=filter_expression
+            index_name, query_vector=[2.0, 2.0], filter=filter
         )
         assert isinstance(
             search_and_fetch_vectors_response, SearchAndFetchVectors.Success


### PR DESCRIPTION
In preparation for using filters across the two `get` methods and also
`delete`, we rename `filter_expression` to `filter`. In general these methods
may allow a user to pass a filter expression or, for convenience, a list of ids
(strings).