### PR TITLE
refactor: use mvi filter fields for get/delete items

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -171,13 +171,13 @@ dev = ["Sphinx (>=5.1.1)", "black (==23.1.0)", "build (>=0.10.0)", "coverage (>=
 
 [[package]]
 name = "momento-wire-types"
-version = "0.105.3"
+version = "0.106.0"
 description = "Momento Client Proto Generated Files"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "momento_wire_types-0.105.3-py3-none-any.whl", hash = "sha256:156c704eec560b9a102c16aa08283981f23fa6d8e61ddbb05b6206b979733672"},
-    {file = "momento_wire_types-0.105.3.tar.gz", hash = "sha256:12a785c7950b8cf62c8516061bfa8b9124619e097f82c16d110e770385ad16bc"},
+    {file = "momento_wire_types-0.106.0-py3-none-any.whl", hash = "sha256:7fc36fdb78872e0e0905a7229c35bed9065ed49709085acd59f85c07a10a2aa7"},
+    {file = "momento_wire_types-0.106.0.tar.gz", hash = "sha256:54052bbd23ff765f8667086c2bf5a537f4545190d846a03f1de473ecff59e4a3"},
 ]
 
 [package.dependencies]
@@ -617,4 +617,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "7a1a7a6bb6d7e6608f2d6daff22c9db84b9f30efdcf34c350b67dafc76616af0"
+content-hash = "b4532919b23bee37192a1c99efa8c592c96efeb03ddacace5752618f8830f006"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["src/momento/internal/codegen.py"]
 [tool.poetry.dependencies]
 python = "^3.7"
 
-momento-wire-types = "^0.105.3"
+momento-wire-types = "^0.106.0"
 grpcio = "^1.46.0"
 # note if you bump this presigned url test need be updated
 pyjwt = "^2.4.0"

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -14,6 +14,7 @@ from momento.internal._utilities import _validate_index_name, _validate_top_k
 from momento.internal.aio._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.internal.services import Service
 from momento.requests.vector_index import AllMetadata, FilterExpression, Item
+from momento.requests.vector_index import filters as F
 from momento.responses.vector_index import (
     CountItems,
     CountItemsResponse,
@@ -108,7 +109,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._DeleteItemBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
             )
 
             await self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -237,7 +237,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 
@@ -264,7 +264,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -14,6 +14,7 @@ from momento.internal._utilities import _validate_index_name, _validate_top_k
 from momento.internal.services import Service
 from momento.internal.synchronous._vector_index_grpc_manager import _VectorIndexDataGrpcManager
 from momento.requests.vector_index import AllMetadata, FilterExpression, Item
+from momento.requests.vector_index import filters as F
 from momento.responses.vector_index import (
     CountItems,
     CountItemsResponse,
@@ -108,7 +109,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._DeleteItemBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
             )
 
             self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -237,7 +237,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 
@@ -264,7 +264,7 @@ class _VectorIndexDataClient:
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,
-                ids=ids,
+                filter=F.IdInSet(ids).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/responses/vector_index/data/get_item_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_batch.py
@@ -36,17 +36,15 @@ class GetItemBatch(ABC):
 
         @staticmethod
         def from_proto(response: pb._GetItemBatchResponse) -> "GetItemBatch.Success":
-            """Converts a proto hit to a `GetItemBatch.Success`."""
-            values = {}
-            for item in response.item_response:
-                type = item.WhichOneof("response")
-                if type == "hit":
-                    id_, metadata = item.hit.id, pb_metadata_to_dict(item.hit.metadata)
-                    values[id_] = Item(id=id_, vector=list(item.hit.vector.elements), metadata=metadata)
-                elif type == "miss":
-                    pass
-                else:
-                    raise UnknownException(f"Unknown response type {type!r}.")
+            """Converts a sequence of proto _GetItemBatchResponse to a `GetItemBatch.Success`."""
+            values = {
+                item.id: Item(
+                    id=item.id,
+                    vector=list(item.vector.elements),
+                    metadata=pb_metadata_to_dict(item.metadata),
+                )
+                for item in response.item_response
+            }
 
             return GetItemBatch.Success(values=values)
 

--- a/src/momento/responses/vector_index/data/get_item_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_batch.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from momento_wire_types import vectorindex_pb2 as pb
 
 from momento.common_data.vector_index.item import Item
-from momento.errors.exceptions import UnknownException
 
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse

--- a/src/momento/responses/vector_index/data/get_item_metadata_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_metadata_batch.py
@@ -36,17 +36,8 @@ class GetItemMetadataBatch(ABC):
 
         @staticmethod
         def from_proto(response: pb._GetItemMetadataBatchResponse) -> "GetItemMetadataBatch.Success":
-            """Converts a proto hit to a `GetItemMetadataBatch.Success`."""
-            values = {}
-            for item in response.item_metadata_response:
-                type = item.WhichOneof("response")
-                if type == "hit":
-                    values[item.hit.id] = pb_metadata_to_dict(item.hit.metadata)
-                elif type == "miss":
-                    pass
-                else:
-                    raise UnknownException(f"Unknown response type {type!r}.")
-
+            """Converts a proto _GetItemMetadataBatchResponse to a `GetItemMetadataBatch.Success`."""
+            values = {item.id: pb_metadata_to_dict(item.metadata) for item in response.item_metadata_response}
             return GetItemMetadataBatch.Success(values=values)
 
     class Error(GetItemMetadataBatchResponse, ErrorResponseMixin):

--- a/src/momento/responses/vector_index/data/get_item_metadata_batch.py
+++ b/src/momento/responses/vector_index/data/get_item_metadata_batch.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from momento_wire_types import vectorindex_pb2 as pb
 
 from momento.common_data.vector_index.item import Metadata
-from momento.errors.exceptions import UnknownException
 
 from ...mixins import ErrorResponseMixin
 from ..response import VectorIndexResponse


### PR DESCRIPTION
We are in the process of migrating MVI `delete item batch`, `get item batch`, and `get item metadata batch` to use a filter expression to select items to delete (get) as opposed to a list of id's. For convenience, we will still allow users to select items with a list of id's from the top level methods. This PR migrates the backend.

As part of the migration we are also moving away from the hit/miss pattern for `get item batch` and `get item metadata batch` response messages. While the hit/miss pattern made sense for when we only selected items by id, it no longer makes sense for when a user supplies a general filter expression. What's more, previously when we read the hit/miss responses, we built a dictionary containing only the hits, so the distinction wasn't as important.

In future PRs we will add overloads to also use a filter expression from delete and get item methods.