### PR TITLE
feat: add mvi delete by filter overload

### DIFF
--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -98,19 +98,22 @@ class _VectorIndexDataClient:
     async def delete_item_batch(
         self,
         index_name: str,
-        filter: list[str],
+        filter: FilterExpression | list[str],
     ) -> DeleteItemBatchResponse:
         try:
             self._log_issuing_request("DeleteItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(filter) == 0:
-                return DeleteItemBatch.Success()
+            filter_expression: vectorindex_pb._FilterExpression
 
-            request = vectorindex_pb._DeleteItemBatchRequest(
-                index_name=index_name,
-                filter=F.IdInSet(filter).to_filter_expression_proto(),
-            )
+            if isinstance(filter, list):
+                if len(filter) == 0:
+                    return DeleteItemBatch.Success()
+                filter_expression = F.IdInSet(filter).to_filter_expression_proto()
+            else:
+                filter_expression = filter.to_filter_expression_proto()
+
+            request = vectorindex_pb._DeleteItemBatchRequest(index_name=index_name, filter=filter_expression)
 
             await self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)
 

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -106,12 +106,12 @@ class _VectorIndexDataClient:
 
             filter_expression: vectorindex_pb._FilterExpression
 
-            if isinstance(filter, list):
+            if isinstance(filter, FilterExpression):
+                filter_expression = filter.to_filter_expression_proto()
+            else:
                 if len(filter) == 0:
                     return DeleteItemBatch.Success()
                 filter_expression = F.IdInSet(filter).to_filter_expression_proto()
-            else:
-                filter_expression = filter.to_filter_expression_proto()
 
             request = vectorindex_pb._DeleteItemBatchRequest(index_name=index_name, filter=filter_expression)
 

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -98,19 +98,22 @@ class _VectorIndexDataClient:
     def delete_item_batch(
         self,
         index_name: str,
-        filter: list[str],
+        filter: FilterExpression | list[str],
     ) -> DeleteItemBatchResponse:
         try:
             self._log_issuing_request("DeleteItemBatch", {"index_name": index_name})
             _validate_index_name(index_name)
 
-            if len(filter) == 0:
-                return DeleteItemBatch.Success()
+            filter_expression: vectorindex_pb._FilterExpression
 
-            request = vectorindex_pb._DeleteItemBatchRequest(
-                index_name=index_name,
-                filter=F.IdInSet(filter).to_filter_expression_proto(),
-            )
+            if isinstance(filter, list):
+                if len(filter) == 0:
+                    return DeleteItemBatch.Success()
+                filter_expression = F.IdInSet(filter).to_filter_expression_proto()
+            else:
+                filter_expression = filter.to_filter_expression_proto()
+
+            request = vectorindex_pb._DeleteItemBatchRequest(index_name=index_name, filter=filter_expression)
 
             self._build_stub().DeleteItemBatch(request, timeout=self._default_deadline_seconds)
 

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -106,12 +106,12 @@ class _VectorIndexDataClient:
 
             filter_expression: vectorindex_pb._FilterExpression
 
-            if isinstance(filter, list):
+            if isinstance(filter, FilterExpression):
+                filter_expression = filter.to_filter_expression_proto()
+            else:
                 if len(filter) == 0:
                     return DeleteItemBatch.Success()
                 filter_expression = F.IdInSet(filter).to_filter_expression_proto()
-            else:
-                filter_expression = filter.to_filter_expression_proto()
 
             request = vectorindex_pb._DeleteItemBatchRequest(index_name=index_name, filter=filter_expression)
 

--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -194,14 +194,16 @@ class PreviewVectorIndexClient:
         """
         return self._data_client.upsert_item_batch(index_name, items)
 
-    def delete_item_batch(self, index_name: str, filter: list[str]) -> DeleteItemBatchResponse:
+    def delete_item_batch(self, index_name: str, filter: FilterExpression | list[str]) -> DeleteItemBatchResponse:
         """Deletes a batch of items from a vector index.
 
         Deletes any and all items with the given IDs from the index.
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            filter (list[str]): The IDs of the items to be deleted from the index.
+            filter (FilterExpression | list[str]): A filter expression to filter
+                items by ID. If a list of strings is provided, it is treated as a
+                "IdInSet" filter expression.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -194,14 +194,16 @@ class PreviewVectorIndexClientAsync:
         """
         return await self._data_client.upsert_item_batch(index_name, items)
 
-    async def delete_item_batch(self, index_name: str, filter: list[str]) -> DeleteItemBatchResponse:
+    async def delete_item_batch(self, index_name: str, filter: FilterExpression | list[str]) -> DeleteItemBatchResponse:
         """Deletes a batch of items from a vector index.
 
         Deletes any and all items with the given IDs from the index.
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            filter (list[str]): The IDs of the items to be deleted from the index.
+            filter (FilterExpression | list[str]): A filter expression to filter
+                items by ID. If a list of strings is provided, it is treated as a
+                "IdInSet" filter expression.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.


### PR DESCRIPTION
Adds an overload MVI `delete_item_batch` to allow users to delete items by not just a list of ids, but also a more general filter expression. We maintain the option of providing a list of ids for convenience. This PR adds integration tests and updates the documentation.
