### PR TITLE
fix: timedelta to ms conversion and timedelta to deadline conversion

### DIFF
--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -14,6 +14,7 @@ from ._data_validation import (
     _validate_ttl,
 )
 from ._momento_version import momento_version
+from ._time import _timedelta_to_ms
 from ._vector_index_validation import (
     _validate_index_name,
     _validate_num_dimensions,

--- a/src/momento/internal/_utilities/_grpc_channel_options.py
+++ b/src/momento/internal/_utilities/_grpc_channel_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import grpc
 
 from momento.config.transport.grpc_configuration import GrpcConfiguration
+from momento.internal._utilities import _timedelta_to_ms
 
 DEFAULT_MAX_MESSAGE_SIZE = 5_243_000  # bytes
 
@@ -37,10 +38,10 @@ def grpc_channel_options_from_grpc_config(grpc_config: GrpcConfiguration) -> grp
 
     keepalive_time = grpc_config.get_keepalive_time()
     if keepalive_time is not None:
-        channel_options.append(("grpc.keepalive_time_ms", keepalive_time.seconds * 1000))
+        channel_options.append(("grpc.keepalive_time_ms", _timedelta_to_ms(keepalive_time)))
 
     keepalive_timeout = grpc_config.get_keepalive_timeout()
     if keepalive_timeout is not None:
-        channel_options.append(("grpc.keepalive_timeout_ms", keepalive_timeout.seconds * 1000))
+        channel_options.append(("grpc.keepalive_timeout_ms", _timedelta_to_ms(keepalive_timeout)))
 
     return channel_options

--- a/src/momento/internal/_utilities/_time.py
+++ b/src/momento/internal/_utilities/_time.py
@@ -1,0 +1,15 @@
+from datetime import timedelta
+
+
+def _timedelta_to_ms(delta: timedelta) -> int:
+    """Expresses a timedelta as milliseconds.
+
+    Note: truncates the microseconds.
+
+    Args:
+        delta (timedelta): The timedelta to convert.
+
+    Returns:
+        int: The total duration of the timedelta in milliseconds.
+    """
+    return int(delta.total_seconds() * 1000)

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -16,6 +16,7 @@ from momento.internal._utilities import (
     _gen_dictionary_items_as_bytes,
     _gen_list_as_bytes,
     _gen_set_input_as_bytes,
+    _timedelta_to_ms,
     _validate_cache_name,
     _validate_dictionary_name,
     _validate_list_name,
@@ -1107,7 +1108,7 @@ class _ScsDataClient:
         if ttl is not None:
             which_ttl = ttl
 
-        return int(which_ttl.total_seconds() * 1000)
+        return _timedelta_to_ms(which_ttl)
 
     def _build_stub(self) -> cache_grpc.ScsStub:
         return self._grpc_manager.async_stub()

--- a/src/momento/internal/aio/_scs_data_client.py
+++ b/src/momento/internal/aio/_scs_data_client.py
@@ -155,7 +155,7 @@ class _ScsDataClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         self._grpc_manager = _DataGrpcManager(configuration, credential_provider)
         _validate_ttl(default_ttl)

--- a/src/momento/internal/aio/_vector_index_data_client.py
+++ b/src/momento/internal/aio/_vector_index_data_client.py
@@ -45,7 +45,7 @@ class _VectorIndexDataClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         self._grpc_manager = _VectorIndexDataGrpcManager(configuration, credential_provider)
 

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -155,7 +155,7 @@ class _ScsDataClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         self._grpc_manager = _DataGrpcManager(configuration, credential_provider)
         _validate_ttl(default_ttl)

--- a/src/momento/internal/synchronous/_scs_data_client.py
+++ b/src/momento/internal/synchronous/_scs_data_client.py
@@ -16,6 +16,7 @@ from momento.internal._utilities import (
     _gen_dictionary_items_as_bytes,
     _gen_list_as_bytes,
     _gen_set_input_as_bytes,
+    _timedelta_to_ms,
     _validate_cache_name,
     _validate_dictionary_name,
     _validate_list_name,
@@ -1105,7 +1106,7 @@ class _ScsDataClient:
         if ttl is not None:
             which_ttl = ttl
 
-        return int(which_ttl.total_seconds() * 1000)
+        return _timedelta_to_ms(which_ttl)
 
     def _build_stub(self) -> cache_grpc.ScsStub:
         return self._grpc_manager.stub()

--- a/src/momento/internal/synchronous/_vector_index_data_client.py
+++ b/src/momento/internal/synchronous/_vector_index_data_client.py
@@ -45,7 +45,7 @@ class _VectorIndexDataClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         self._grpc_manager = _VectorIndexDataGrpcManager(configuration, credential_provider)
 

--- a/tests/momento/internal/_utilities/test_time.py
+++ b/tests/momento/internal/_utilities/test_time.py
@@ -1,0 +1,22 @@
+from datetime import timedelta
+
+import pytest
+from momento.internal._utilities import _timedelta_to_ms
+
+
+@pytest.mark.parametrize(
+    ["delta", "actual_ms"],
+    [
+        [timedelta(days=1), 24 * 60 * 60 * 1000],
+        [timedelta(hours=1), 60 * 60 * 1000],
+        [timedelta(minutes=1), 60 * 1000],
+        [timedelta(seconds=1), 1000],
+        [timedelta(milliseconds=1), 1],
+        [timedelta(microseconds=1), 0],
+        [timedelta(days=1, seconds=1), 24 * 60 * 60 * 1000 + 1000],
+        [timedelta(seconds=1, milliseconds=100), 1100],
+        [timedelta(milliseconds=1100), 1100],
+    ],
+)
+def test_timedelta_to_ms(delta: timedelta, actual_ms: int) -> None:
+    assert _timedelta_to_ms(delta) == actual_ms


### PR DESCRIPTION
This PR corrects two bugs.

First we add a utility function to convert timedelta objects to milliseconds, unit tests, and refactor code to use this across the board. Previously we were converting timedeltas to milliseconds in several places which led to bugs when calling `.seconds` (not fractional) vs `total_seconds()` (fractional). Calling the former was truncating the milliseconds portion.

Second we correct a bug the gRPC timeout. After reading from the config, we converted the timedelta to total whole seconds. This again truncated the milliseconds portion; because the gRPC parameter accepts fractional seconds, we should not have been truncating.