### PR TITLE
chore: use ubuntu-24.04 for ci where possible

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -44,7 +44,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           version: 1.3.1
-          virtualenvs-in-project: false
+          virtualenvs-in-project: true
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -97,10 +97,18 @@ jobs:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.1
+          virtualenvs-in-project: true
+
       - name: Python SDK sample
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Verify README generation
         uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
@@ -113,13 +121,6 @@ jobs:
           dev_docs_slug: python
           template_file: ./README.template.md
           output_file: ./README.md
-
-      - name: Bootstrap poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
 
       - name: Install dependencies
         working-directory: ./examples

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,8 +9,16 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+         # TODO: one of the examples dependencies does not support 3.11
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         new-python-protobuf: ["true"]
+        include:
+          - python-version: "3.7"
+            new-python-protobuf: "false"
+          - python-version: "3.7"
+            package: prepy310
+          - python-version: "3.8"
+            package: prepy310
 
     env:
       TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -40,18 +40,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.1
+          virtualenvs-in-project: false
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
-
-      - name: Bootstrap poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
@@ -62,7 +62,7 @@ jobs:
         run: poetry run pytest -p no:sugar -q
 
   test-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         # TODO: one of the examples dependencies does not support 3.11

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,19 +6,27 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
     strategy:
       matrix:
-         # TODO: one of the examples dependencies does not support 3.11
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # TODO: one of the examples dependencies does not support 3.11
+        os: [ubuntu-24.04]
+        python-version: ["3.9", "3.10", "3.11"]
         new-python-protobuf: ["true"]
         include:
+          # 3.7 and 3.8 are no longer available on ubuntu-24.04
+          # We run on 20.04 which was the last version where this worked.
+          # If support for 20.04 becomes an issue, we can install 3.7 and 3.8
+          # with pyenv or manually.
+          - python-version: "3.7"
+            new-python-protobuf: "true"
+            os: ubuntu-20.04
           - python-version: "3.7"
             new-python-protobuf: "false"
-          - python-version: "3.7"
-            package: prepy310
+            os: ubuntu-20.04
           - python-version: "3.8"
-            package: prepy310
+            new-python-protobuf: "true"
+            os: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     env:
       TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Bootstrap poetry
         run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,11 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         new-python-protobuf: ["true"]
-        include:
-          - python-version: "3.7"
-            new-python-protobuf: "false"
 
     env:
       TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
@@ -67,10 +64,6 @@ jobs:
       matrix:
         # TODO: one of the examples dependencies does not support 3.11
         include:
-          - python-version: "3.7"
-            package: prepy310
-          - python-version: "3.8"
-            package: prepy310
           - python-version: "3.9"
             package: prepy310
           - python-version: "3.10"

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup repo

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.release.outputs.release }}
     steps:
@@ -30,14 +30,30 @@ jobs:
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
   test:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-20.04]
+        python-version: ["3.9", "3.10", "3.11"]
         new-python-protobuf: ["true"]
         include:
+          # 3.7 and 3.8 are no longer available on ubuntu-24.04
+          # We run on 20.04 which was the last version where this worked.
+          # If support for 20.04 becomes an issue, we can install 3.7 and 3.8
+          # with pyenv or manually.
+          - python-version: "3.7"
+            new-python-protobuf: "true"
+            os: ubuntu-20.04
           - python-version: "3.7"
             new-python-protobuf: "false"
+            os: ubuntu-20.04
+          - python-version: "3.8"
+            new-python-protobuf: "true"
+            os: ubuntu-20.04
+          - python-version: "3.8"
+            new-python-protobuf: "false"
+            os: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+
     env:
       TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
@@ -45,17 +61,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.1
+          virtualenvs-in-project: true
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Bootstrap poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
 
       - name: Install dependencies
         run: poetry install
@@ -80,20 +95,22 @@ jobs:
         run: poetry run pytest -p no:sugar -q
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [release, test]
 
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.1
+          virtualenvs-in-project: true
+
       - name: Setup Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-
-      - name: Bootstrap poetry
-        run: |
-          curl -sL https://install.python-poetry.org | python - -y --version 1.3.1
 
       - name: Bump version
         run: poetry version ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Updates the CI workflows to use `ubuntu-24.04` for python 3.9+ and `ubuntu-20.04` for python 3.7 and 3.8. Previously we could not run on `ubuntu-22.04` due to a difficult-to-diagnose timeout problem. This timeout problem manifested on Azure VMs with ubuntu-22.04 but not on other platforms.

This problem does not manifest on `ubuntu-24.04`, so we can use that where possible. Because python 3.7 and python 3.8 are not available on `ubuntu-24.04`, we still run those on `ubuntu-20.04`. At some point we can look in to installing via `pyenv` or manually on `ubuntu-24.04`.