### PR TITLE
chore: eager connection should fail fast

### DIFF
--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -91,6 +91,9 @@ class _DataGrpcManager:
             await asyncio.wait_for(self.wait_for_ready(), timeout_seconds)
         except Exception as error:
             self._logger.debug(f"Failed to connect to the server within the given timeout. {error}")
+            raise RuntimeError(
+                f"Failed to connect to Momento's server within given eager connection timeout {error}"
+            ) from error
 
     async def wait_for_ready(self) -> None:
         latest_state = self._secure_channel.get_state(True)  # try_to_connect

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -97,6 +97,7 @@ class _DataGrpcManager:
             )
             # the subscription is no longer needed; it was only meant to watch if we could connect eagerly
             self._secure_channel.unsubscribe(on_state_change)
+            raise RuntimeError("Failed to connect to Momento's server within given eager connection timeout")
 
         """
         A callback that is triggered whenever a connection's state changes. We explicitly subscribe to

--- a/tests/momento/cache_client/test_init.py
+++ b/tests/momento/cache_client/test_init.py
@@ -43,3 +43,12 @@ def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=0))
         CacheClient(configuration, credential_provider, default_ttl_seconds)
+
+
+def test_init_eagerly_connecting_cache_client(
+    configuration: Configuration, credential_provider: CredentialProvider, default_ttl_seconds: timedelta
+) -> None:
+    client = CacheClient.create(
+        configuration, credential_provider, default_ttl_seconds, eager_connection_timeout=timedelta(seconds=30)
+    )
+    assert client

--- a/tests/momento/cache_client/test_init_async.py
+++ b/tests/momento/cache_client/test_init_async.py
@@ -45,3 +45,12 @@ async def test_init_throws_exception_when_client_uses_zero_request_timeout_ms(
     with pytest.raises(InvalidArgumentException, match="Request timeout must be a positive amount of time."):
         configuration = configuration.with_client_timeout(timedelta(seconds=0))
         CacheClientAsync(configuration, credential_provider, default_ttl_seconds)
+
+
+async def test_init_eagerly_connecting_cache_client(
+    configuration: Configuration, credential_provider: CredentialProvider, default_ttl_seconds: timedelta
+) -> None:
+    client = await CacheClientAsync.create(
+        configuration, credential_provider, default_ttl_seconds, eager_connection_timeout=timedelta(seconds=30)
+    )
+    assert client


### PR DESCRIPTION
Eager connection should raise the error instead of logging the failure.

Tested locally and saw `RuntimeError: Failed to connect to Momento's server within given eager connection timeout` and the stack trace.