### PR TITLE
fix: when detecting momento version also catch `ModuleNotFoundError`

### DIFF
--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -11,7 +11,7 @@ try:
     import importlib_metadata
 
     momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     # For python >= 3.8
     from importlib.metadata import version  # type: ignore[import]
 


### PR DESCRIPTION
A user reports that in some environments the Momento version
detection code raises a `ModuleNotFoundError` as opposed to 
`ImportError`. We modify the try-except to also catch that error 
as the user reports this in a python 3.8 environment.
