### PR TITLE
refactor: rename mvi parameter `ids` to `filter` on `get`/`delete` items

### DIFF
--- a/examples/prepy310/vector_index.py
+++ b/examples/prepy310/vector_index.py
@@ -107,7 +107,7 @@ def search(client: PreviewVectorIndexClient, index_name: str) -> None:
 def delete_items(client: PreviewVectorIndexClient, index_name: str) -> None:
     item_ids_to_delete = ["test_item_1", "test_item_3"]
     _logger.info(f"Deleting items: {item_ids_to_delete}")
-    delete_response = client.delete_item_batch(index_name, ids=item_ids_to_delete)
+    delete_response = client.delete_item_batch(index_name, filter=item_ids_to_delete)
     if isinstance(delete_response, DeleteItemBatch.Success):
         _logger.info("Successfully deleted items")
     elif isinstance(delete_response, DeleteItemBatch.Error):

--- a/examples/prepy310/vector_index_async.py
+++ b/examples/prepy310/vector_index_async.py
@@ -110,7 +110,7 @@ async def search(client: PreviewVectorIndexClientAsync, index_name: str) -> None
 async def delete_items(client: PreviewVectorIndexClientAsync, index_name: str) -> None:
     item_ids_to_delete = ["test_item_1", "test_item_3"]
     _logger.info(f"Deleting items: {item_ids_to_delete}")
-    delete_response = await client.delete_item_batch(index_name, ids=item_ids_to_delete)
+    delete_response = await client.delete_item_batch(index_name, filter=item_ids_to_delete)
     if isinstance(delete_response, DeleteItemBatch.Success):
         _logger.info("Successfully deleted items")
     elif isinstance(delete_response, DeleteItemBatch.Error):

--- a/examples/py310/vector_index.py
+++ b/examples/py310/vector_index.py
@@ -111,7 +111,7 @@ def search(client: PreviewVectorIndexClient, index_name: str) -> None:
 def delete_items(client: PreviewVectorIndexClient, index_name: str) -> None:
     item_ids_to_delete = ["test_item_1", "test_item_3"]
     _logger.info(f"Deleting items: {item_ids_to_delete}")
-    delete_response = client.delete_item_batch(index_name, ids=item_ids_to_delete)
+    delete_response = client.delete_item_batch(index_name, filter=item_ids_to_delete)
     match delete_response:
         case DeleteItemBatch.Success():
             _logger.info("Successfully deleted items")

--- a/examples/py310/vector_index_async.py
+++ b/examples/py310/vector_index_async.py
@@ -114,7 +114,7 @@ async def search(client: PreviewVectorIndexClientAsync, index_name: str) -> None
 async def delete_items(client: PreviewVectorIndexClientAsync, index_name: str) -> None:
     item_ids_to_delete = ["test_item_1", "test_item_3"]
     _logger.info(f"Deleting items: {item_ids_to_delete}")
-    delete_response = await client.delete_item_batch(index_name, ids=item_ids_to_delete)
+    delete_response = await client.delete_item_batch(index_name, filter=item_ids_to_delete)
     match delete_response:
         case DeleteItemBatch.Success():
             _logger.info("Successfully deleted items")

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -98,18 +98,18 @@ class _VectorIndexDataClient:
     async def delete_item_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> DeleteItemBatchResponse:
         try:
             self._log_issuing_request("DeleteItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return DeleteItemBatch.Success()
 
             request = vectorindex_pb._DeleteItemBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
             )
 
             await self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -226,18 +226,18 @@ class _VectorIndexDataClient:
     async def get_item_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> GetItemBatchResponse:
         try:
             self._log_issuing_request("GetItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return GetItemBatch.Success(values={})
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -253,18 +253,18 @@ class _VectorIndexDataClient:
     async def get_item_metadata_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> GetItemMetadataBatchResponse:
         try:
             self._log_issuing_request("GetItemMetadataBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return GetItemMetadataBatch.Success(values={})
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -98,18 +98,18 @@ class _VectorIndexDataClient:
     def delete_item_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> DeleteItemBatchResponse:
         try:
             self._log_issuing_request("DeleteItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return DeleteItemBatch.Success()
 
             request = vectorindex_pb._DeleteItemBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
             )
 
             self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -253,18 +253,18 @@ class _VectorIndexDataClient:
     def get_item_metadata_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> GetItemMetadataBatchResponse:
         try:
             self._log_issuing_request("GetItemMetadataBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return GetItemMetadataBatch.Success(values={})
 
             request = vectorindex_pb._GetItemMetadataBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -226,18 +226,18 @@ class _VectorIndexDataClient:
     def get_item_batch(
         self,
         index_name: str,
-        ids: list[str],
+        filter: list[str],
     ) -> GetItemBatchResponse:
         try:
             self._log_issuing_request("GetItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(ids) == 0:
+            if len(filter) == 0:
                 return GetItemBatch.Success(values={})
 
             request = vectorindex_pb._GetItemBatchRequest(
                 index_name=index_name,
-                filter=F.IdInSet(ids).to_filter_expression_proto(),
+                filter=F.IdInSet(filter).to_filter_expression_proto(),
                 metadata_fields=vectorindex_pb._MetadataRequest(all=vectorindex_pb._MetadataRequest.All()),
             )
 

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -277,17 +277,17 @@ class PreviewVectorIndexClient:
             index_name, query_vector, top_k, metadata_fields, score_threshold, filter
         )
 
-    def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:
+    def get_item_batch(self, index_name: str, filter: list[str]) -> GetItemBatchResponse:
         """Gets a batch of items from a vector index by ID.
 
         Args:
             index_name (str): Name of the index to get the item from.
-            ids (list[str]): The IDs of the items to be retrieved from the index.
+            filter (list[str]): The IDs of the items to be retrieved from the index.
 
         Returns:
             GetItemBatchResponse: The result of a get item batch operation.
         """
-        return self._data_client.get_item_batch(index_name, ids)
+        return self._data_client.get_item_batch(index_name, filter)
 
     def get_item_metadata_batch(self, index_name: str, ids: list[str]) -> GetItemMetadataBatchResponse:
         """Gets metadata for a batch of items from a vector index by ID.

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -194,19 +194,19 @@ class PreviewVectorIndexClient:
         """
         return self._data_client.upsert_item_batch(index_name, items)
 
-    def delete_item_batch(self, index_name: str, ids: list[str]) -> DeleteItemBatchResponse:
+    def delete_item_batch(self, index_name: str, filter: list[str]) -> DeleteItemBatchResponse:
         """Deletes a batch of items from a vector index.
 
         Deletes any and all items with the given IDs from the index.
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            ids (list[str]): The IDs of the items to be deleted from the index.
+            filter (list[str]): The IDs of the items to be deleted from the index.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.
         """
-        return self._data_client.delete_item_batch(index_name, ids)
+        return self._data_client.delete_item_batch(index_name, filter)
 
     def search(
         self,

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -289,16 +289,16 @@ class PreviewVectorIndexClient:
         """
         return self._data_client.get_item_batch(index_name, filter)
 
-    def get_item_metadata_batch(self, index_name: str, ids: list[str]) -> GetItemMetadataBatchResponse:
+    def get_item_metadata_batch(self, index_name: str, filter: list[str]) -> GetItemMetadataBatchResponse:
         """Gets metadata for a batch of items from a vector index by ID.
 
         Args:
             index_name (str): Name of the index to get the items from.
-            ids (list[str]): The IDs of the item metadata to be retrieved from the index.
+            filter (list[str]): The IDs of the item metadata to be retrieved from the index.
 
         Returns:
             GetItemMetadataBatchResponse: The result of a get item metadata batch operation.
         """
-        return self._data_client.get_item_metadata_batch(index_name, ids)
+        return self._data_client.get_item_metadata_batch(index_name, filter)
 
     # TODO: repr

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -194,19 +194,19 @@ class PreviewVectorIndexClientAsync:
         """
         return await self._data_client.upsert_item_batch(index_name, items)
 
-    async def delete_item_batch(self, index_name: str, ids: list[str]) -> DeleteItemBatchResponse:
+    async def delete_item_batch(self, index_name: str, filter: list[str]) -> DeleteItemBatchResponse:
         """Deletes a batch of items from a vector index.
 
         Deletes any and all items with the given IDs from the index.
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            ids (list[str]): The IDs of the items to be deleted from the index.
+            filter (list[str]): The IDs of the items to be deleted from the index.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.
         """
-        return await self._data_client.delete_item_batch(index_name, ids)
+        return await self._data_client.delete_item_batch(index_name, filter)
 
     async def search(
         self,

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -289,16 +289,16 @@ class PreviewVectorIndexClientAsync:
         """
         return await self._data_client.get_item_batch(index_name, filter)
 
-    async def get_item_metadata_batch(self, index_name: str, ids: list[str]) -> GetItemMetadataBatchResponse:
+    async def get_item_metadata_batch(self, index_name: str, filter: list[str]) -> GetItemMetadataBatchResponse:
         """Gets metadata for a batch of items from a vector index by ID.
 
         Args:
             index_name (str): Name of the index to get the items from.
-            ids (list[str]): The IDs of the item metadata to be retrieved from the index.
+            filter (list[str]): The IDs of the item metadata to be retrieved from the index.
 
         Returns:
             GetItemMetadataBatchResponse: The result of a get item metadata batch operation.
         """
-        return await self._data_client.get_item_metadata_batch(index_name, ids)
+        return await self._data_client.get_item_metadata_batch(index_name, filter)
 
     # TODO: repr

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -277,17 +277,17 @@ class PreviewVectorIndexClientAsync:
             index_name, query_vector, top_k, metadata_fields, score_threshold, filter
         )
 
-    async def get_item_batch(self, index_name: str, ids: list[str]) -> GetItemBatchResponse:
+    async def get_item_batch(self, index_name: str, filter: list[str]) -> GetItemBatchResponse:
         """Gets a batch of items from a vector index by ID.
 
         Args:
             index_name (str): Name of the index to get the item from.
-            ids (list[str]): The IDs of the items to be retrieved from the index.
+            filter (list[str]): The IDs of the items to be retrieved from the index.
 
         Returns:
             GetItemBatchResponse: The result of a get item batch operation.
         """
-        return await self._data_client.get_item_batch(index_name, ids)
+        return await self._data_client.get_item_batch(index_name, filter)
 
     async def get_item_metadata_batch(self, index_name: str, ids: list[str]) -> GetItemMetadataBatchResponse:
         """Gets metadata for a batch of items from a vector index by ID.

--- a/tests/momento/vector_index_client/test_data.py
+++ b/tests/momento/vector_index_client/test_data.py
@@ -683,7 +683,7 @@ def test_search_with_filter_expression(
 
 
 def test_delete_validates_index_name(vector_index_client: PreviewVectorIndexClient) -> None:
-    response = vector_index_client.delete_item_batch(index_name="", ids=[])
+    response = vector_index_client.delete_item_batch(index_name="", filter=[])
     assert isinstance(response, DeleteItemBatch.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
@@ -721,7 +721,7 @@ def test_delete_deletes_ids(
         SearchHit(id="test_item_1", score=5.0),
     ]
 
-    delete_response = vector_index_client.delete_item_batch(index_name, ids=["test_item_1", "test_item_3"])
+    delete_response = vector_index_client.delete_item_batch(index_name, filter=["test_item_1", "test_item_3"])
     assert isinstance(delete_response, DeleteItemBatch.Success)
 
     sleep(2)
@@ -859,7 +859,7 @@ def test_count_items_with_items(
 
     num_items_to_delete = 5
     delete_response = vector_index_client.delete_item_batch(
-        index_name, ids=[item.id for item in items[:num_items_to_delete]]
+        index_name, filter=[item.id for item in items[:num_items_to_delete]]
     )
     assert isinstance(delete_response, DeleteItemBatch.Success)
 

--- a/tests/momento/vector_index_client/test_data_async.py
+++ b/tests/momento/vector_index_client/test_data_async.py
@@ -687,7 +687,7 @@ async def test_search_with_filter_expression(
 
 
 async def test_delete_validates_index_name(vector_index_client_async: PreviewVectorIndexClientAsync) -> None:
-    response = await vector_index_client_async.delete_item_batch(index_name="", ids=[])
+    response = await vector_index_client_async.delete_item_batch(index_name="", filter=[])
     assert isinstance(response, DeleteItemBatch.Error)
     assert response.error_code == MomentoErrorCode.INVALID_ARGUMENT_ERROR
 
@@ -725,7 +725,9 @@ async def test_delete_deletes_ids(
         SearchHit(id="test_item_1", score=5.0),
     ]
 
-    delete_response = await vector_index_client_async.delete_item_batch(index_name, ids=["test_item_1", "test_item_3"])
+    delete_response = await vector_index_client_async.delete_item_batch(
+        index_name, filter=["test_item_1", "test_item_3"]
+    )
     assert isinstance(delete_response, DeleteItemBatch.Success)
 
     await sleep_async(2)
@@ -863,7 +865,7 @@ async def test_count_items_with_items(
 
     num_items_to_delete = 5
     delete_response = await vector_index_client_async.delete_item_batch(
-        index_name, ids=[item.id for item in items[:num_items_to_delete]]
+        index_name, filter=[item.id for item in items[:num_items_to_delete]]
     )
     assert isinstance(delete_response, DeleteItemBatch.Success)
 


### PR DESCRIPTION
- refactor: rename `ids` parameter to `filter` on delete_item_batch
- refactor: rename `ids` parameter to `filter` on get item batch
- refactor: rename `ids parameter to `filter` on `get item metadata`
