### PR TITLE
chore: add agent details and new runtime version header

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -40,17 +40,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:
           version: 1.3.1
           virtualenvs-in-project: true
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: poetry
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -61,16 +61,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:
           version: 1.3.1
           virtualenvs-in-project: true
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: poetry install

--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -1,3 +1,4 @@
+from ._client_type import ClientType
 from ._data_validation import (
     _as_bytes,
     _gen_dictionary_fields_as_bytes,
@@ -14,4 +15,5 @@ from ._data_validation import (
     _validate_ttl,
 )
 from ._momento_version import momento_version
+from ._python_runtime_version import PYTHON_RUNTIME_VERSION
 from ._time import _timedelta_to_ms

--- a/src/momento/internal/_utilities/_client_type.py
+++ b/src/momento/internal/_utilities/_client_type.py
@@ -1,0 +1,13 @@
+"""Enumerates the types of clients that can be used.
+
+Used to populate the agent header in gRPC requests.
+"""
+
+from enum import Enum
+
+
+class ClientType(Enum):
+    """Describes the type of client that is being used."""
+
+    CACHE = "cache"
+    TOPIC = "topic"

--- a/src/momento/internal/_utilities/_python_runtime_version.py
+++ b/src/momento/internal/_utilities/_python_runtime_version.py
@@ -1,0 +1,10 @@
+"""Python runtime version information.
+
+Used to populate the `runtime-version` header in gRPC requests.
+"""
+import sys
+
+PYTHON_RUNTIME_VERSION = (
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} "
+    f"({sys.version_info.releaselevel} {sys.version_info.serial})"
+)

--- a/src/momento/internal/aio/_add_header_client_interceptor.py
+++ b/src/momento/internal/aio/_add_header_client_interceptor.py
@@ -10,7 +10,7 @@ from momento.internal.services import Service
 
 
 class Header:
-    once_only_headers = ["agent"]
+    once_only_headers = ["agent", "runtime-version"]
 
     def __init__(self, name: str, value: str):
         self.name = name

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import timedelta
 from threading import Event
 from typing import Optional
@@ -31,11 +30,6 @@ from momento.internal.synchronous._add_header_client_interceptor import (
 )
 from momento.internal.synchronous._retry_interceptor import RetryInterceptor
 from momento.retry import RetryStrategy
-
-python_runtime_version = (
-    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} "
-    f"({sys.version_info.releaselevel} {sys.version_info.serial})"
-)
 
 
 class _ControlGrpcManager:

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import timedelta
 from threading import Event
 from typing import Optional
@@ -14,7 +15,7 @@ from momento.auth import CredentialProvider
 from momento.config import Configuration, TopicConfiguration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors.exceptions import ConnectionException
-from momento.internal._utilities import momento_version
+from momento.internal._utilities import PYTHON_RUNTIME_VERSION, ClientType, momento_version
 from momento.internal._utilities._channel_credentials import (
     channel_credentials_from_root_certs_or_default,
 )
@@ -31,6 +32,11 @@ from momento.internal.synchronous._add_header_client_interceptor import (
 from momento.internal.synchronous._retry_interceptor import RetryInterceptor
 from momento.retry import RetryStrategy
 
+python_runtime_version = (
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} "
+    f"({sys.version_info.releaselevel} {sys.version_info.serial})"
+)
+
 
 class _ControlGrpcManager:
     """Internal gRPC control mananger."""
@@ -46,7 +52,8 @@ class _ControlGrpcManager:
             ),
         )
         intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_interceptors(credential_provider.auth_token, configuration.get_retry_strategy())
+            self._secure_channel,
+            *_interceptors(credential_provider.auth_token, ClientType.CACHE, configuration.get_retry_strategy()),
         )
         self._stub = control_client.ScsControlStub(intercept_channel)  # type: ignore[no-untyped-call]
 
@@ -73,7 +80,8 @@ class _DataGrpcManager:
         )
 
         intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_interceptors(credential_provider.auth_token, configuration.get_retry_strategy())
+            self._secure_channel,
+            *_interceptors(credential_provider.auth_token, ClientType.CACHE, configuration.get_retry_strategy()),
         )
         self._stub = cache_client.ScsStub(intercept_channel)  # type: ignore[no-untyped-call]
 
@@ -164,7 +172,7 @@ class _PubsubGrpcManager:
             options=grpc_data_channel_options_from_grpc_config(grpc_config),
         )
         intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_interceptors(credential_provider.auth_token, None)
+            self._secure_channel, *_interceptors(credential_provider.auth_token, ClientType.TOPIC, None)
         )
         self._stub = pubsub_client.PubsubStub(intercept_channel)  # type: ignore[no-untyped-call]
 
@@ -190,7 +198,7 @@ class _PubsubGrpcStreamManager:
             options=grpc_data_channel_options_from_grpc_config(grpc_config),
         )
         intercept_channel = grpc.intercept_channel(
-            self._secure_channel, *_stream_interceptors(credential_provider.auth_token)
+            self._secure_channel, *_stream_interceptors(credential_provider.auth_token, ClientType.TOPIC)
         )
         self._stub = pubsub_client.PubsubStub(intercept_channel)  # type: ignore[no-untyped-call]
 
@@ -202,9 +210,13 @@ class _PubsubGrpcStreamManager:
 
 
 def _interceptors(
-    auth_token: str, retry_strategy: Optional[RetryStrategy] = None
+    auth_token: str, client_type: ClientType, retry_strategy: Optional[RetryStrategy] = None
 ) -> list[grpc.UnaryUnaryClientInterceptor]:
-    headers = [Header("authorization", auth_token), Header("agent", f"python:{_ControlGrpcManager.version}")]
+    headers = [
+        Header("authorization", auth_token),
+        Header("agent", f"python:{client_type.value}:{_ControlGrpcManager.version}"),
+        Header("runtime-version", f"python {PYTHON_RUNTIME_VERSION}"),
+    ]
     return list(
         filter(
             None, [AddHeaderClientInterceptor(headers), RetryInterceptor(retry_strategy) if retry_strategy else None]
@@ -212,9 +224,10 @@ def _interceptors(
     )
 
 
-def _stream_interceptors(auth_token: str) -> list[grpc.UnaryStreamClientInterceptor]:
+def _stream_interceptors(auth_token: str, client_type: ClientType) -> list[grpc.UnaryStreamClientInterceptor]:
     headers = [
         Header("authorization", auth_token),
-        Header("agent", f"python:{_PubsubGrpcStreamManager.version}"),
+        Header("agent", f"python:{client_type.value}:{_PubsubGrpcStreamManager.version}"),
+        Header("runtime-version", f"python {PYTHON_RUNTIME_VERSION}"),
     ]
     return [AddHeaderStreamingClientInterceptor(headers)]


### PR DESCRIPTION
# Agent details and runtime-version header
Adds the service client type to the `agent` header details, and adds a
new `runtime-version` header for the cache and topics clients.

The runtime version information looks like:

major.minor.patch (releasetype serial)

for example:

`python 3.11.2 (final 0)`

The releasetype covers alpha vs beta vs experimental vs final
versions. The serial covers particular alpha/beta release versioning.

# CI fix
We also fix the poetry installation in CI for python 3.7. Previously we installed poetry first, then installed python setting the cache as poetry. On older versions of ubuntu this does not work since it uses the wrong python version to install poetry. So we change the installation order to how it was before: first install python, then install poetry.