### PR TITLE
docs: improve delete by filter docstring

### DIFF
--- a/src/momento/vector_index_client.py
+++ b/src/momento/vector_index_client.py
@@ -201,9 +201,8 @@ class PreviewVectorIndexClient:
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            filter (FilterExpression | list[str]): A filter expression to filter
-                items by ID. If a list of strings is provided, it is treated as a
-                "IdInSet" filter expression.
+            filter (FilterExpression | list[str]): A filter expression to match
+                items to be deleted, or list of item IDs to be deleted.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.

--- a/src/momento/vector_index_client_async.py
+++ b/src/momento/vector_index_client_async.py
@@ -201,9 +201,8 @@ class PreviewVectorIndexClientAsync:
 
         Args:
             index_name (str): Name of the index to delete the items from.
-            filter (FilterExpression | list[str]): A filter expression to filter
-                items by ID. If a list of strings is provided, it is treated as a
-                "IdInSet" filter expression.
+            filter (FilterExpression | list[str]): A filter expression to match
+                items to be deleted, or list of item IDs to be deleted.
 
         Returns:
             DeleteItemBatchResponse: The result of a delete item batch operation.


### PR DESCRIPTION
Previously the delete by filter docstring was incorrect, stating that
the filter expression "filters items by ID". The filter expression
matches items to be deleted.
