### PR TITLE
feat: add auth client and generate_disposable_token api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ lint:
 
 .PHONY: do-gen-sync
 do-gen-sync:
+# cache client
 	@poetry run python src/momento/internal/codegen.py src/momento/internal/aio/_scs_control_client.py src/momento/internal/synchronous/_scs_control_client.py
 	@poetry run python src/momento/internal/codegen.py src/momento/internal/aio/_scs_data_client.py src/momento/internal/synchronous/_scs_data_client.py
 	@poetry run python src/momento/internal/codegen.py src/momento/cache_client_async.py src/momento/cache_client.py
@@ -37,6 +38,10 @@ do-gen-sync:
 	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_set_async.py tests/momento/cache_client/test_set.py
 	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_sorted_set_async.py tests/momento/cache_client/test_sorted_set.py
 	@poetry run python src/momento/internal/codegen.py tests/momento/cache_client/test_sorted_set_simple_async.py tests/momento/cache_client/test_sorted_set_simple.py
+# auth client
+	@poetry run python src/momento/internal/codegen.py src/momento/internal/aio/_scs_token_client.py src/momento/internal/synchronous/_scs_token_client.py
+	@poetry run python src/momento/internal/codegen.py src/momento/auth_client_async.py src/momento/auth_client.py
+	@poetry run python src/momento/internal/codegen.py tests/momento/auth_client/test_auth_client_async.py tests/momento/auth_client/test_auth_client.py
 
 .PHONY: gen-sync
 ## Generate synchronous code and tests from asynchronous code.

--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -10,6 +10,8 @@ import logging
 from momento import logs
 
 from .auth import CredentialProvider
+from .auth_client import AuthClient
+from .auth_client_async import AuthClientAsync
 from .cache_client import CacheClient
 from .cache_client_async import CacheClientAsync
 from .config import Configurations, TopicConfigurations
@@ -27,4 +29,6 @@ __all__ = [
     "CacheClientAsync",
     "TopicClient",
     "TopicClientAsync",
+    "AuthClient",
+    "AuthClientAsync",
 ]

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from momento.auth.access_control.permission_scope import (
+    CachePermission,
+    CacheRole,
+    CacheSelector,
+    Permissions,
+)
+
+
+class AllCacheItems:
+    pass
+
+@dataclass
+class CacheItemKey:
+    key: str
+
+@dataclass
+class CacheItemKeyPrefix:
+    key_prefix: str
+
+@dataclass
+class CacheItemSelector:
+    cache_item: Union[CacheItemKey, CacheItemKeyPrefix, AllCacheItems, str]
+
+    def __init__(self, cache_item: Union[CacheItemKey, CacheItemKeyPrefix, AllCacheItems, str]):
+        self.cache_item = cache_item
+
+    def is_all_cache_items(self) -> bool:
+        return isinstance(self.cache_item, AllCacheItems)
+
+class DisposableTokenCachePermission(CachePermission):
+    cache_item_selector: CacheItemSelector
+
+    def __init__(self, item: CacheItemSelector, cache: CacheSelector, role: CacheRole):
+        super().__init__(cache, role)
+        self.item = item
+
+@dataclass
+class DisposableTokenCachePermissions:
+    disposable_token_permissions: List[DisposableTokenCachePermission]
+
+    def __init__(self, permissions: List[DisposableTokenCachePermission]):
+        self.disposable_token_permissions = permissions
+
+@dataclass
+class DisposableTokenScope:
+    disposable_token_scope: Union[Permissions, DisposableTokenCachePermissions]
+
+    def __init__(self, permission_scope: Union[Permissions, DisposableTokenCachePermissions]):
+        self.disposable_token_scope = permission_scope
+
+@dataclass
+class DisposableTokenProps:
+    token_id: Optional[str]

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -12,13 +12,16 @@ from momento.auth.access_control.permission_scope import (
 class AllCacheItems:
     pass
 
+
 @dataclass
 class CacheItemKey:
     key: str
 
+
 @dataclass
 class CacheItemKeyPrefix:
     key_prefix: str
+
 
 @dataclass
 class CacheItemSelector:
@@ -30,12 +33,14 @@ class CacheItemSelector:
     def is_all_cache_items(self) -> bool:
         return isinstance(self.cache_item, AllCacheItems)
 
+
 class DisposableTokenCachePermission(CachePermission):
     cache_item_selector: CacheItemSelector
 
     def __init__(self, item: CacheItemSelector, cache: CacheSelector, role: CacheRole):
         super().__init__(cache, role)
         self.item = item
+
 
 @dataclass
 class DisposableTokenCachePermissions:
@@ -44,12 +49,14 @@ class DisposableTokenCachePermissions:
     def __init__(self, permissions: List[DisposableTokenCachePermission]):
         self.disposable_token_permissions = permissions
 
+
 @dataclass
 class DisposableTokenScope:
     disposable_token_scope: Union[Permissions, DisposableTokenCachePermissions]
 
     def __init__(self, permission_scope: Union[Permissions, DisposableTokenCachePermissions]):
         self.disposable_token_scope = permission_scope
+
 
 @dataclass
 class DisposableTokenProps:

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -1,3 +1,7 @@
+"""Disposable Token Scope.
+
+Defines the data classes for specifying the permission scope of a disposable token.
+"""
 from dataclasses import dataclass
 from typing import List, Optional, Union
 

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -3,12 +3,11 @@ from typing import List, Optional, Union
 
 from momento.auth.access_control.permission_scope import (
     CachePermission,
-    CacheRole,
-    CacheSelector,
     Permissions,
 )
 
 
+@dataclass
 class AllCacheItems:
     pass
 
@@ -27,35 +26,23 @@ class CacheItemKeyPrefix:
 class CacheItemSelector:
     cache_item: Union[CacheItemKey, CacheItemKeyPrefix, AllCacheItems, str]
 
-    def __init__(self, cache_item: Union[CacheItemKey, CacheItemKeyPrefix, AllCacheItems, str]):
-        self.cache_item = cache_item
-
     def is_all_cache_items(self) -> bool:
         return isinstance(self.cache_item, AllCacheItems)
 
 
+@dataclass
 class DisposableTokenCachePermission(CachePermission):
     cache_item_selector: CacheItemSelector
-
-    def __init__(self, item: CacheItemSelector, cache: CacheSelector, role: CacheRole):
-        super().__init__(cache, role)
-        self.cache_item_selector = item
 
 
 @dataclass
 class DisposableTokenCachePermissions:
     disposable_token_permissions: List[DisposableTokenCachePermission]
 
-    def __init__(self, permissions: List[DisposableTokenCachePermission]):
-        self.disposable_token_permissions = permissions
-
 
 @dataclass
 class DisposableTokenScope:
     disposable_token_scope: Union[Permissions, DisposableTokenCachePermissions]
-
-    def __init__(self, permission_scope: Union[Permissions, DisposableTokenCachePermissions]):
-        self.disposable_token_scope = permission_scope
 
     def get_permissions_objects(self) -> Permissions:
         if isinstance(self.disposable_token_scope, DisposableTokenCachePermissions):

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -57,6 +57,11 @@ class DisposableTokenScope:
     def __init__(self, permission_scope: Union[Permissions, DisposableTokenCachePermissions]):
         self.disposable_token_scope = permission_scope
 
+    def get_permissions_objects(self) -> Permissions:
+        if isinstance(self.disposable_token_scope, DisposableTokenCachePermissions):
+            raise ValueError("Cannot get Permissions from DisposableTokenCachePermissions")
+        return self.disposable_token_scope
+
 
 @dataclass
 class DisposableTokenProps:

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -13,21 +13,29 @@ from momento.auth.access_control.permission_scope import (
 
 @dataclass
 class AllCacheItems:
+    """Indicates permission to access all items in a cache."""
+
     pass
 
 
 @dataclass
 class CacheItemKey:
+    """The key of a cache item."""
+
     key: str
 
 
 @dataclass
 class CacheItemKeyPrefix:
+    """The prefix of a cache item key."""
+
     key_prefix: str
 
 
 @dataclass
 class CacheItemSelector:
+    """A selection of cache items to grant permissions to, either all cache items, a specific cache item, or a items that match a specified key prefix."""
+
     cache_item: Union[CacheItemKey, CacheItemKeyPrefix, AllCacheItems, str]
 
     def is_all_cache_items(self) -> bool:
@@ -36,19 +44,27 @@ class CacheItemSelector:
 
 @dataclass
 class DisposableTokenCachePermission(CachePermission):
+    """Encapsulates the information needed to grant permissions to a cache item."""
+
     cache_item_selector: CacheItemSelector
 
 
 @dataclass
 class DisposableTokenCachePermissions:
+    """A list of permissions to grant to a disposable token."""
+
     disposable_token_permissions: List[DisposableTokenCachePermission]
 
 
 @dataclass
 class DisposableTokenScope:
+    """A set of permissions to grant to a disposable token."""
+
     disposable_token_scope: Union[Permissions, DisposableTokenCachePermissions]
 
 
 @dataclass
 class DisposableTokenProps:
+    """Additional properties for a disposable token, such as token_id, which can be used to identify the source of a token."""
+
     token_id: Optional[str]

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -44,11 +44,6 @@ class DisposableTokenCachePermissions:
 class DisposableTokenScope:
     disposable_token_scope: Union[Permissions, DisposableTokenCachePermissions]
 
-    def get_permissions_objects(self) -> Permissions:
-        if isinstance(self.disposable_token_scope, DisposableTokenCachePermissions):
-            raise ValueError("Cannot get Permissions from DisposableTokenCachePermissions")
-        return self.disposable_token_scope
-
 
 @dataclass
 class DisposableTokenProps:

--- a/src/momento/auth/access_control/disposable_token_scope.py
+++ b/src/momento/auth/access_control/disposable_token_scope.py
@@ -39,7 +39,7 @@ class DisposableTokenCachePermission(CachePermission):
 
     def __init__(self, item: CacheItemSelector, cache: CacheSelector, role: CacheRole):
         super().__init__(cache, role)
-        self.item = item
+        self.cache_item_selector = item
 
 
 @dataclass

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -1,63 +1,63 @@
+from typing import Union
+
 from momento.auth.access_control.disposable_token_scope import (
     CacheItemKey,
     CacheItemKeyPrefix,
     CacheItemSelector,
     DisposableTokenCachePermission,
-    DisposableTokenCachePermissions,
-    DisposableTokenScope,
 )
-from momento.auth.access_control.permission_scope import CacheRole, CacheSelector
+from momento.auth.access_control.permission_scope import AllCaches, CacheName, CacheRole, CacheSelector
 
 
-def cache_key_read_write(cache_selector: CacheSelector, key: CacheItemKey) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key),
-        cache=cache_selector,
+def cache_key_read_write(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_key),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.READ_WRITE,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
 
-def cache_key_prefix_read_write(cache_selector: CacheSelector, key_prefix: CacheItemKeyPrefix) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key_prefix),
-        cache=cache_selector,
+def cache_key_prefix_read_write(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_prefix),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.READ_WRITE,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
 
-def cache_key_read_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key),
-        cache=cache_selector,
+def cache_key_read_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_key),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.READ_ONLY,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
 
-def cache_key_prefix_read_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key_prefix),
-        cache=cache_selector,
+def cache_key_prefix_read_only(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_prefix),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.READ_ONLY,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
 
-def cache_key_write_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key),
-        cache=cache_selector,
+def cache_key_write_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_key),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.WRITE_ONLY,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
 
-def cache_key_prefix_write_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
-    permissions = DisposableTokenCachePermission(
-        item=CacheItemSelector(key_prefix),
-        cache=cache_selector,
+def cache_key_prefix_write_only(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+    return DisposableTokenCachePermission(
+        item=CacheItemSelector(cache_item=_prefix),
+        cache=CacheSelector(cache=cache),
         role=CacheRole.WRITE_ONLY,
     )
-    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -30,15 +30,15 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_key),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.READ_WRITE,
+                    CacheSelector(cache),
+                    CacheRole.READ_WRITE,
+                    CacheItemSelector(_key),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_key_prefix_read_write(
@@ -46,15 +46,15 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_prefix),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.READ_WRITE,
+                    CacheSelector(cache),
+                    CacheRole.READ_WRITE,
+                    CacheItemSelector(_prefix),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_key_read_only(
@@ -62,15 +62,15 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_key),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.READ_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.READ_ONLY,
+                    CacheItemSelector(_key),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_key_prefix_read_only(
@@ -78,15 +78,15 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_prefix),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.READ_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.READ_ONLY,
+                    CacheItemSelector(_prefix),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_key_write_only(
@@ -94,15 +94,15 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_key),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.WRITE_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.WRITE_ONLY,
+                    CacheItemSelector(_key),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_key_prefix_write_only(
@@ -110,93 +110,93 @@ class DisposableTokenScopes:
     ) -> DisposableTokenScope:
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
-            permissions=[
+            [
                 DisposableTokenCachePermission(
-                    item=CacheItemSelector(cache_item=_prefix),
-                    cache=CacheSelector(cache=cache),
-                    role=CacheRole.WRITE_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.WRITE_ONLY,
+                    CacheItemSelector(_prefix),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 CachePermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=CacheRole.READ_WRITE,
+                    CacheSelector(cache),
+                    CacheRole.READ_WRITE,
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 CachePermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=CacheRole.READ_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.READ_ONLY,
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 CachePermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=CacheRole.WRITE_ONLY,
+                    CacheSelector(cache),
+                    CacheRole.WRITE_ONLY,
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def topic_publish_subscribe(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 TopicPermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=TopicRole.PUBLISH_SUBSCRIBE,
-                    topic_selector=TopicSelector(topic=topic),
+                    TopicRole.PUBLISH_SUBSCRIBE,
+                    CacheSelector(cache),
+                    TopicSelector(topic),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def topic_subscribe_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 TopicPermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=TopicRole.SUBSCRIBE_ONLY,
-                    topic_selector=TopicSelector(topic=topic),
+                    TopicRole.SUBSCRIBE_ONLY,
+                    CacheSelector(cache),
+                    TopicSelector(topic),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)
 
     @staticmethod
     def topic_publish_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
         scope = Permissions(
-            permissions=[
+            [
                 TopicPermission(
-                    cache_selector=CacheSelector(cache=cache),
-                    role=TopicRole.PUBLISH_ONLY,
-                    topic_selector=TopicSelector(topic=topic),
+                    TopicRole.PUBLISH_ONLY,
+                    CacheSelector(cache),
+                    TopicSelector(topic),
                 )
             ]
         )
-        return DisposableTokenScope(permission_scope=scope)
+        return DisposableTokenScope(scope)

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -5,71 +5,101 @@ from momento.auth.access_control.disposable_token_scope import (
     CacheItemKeyPrefix,
     CacheItemSelector,
     DisposableTokenCachePermission,
+    DisposableTokenCachePermissions,
+    DisposableTokenScope,
 )
 from momento.auth.access_control.permission_scope import AllCaches, CacheName, CacheRole, CacheSelector
 
 
 def cache_key_read_write(
     cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
-) -> DisposableTokenCachePermission:
+) -> DisposableTokenScope:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_key),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.READ_WRITE,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_key),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.READ_WRITE,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)
 
 
 def cache_key_prefix_read_write(
     cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenCachePermission:
+) -> DisposableTokenScope:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_prefix),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.READ_WRITE,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_prefix),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.READ_WRITE,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)
 
 
-def cache_key_read_only(
-    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
-) -> DisposableTokenCachePermission:
+def cache_key_read_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenScope:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_key),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.READ_ONLY,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_key),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.READ_ONLY,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)
 
 
 def cache_key_prefix_read_only(
     cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenCachePermission:
+) -> DisposableTokenScope:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_prefix),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.READ_ONLY,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_prefix),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.READ_ONLY,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)
 
 
 def cache_key_write_only(
     cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
-) -> DisposableTokenCachePermission:
+) -> DisposableTokenScope:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_key),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.WRITE_ONLY,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_key),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.WRITE_ONLY,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)
 
 
 def cache_key_prefix_write_only(
     cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenCachePermission:
+) -> DisposableTokenScope:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    return DisposableTokenCachePermission(
-        item=CacheItemSelector(cache_item=_prefix),
-        cache=CacheSelector(cache=cache),
-        role=CacheRole.WRITE_ONLY,
+    scope = DisposableTokenCachePermissions(
+        permissions=[
+            DisposableTokenCachePermission(
+                item=CacheItemSelector(cache_item=_prefix),
+                cache=CacheSelector(cache=cache),
+                role=CacheRole.WRITE_ONLY,
+            )
+        ]
     )
+    return DisposableTokenScope(permission_scope=scope)

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -8,98 +8,195 @@ from momento.auth.access_control.disposable_token_scope import (
     DisposableTokenCachePermissions,
     DisposableTokenScope,
 )
-from momento.auth.access_control.permission_scope import AllCaches, CacheName, CacheRole, CacheSelector
+from momento.auth.access_control.permission_scope import (
+    AllCaches,
+    AllTopics,
+    CacheName,
+    CachePermission,
+    CacheRole,
+    CacheSelector,
+    Permissions,
+    TopicName,
+    TopicPermission,
+    TopicRole,
+    TopicSelector,
+)
 
 
-def cache_key_read_write(
-    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
-) -> DisposableTokenScope:
-    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_key),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.READ_WRITE,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+class DisposableTokenScopes:
+    @staticmethod
+    def cache_key_read_write(
+        cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+    ) -> DisposableTokenScope:
+        _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_key),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.READ_WRITE,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
+    @staticmethod
+    def cache_key_prefix_read_write(
+        cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+    ) -> DisposableTokenScope:
+        _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_prefix),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.READ_WRITE,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
-def cache_key_prefix_read_write(
-    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenScope:
-    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_prefix),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.READ_WRITE,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+    @staticmethod
+    def cache_key_read_only(
+        cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+    ) -> DisposableTokenScope:
+        _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_key),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.READ_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
+    @staticmethod
+    def cache_key_prefix_read_only(
+        cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+    ) -> DisposableTokenScope:
+        _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_prefix),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.READ_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
-def cache_key_read_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenScope:
-    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_key),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.READ_ONLY,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+    @staticmethod
+    def cache_key_write_only(
+        cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+    ) -> DisposableTokenScope:
+        _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_key),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.WRITE_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
+    @staticmethod
+    def cache_key_prefix_write_only(
+        cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+    ) -> DisposableTokenScope:
+        _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
+        scope = DisposableTokenCachePermissions(
+            permissions=[
+                DisposableTokenCachePermission(
+                    item=CacheItemSelector(cache_item=_prefix),
+                    cache=CacheSelector(cache=cache),
+                    role=CacheRole.WRITE_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
-def cache_key_prefix_read_only(
-    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenScope:
-    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_prefix),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.READ_ONLY,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+    @staticmethod
+    def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.READ_WRITE,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
+    @staticmethod
+    def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.READ_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
-def cache_key_write_only(
-    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
-) -> DisposableTokenScope:
-    _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_key),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.WRITE_ONLY,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+    @staticmethod
+    def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.WRITE_ONLY,
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
+    @staticmethod
+    def topic_publish_subscribe(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.PUBLISH_SUBSCRIBE,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
 
-def cache_key_prefix_write_only(
-    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
-) -> DisposableTokenScope:
-    _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
-    scope = DisposableTokenCachePermissions(
-        permissions=[
-            DisposableTokenCachePermission(
-                item=CacheItemSelector(cache_item=_prefix),
-                cache=CacheSelector(cache=cache),
-                role=CacheRole.WRITE_ONLY,
-            )
-        ]
-    )
-    return DisposableTokenScope(permission_scope=scope)
+    @staticmethod
+    def topic_subscribe_only(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.SUBSCRIBE_ONLY,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)
+
+    @staticmethod
+    def topic_publish_only(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> DisposableTokenScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.PUBLISH_ONLY,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return DisposableTokenScope(permission_scope=scope)

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -1,0 +1,58 @@
+from momento.auth.access_control.disposable_token_scope import (
+    CacheItemKey,
+    CacheItemKeyPrefix,
+    CacheItemSelector,
+    DisposableTokenCachePermission,
+    DisposableTokenCachePermissions,
+    DisposableTokenScope,
+)
+from momento.auth.access_control.permission_scope import CacheRole, CacheSelector
+
+
+def cache_key_read_write(cache_selector: CacheSelector, key: CacheItemKey) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key),
+        cache=cache_selector,
+        role=CacheRole.READ_WRITE,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
+def cache_key_prefix_read_write(cache_selector: CacheSelector, key_prefix: CacheItemKeyPrefix) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key_prefix),
+        cache=cache_selector,
+        role=CacheRole.READ_WRITE,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
+def cache_key_read_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key),
+        cache=cache_selector,
+        role=CacheRole.READ_ONLY,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
+def cache_key_prefix_read_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key_prefix),
+        cache=cache_selector,
+        role=CacheRole.READ_ONLY,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
+def cache_key_write_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key),
+        cache=cache_selector,
+        role=CacheRole.WRITE_ONLY,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
+def cache_key_prefix_write_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
+    permissions = DisposableTokenCachePermission(
+        item=CacheItemSelector(key_prefix),
+        cache=cache_selector,
+        role=CacheRole.WRITE_ONLY,
+    )
+    return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -9,7 +9,9 @@ from momento.auth.access_control.disposable_token_scope import (
 from momento.auth.access_control.permission_scope import AllCaches, CacheName, CacheRole, CacheSelector
 
 
-def cache_key_read_write(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+def cache_key_read_write(
+    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+) -> DisposableTokenCachePermission:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_key),
@@ -18,7 +20,9 @@ def cache_key_read_write(cache: Union[AllCaches, CacheName, str], key: Union[Cac
     )
 
 
-def cache_key_prefix_read_write(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+def cache_key_prefix_read_write(
+    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+) -> DisposableTokenCachePermission:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_prefix),
@@ -27,7 +31,9 @@ def cache_key_prefix_read_write(cache: Union[AllCaches, CacheName, str], key_pre
     )
 
 
-def cache_key_read_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+def cache_key_read_only(
+    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+) -> DisposableTokenCachePermission:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_key),
@@ -36,7 +42,9 @@ def cache_key_read_only(cache: Union[AllCaches, CacheName, str], key: Union[Cach
     )
 
 
-def cache_key_prefix_read_only(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+def cache_key_prefix_read_only(
+    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+) -> DisposableTokenCachePermission:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_prefix),
@@ -45,7 +53,9 @@ def cache_key_prefix_read_only(cache: Union[AllCaches, CacheName, str], key_pref
     )
 
 
-def cache_key_write_only(cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]) -> DisposableTokenCachePermission:
+def cache_key_write_only(
+    cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
+) -> DisposableTokenCachePermission:
     _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_key),
@@ -54,7 +64,9 @@ def cache_key_write_only(cache: Union[AllCaches, CacheName, str], key: Union[Cac
     )
 
 
-def cache_key_prefix_write_only(cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]) -> DisposableTokenCachePermission:
+def cache_key_prefix_write_only(
+    cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
+) -> DisposableTokenCachePermission:
     _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
     return DisposableTokenCachePermission(
         item=CacheItemSelector(cache_item=_prefix),

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -28,10 +28,24 @@ from momento.auth.access_control.permission_scope import (
 
 
 class DisposableTokenScopes:
+    """Disposable Token Scopes.
+
+    Convenience methods for creating permission scopes for disposable tokens.
+    """
+
     @staticmethod
     def cache_key_read_write(
         cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
     ) -> DisposableTokenScope:
+        """Create permissions for read-write access to a specific key in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key (Union[CacheItemKey, str]): The key to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
             [
@@ -48,6 +62,15 @@ class DisposableTokenScopes:
     def cache_key_prefix_read_write(
         cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
     ) -> DisposableTokenScope:
+        """Create permissions for read-write access to keys that match a specific key prefix in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key_prefix (Union[CacheItemKey, str]): The key prefix to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
             [
@@ -64,6 +87,15 @@ class DisposableTokenScopes:
     def cache_key_read_only(
         cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
     ) -> DisposableTokenScope:
+        """Create permissions for read-only access to a specific key in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key (Union[CacheItemKey, str]): The key to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
             [
@@ -80,6 +112,15 @@ class DisposableTokenScopes:
     def cache_key_prefix_read_only(
         cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
     ) -> DisposableTokenScope:
+        """Create permissions for read-only access to keys that match a specific key prefix in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key_prefix (Union[CacheItemKey, str]): The key prefix to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
             [
@@ -96,6 +137,15 @@ class DisposableTokenScopes:
     def cache_key_write_only(
         cache: Union[AllCaches, CacheName, str], key: Union[CacheItemKey, str]
     ) -> DisposableTokenScope:
+        """Create permissions for write-only access to a specific key in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key (Union[CacheItemKey, str]): The key to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _key = key if isinstance(key, CacheItemKey) else CacheItemKey(key)
         scope = DisposableTokenCachePermissions(
             [
@@ -112,6 +162,15 @@ class DisposableTokenScopes:
     def cache_key_prefix_write_only(
         cache: Union[AllCaches, CacheName, str], key_prefix: Union[CacheItemKeyPrefix, str]
     ) -> DisposableTokenScope:
+        """Create permissions for write-only access to keys that match a specific key prefix in specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            key_prefix (Union[CacheItemKey, str]): The key prefix to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         _prefix = key_prefix if isinstance(key_prefix, CacheItemKeyPrefix) else CacheItemKeyPrefix(key_prefix)
         scope = DisposableTokenCachePermissions(
             [
@@ -126,6 +185,14 @@ class DisposableTokenScopes:
 
     @staticmethod
     def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        """Create permissions for read-write access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 CachePermission(
@@ -138,6 +205,14 @@ class DisposableTokenScopes:
 
     @staticmethod
     def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        """Create permissions for read-only access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 CachePermission(
@@ -150,6 +225,14 @@ class DisposableTokenScopes:
 
     @staticmethod
     def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> DisposableTokenScope:
+        """Create permissions for write-only access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 CachePermission(
@@ -164,6 +247,15 @@ class DisposableTokenScopes:
     def topic_publish_subscribe(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
+        """Create permissions for publish-subscribe access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 TopicPermission(
@@ -179,6 +271,15 @@ class DisposableTokenScopes:
     def topic_subscribe_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
+        """Create permissions for subscribe-only access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 TopicPermission(
@@ -194,6 +295,15 @@ class DisposableTokenScopes:
     def topic_publish_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> DisposableTokenScope:
+        """Create permissions for publish-only access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             [
                 TopicPermission(

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -1,3 +1,7 @@
+"""Disposable Token Scopes.
+
+Convenience methods for creating disposable token scopes.
+"""
 from typing import Union
 
 from momento.auth.access_control.disposable_token_scope import (

--- a/src/momento/auth/access_control/disposable_token_scopes.py
+++ b/src/momento/auth/access_control/disposable_token_scopes.py
@@ -17,6 +17,7 @@ def cache_key_read_write(cache_selector: CacheSelector, key: CacheItemKey) -> Di
     )
     return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
+
 def cache_key_prefix_read_write(cache_selector: CacheSelector, key_prefix: CacheItemKeyPrefix) -> DisposableTokenScope:
     permissions = DisposableTokenCachePermission(
         item=CacheItemSelector(key_prefix),
@@ -24,6 +25,7 @@ def cache_key_prefix_read_write(cache_selector: CacheSelector, key_prefix: Cache
         role=CacheRole.READ_WRITE,
     )
     return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
 
 def cache_key_read_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
     permissions = DisposableTokenCachePermission(
@@ -33,6 +35,7 @@ def cache_key_read_only(cache_selector: CacheSelector, key: str) -> DisposableTo
     )
     return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
+
 def cache_key_prefix_read_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
     permissions = DisposableTokenCachePermission(
         item=CacheItemSelector(key_prefix),
@@ -41,6 +44,7 @@ def cache_key_prefix_read_only(cache_selector: CacheSelector, key_prefix: str) -
     )
     return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
 
+
 def cache_key_write_only(cache_selector: CacheSelector, key: str) -> DisposableTokenScope:
     permissions = DisposableTokenCachePermission(
         item=CacheItemSelector(key),
@@ -48,6 +52,7 @@ def cache_key_write_only(cache_selector: CacheSelector, key: str) -> DisposableT
         role=CacheRole.WRITE_ONLY,
     )
     return DisposableTokenScope(permission_scope=DisposableTokenCachePermissions([permissions]))
+
 
 def cache_key_prefix_write_only(cache_selector: CacheSelector, key_prefix: str) -> DisposableTokenScope:
     permissions = DisposableTokenCachePermission(

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -1,8 +1,10 @@
+"""Permission Scope.
+
+Defines the data classes for specifying the permission scope of a generated token.
+"""
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Union
-
-# from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
 
 
 @dataclass

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -9,20 +9,28 @@ from typing import List, Union
 
 @dataclass
 class AllCaches:
+    """Indicates permission to access all caches."""
+
     pass
 
 
 @dataclass
 class AllTopics:
+    """Indicates permission to access all topics."""
+
     pass
 
 
 @dataclass
 class PredefinedScope:
+    """Indicates a predefined permission scope."""
+
     pass
 
 
 class CacheRole(Enum):
+    """The permission level for a cache."""
+
     READ_WRITE = "read_write"
     READ_ONLY = "read_only"
     WRITE_ONLY = "write_only"
@@ -30,24 +38,33 @@ class CacheRole(Enum):
 
 @dataclass
 class CacheName:
+    """The name of a cache."""
+
     name: str
 
 
 @dataclass
 class CacheSelector:
+    """A selection of caches to grant permissions to, either all caches or a specific cache."""
+
     cache: Union[CacheName, AllCaches, str]
 
     def is_all_caches(self) -> bool:
+        """Check if the cache selector is for all caches."""
         return isinstance(self.cache, AllCaches)
 
 
 @dataclass
 class CachePermission:
+    """Encapsulates the information needed to grant permissions to a cache."""
+
     cache_selector: CacheSelector
     role: CacheRole
 
 
 class TopicRole(Enum):
+    """The permission level for a topic."""
+
     PUBLISH_SUBSCRIBE = "publish_subscribe"
     SUBSCRIBE_ONLY = "subscribe_only"
     PUBLISH_ONLY = "publish_only"
@@ -55,11 +72,15 @@ class TopicRole(Enum):
 
 @dataclass
 class TopicName:
+    """The name of a topic."""
+
     name: str
 
 
 @dataclass
 class TopicSelector:
+    """A selection of topics to grant permissions to, either all topics or a specific topic."""
+
     topic: Union[TopicName, AllTopics, str]
 
     def is_all_topics(self) -> bool:
@@ -68,6 +89,8 @@ class TopicSelector:
 
 @dataclass
 class TopicPermission:
+    """Encapsulates the information needed to grant permissions to a topic."""
+
     role: TopicRole
     cache_selector: CacheSelector
     topic_selector: TopicSelector
@@ -78,6 +101,8 @@ Permission = Union[CachePermission, TopicPermission]
 
 @dataclass
 class Permissions:
+    """A list of permissions to grant to an API key."""
+
     permissions: List[Permission]
 
 
@@ -95,6 +120,8 @@ ALL_DATA_READ_WRITE = Permissions(
 
 @dataclass
 class PermissionScope:
+    """A set of permissions to grant to an API key, either a predefined scope or a custom scope."""
+
     permission_scope: Union[Permissions, PredefinedScope]
 
     def is_all_data_read_write(self) -> bool:

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Union
 
+# from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
+
 
 class AllCaches:
     pass
@@ -102,8 +104,7 @@ class PermissionScope:
     def __init__(self, permission_scope: Union[Permissions, PredefinedScope]):
         self.permission_scope = permission_scope
 
-    def get_list_of_permissions(self) -> List[Permission]:
-        if isinstance(self.permission_scope, Permissions):
-            return self.permission_scope.permissions
-        else:
-            raise ValueError("PermissionScope does not contain list of Permission objects")
+    def get_permissions_objects(self) -> Permissions:
+        if isinstance(self.permission_scope, PredefinedScope):
+            raise ValueError("PredefinedScope cannot be converted to a Permissions object")
+        return self.permission_scope

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -97,8 +97,3 @@ class PermissionScope:
 
     def is_all_data_read_write(self) -> bool:
         return self.permission_scope == ALL_DATA_READ_WRITE
-
-    def get_permissions_objects(self) -> Permissions:
-        if isinstance(self.permission_scope, PredefinedScope):
-            raise ValueError("PredefinedScope cannot be converted to a Permissions object")
-        return self.permission_scope

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -59,10 +59,10 @@ class TopicSelector:
     topic: Union[TopicName, AllTopics, str]
 
     def __init__(self, topic: Union[TopicName, AllTopics, str]):
-        self.topic_selector = topic
+        self.topic = topic
 
     def is_all_topics(self) -> bool:
-        return isinstance(self.topic_selector, AllTopics)
+        return isinstance(self.topic, AllTopics)
 
 
 @dataclass
@@ -98,3 +98,12 @@ class PermissionScope:
 
     def is_all_data_read_write(self) -> bool:
         return self.permission_scope == ALL_DATA_READ_WRITE
+
+    def __init__(self, permission_scope: Union[Permissions, PredefinedScope]):
+        self.permission_scope = permission_scope
+
+    def get_list_of_permissions(self) -> List[Permission]:
+        if isinstance(self.permission_scope, Permissions):
+            return self.permission_scope.permissions
+        else:
+            raise ValueError("PermissionScope does not contain list of Permission objects")

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Union
+
+
+class AllCaches:
+    pass
+
+class AllTopics:
+    pass
+
+class PredefinedScope:
+    pass
+
+class CacheRole(Enum):
+    READ_WRITE = "read_write"
+    READ_ONLY = "read_only"
+    WRITE_ONLY = "write_only"
+
+@dataclass
+class CacheName:
+    name: str
+
+@dataclass
+class CacheSelector:
+    cache: Union[CacheName, AllCaches, str]
+
+    def __init__(self, cache: Union[CacheName, AllCaches, str]):
+        self.cache = cache
+
+    def is_all_caches(self) -> bool:
+        return isinstance(self.cache, AllCaches)
+
+@dataclass
+class CachePermission:
+    cache_selector: CacheSelector
+    role: CacheRole
+
+class TopicRole(Enum):
+    PUBLISH_SUBSCRIBE = "publish_subscribe"
+    SUBSCRIBE_ONLY = "subscribe_only"
+    PUBLISH_ONLY = "publish_only"
+
+@dataclass
+class TopicName:
+    name: str
+
+@dataclass
+class TopicSelector:
+    topic: Union[TopicName, AllTopics, str]
+
+    def __init__(self, topic: Union[TopicName, AllTopics, str]):
+        self.topic_selector = topic
+
+    def is_all_topics(self) -> bool:
+        return isinstance(self.topic_selector, AllTopics)
+
+@dataclass
+class TopicPermission:
+    role: TopicRole
+    cache_selector: CacheSelector
+    topic_selector: TopicSelector
+
+Permission = Union[CachePermission, TopicPermission]
+
+@dataclass
+class Permissions:
+    permissions: List[Permission]
+
+ALL_DATA_READ_WRITE = Permissions(
+    permissions=[
+        CachePermission(
+            role=CacheRole.READ_WRITE,
+            cache_selector=CacheSelector(cache=AllCaches())
+        ),
+        TopicPermission(
+            role=TopicRole.PUBLISH_SUBSCRIBE,
+            cache_selector=CacheSelector(cache=AllCaches()),
+            topic_selector=TopicSelector(topic=AllTopics())
+        ),
+    ]
+)
+
+@dataclass
+class PermissionScope:
+    permission_scope: Union[Permissions, PredefinedScope]
+
+    def is_all_data_read_write(self) -> bool:
+        return self.permission_scope == ALL_DATA_READ_WRITE

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -4,15 +4,15 @@ from typing import List, Union
 
 # from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
 
-
+@dataclass
 class AllCaches:
     pass
 
-
+@dataclass
 class AllTopics:
     pass
 
-
+@dataclass
 class PredefinedScope:
     pass
 

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -6,20 +6,25 @@ from typing import List, Union
 class AllCaches:
     pass
 
+
 class AllTopics:
     pass
 
+
 class PredefinedScope:
     pass
+
 
 class CacheRole(Enum):
     READ_WRITE = "read_write"
     READ_ONLY = "read_only"
     WRITE_ONLY = "write_only"
 
+
 @dataclass
 class CacheName:
     name: str
+
 
 @dataclass
 class CacheSelector:
@@ -31,19 +36,23 @@ class CacheSelector:
     def is_all_caches(self) -> bool:
         return isinstance(self.cache, AllCaches)
 
+
 @dataclass
 class CachePermission:
     cache_selector: CacheSelector
     role: CacheRole
+
 
 class TopicRole(Enum):
     PUBLISH_SUBSCRIBE = "publish_subscribe"
     SUBSCRIBE_ONLY = "subscribe_only"
     PUBLISH_ONLY = "publish_only"
 
+
 @dataclass
 class TopicName:
     name: str
+
 
 @dataclass
 class TopicSelector:
@@ -55,31 +64,33 @@ class TopicSelector:
     def is_all_topics(self) -> bool:
         return isinstance(self.topic_selector, AllTopics)
 
+
 @dataclass
 class TopicPermission:
     role: TopicRole
     cache_selector: CacheSelector
     topic_selector: TopicSelector
 
+
 Permission = Union[CachePermission, TopicPermission]
+
 
 @dataclass
 class Permissions:
     permissions: List[Permission]
 
+
 ALL_DATA_READ_WRITE = Permissions(
     permissions=[
-        CachePermission(
-            role=CacheRole.READ_WRITE,
-            cache_selector=CacheSelector(cache=AllCaches())
-        ),
+        CachePermission(role=CacheRole.READ_WRITE, cache_selector=CacheSelector(cache=AllCaches())),
         TopicPermission(
             role=TopicRole.PUBLISH_SUBSCRIBE,
             cache_selector=CacheSelector(cache=AllCaches()),
-            topic_selector=TopicSelector(topic=AllTopics())
+            topic_selector=TopicSelector(topic=AllTopics()),
         ),
     ]
 )
+
 
 @dataclass
 class PermissionScope:

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -35,9 +35,6 @@ class CacheName:
 class CacheSelector:
     cache: Union[CacheName, AllCaches, str]
 
-    def __init__(self, cache: Union[CacheName, AllCaches, str]):
-        self.cache = cache
-
     def is_all_caches(self) -> bool:
         return isinstance(self.cache, AllCaches)
 
@@ -63,9 +60,6 @@ class TopicName:
 class TopicSelector:
     topic: Union[TopicName, AllTopics, str]
 
-    def __init__(self, topic: Union[TopicName, AllTopics, str]):
-        self.topic = topic
-
     def is_all_topics(self) -> bool:
         return isinstance(self.topic, AllTopics)
 
@@ -87,11 +81,11 @@ class Permissions:
 
 ALL_DATA_READ_WRITE = Permissions(
     permissions=[
-        CachePermission(role=CacheRole.READ_WRITE, cache_selector=CacheSelector(cache=AllCaches())),
+        CachePermission(CacheSelector(AllCaches()), CacheRole.READ_WRITE),
         TopicPermission(
-            role=TopicRole.PUBLISH_SUBSCRIBE,
-            cache_selector=CacheSelector(cache=AllCaches()),
-            topic_selector=TopicSelector(topic=AllTopics()),
+            TopicRole.PUBLISH_SUBSCRIBE,
+            CacheSelector(AllCaches()),
+            TopicSelector(AllTopics()),
         ),
     ]
 )
@@ -103,9 +97,6 @@ class PermissionScope:
 
     def is_all_data_read_write(self) -> bool:
         return self.permission_scope == ALL_DATA_READ_WRITE
-
-    def __init__(self, permission_scope: Union[Permissions, PredefinedScope]):
-        self.permission_scope = permission_scope
 
     def get_permissions_objects(self) -> Permissions:
         if isinstance(self.permission_scope, PredefinedScope):

--- a/src/momento/auth/access_control/permission_scope.py
+++ b/src/momento/auth/access_control/permission_scope.py
@@ -4,13 +4,16 @@ from typing import List, Union
 
 # from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
 
+
 @dataclass
 class AllCaches:
     pass
 
+
 @dataclass
 class AllTopics:
     pass
+
 
 @dataclass
 class PredefinedScope:

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -7,7 +7,8 @@ from momento.auth.access_control.permission_scope import (
     CachePermission,
     CacheRole,
     CacheSelector,
-    Permission,
+    Permissions,
+    PermissionScope,
     TopicName,
     TopicPermission,
     TopicRole,
@@ -15,50 +16,82 @@ from momento.auth.access_control.permission_scope import (
 )
 
 
-def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> Permission:
-    return CachePermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=CacheRole.READ_WRITE,
+def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            CachePermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=CacheRole.READ_WRITE,
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)
 
 
-def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> Permission:
-    return CachePermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=CacheRole.READ_ONLY,
+def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            CachePermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=CacheRole.READ_ONLY,
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)
 
 
-def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> Permission:
-    return CachePermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=CacheRole.WRITE_ONLY,
+def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            CachePermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=CacheRole.WRITE_ONLY,
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)
 
 
 def topic_publish_subscribe(
     cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
-) -> Permission:
-    return TopicPermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=TopicRole.PUBLISH_SUBSCRIBE,
-        topic_selector=TopicSelector(topic=topic),
+) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            TopicPermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=TopicRole.PUBLISH_SUBSCRIBE,
+                topic_selector=TopicSelector(topic=topic),
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)
 
 
 def topic_subscribe_only(
     cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
-) -> Permission:
-    return TopicPermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=TopicRole.SUBSCRIBE_ONLY,
-        topic_selector=TopicSelector(topic=topic),
+) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            TopicPermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=TopicRole.SUBSCRIBE_ONLY,
+                topic_selector=TopicSelector(topic=topic),
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)
 
 
-def topic_publish_only(cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]) -> Permission:
-    return TopicPermission(
-        cache_selector=CacheSelector(cache=cache),
-        role=TopicRole.PUBLISH_ONLY,
-        topic_selector=TopicSelector(topic=topic),
+def topic_publish_only(
+    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+) -> PermissionScope:
+    scope = Permissions(
+        permissions=[
+            TopicPermission(
+                cache_selector=CacheSelector(cache=cache),
+                role=TopicRole.PUBLISH_ONLY,
+                topic_selector=TopicSelector(topic=topic),
+            )
+        ]
     )
+    return PermissionScope(permission_scope=scope)

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -37,8 +37,7 @@ def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> Permission:
 
 
 def topic_publish_subscribe(
-    cache: Union[AllCaches, CacheName, str],
-    topic: Union[TopicName, AllTopics, str]
+    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
 ) -> Permission:
     return TopicPermission(
         cache_selector=CacheSelector(cache=cache),
@@ -48,8 +47,7 @@ def topic_publish_subscribe(
 
 
 def topic_subscribe_only(
-    cache: Union[AllCaches, CacheName, str],
-    topic: Union[TopicName, AllTopics, str]
+    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
 ) -> Permission:
     return TopicPermission(
         cache_selector=CacheSelector(cache=cache),
@@ -58,10 +56,7 @@ def topic_subscribe_only(
     )
 
 
-def topic_publish_only(
-    cache: Union[AllCaches, CacheName, str],
-    topic: Union[TopicName, AllTopics, str]
-) -> Permission:
+def topic_publish_only(cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]) -> Permission:
     return TopicPermission(
         cache_selector=CacheSelector(cache=cache),
         role=TopicRole.PUBLISH_ONLY,

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -1,0 +1,56 @@
+from momento.auth.access_control.permission_scope import (
+    CachePermission,
+    CacheRole,
+    CacheSelector,
+    Permissions,
+    PermissionScope,
+    TopicPermission,
+    TopicRole,
+    TopicSelector,
+)
+
+
+def cache_read_write(cache_selector: CacheSelector) -> PermissionScope:
+    permissions = CachePermission(
+        cache_selector=cache_selector,
+        role=CacheRole.READ_WRITE,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))
+
+def cache_read_only(cache_selector: CacheSelector) -> PermissionScope:
+    permissions = CachePermission(
+        cache_selector=cache_selector,
+        role=CacheRole.READ_ONLY,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))
+
+def cache_write_only(cache_selector: CacheSelector) -> PermissionScope:
+    permissions = CachePermission(
+        cache_selector=cache_selector,
+        role=CacheRole.WRITE_ONLY,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))
+
+def topic_publish_subscribe(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
+    permissions = TopicPermission(
+        cache_selector=cache_selector,
+        role=TopicRole.PUBLISH_SUBSCRIBE,
+        topic_selector=topic_selector,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))
+
+def topic_subscribe_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
+    permissions = TopicPermission(
+        cache_selector=cache_selector,
+        role=TopicRole.SUBSCRIBE_ONLY,
+        topic_selector=topic_selector,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))
+
+def topic_publish_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
+    permissions = TopicPermission(
+        cache_selector=cache_selector,
+        role=TopicRole.PUBLISH_ONLY,
+        topic_selector=topic_selector,
+    )
+    return PermissionScope(permission_scope=Permissions([permissions]))

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -1,61 +1,69 @@
+from typing import Union
+
 from momento.auth.access_control.permission_scope import (
+    AllCaches,
+    AllTopics,
+    CacheName,
     CachePermission,
     CacheRole,
     CacheSelector,
-    Permissions,
-    PermissionScope,
+    Permission,
+    TopicName,
     TopicPermission,
     TopicRole,
     TopicSelector,
 )
 
 
-def cache_read_write(cache_selector: CacheSelector) -> PermissionScope:
-    permissions = CachePermission(
-        cache_selector=cache_selector,
+def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> Permission:
+    return CachePermission(
+        cache_selector=CacheSelector(cache=cache),
         role=CacheRole.READ_WRITE,
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))
 
 
-def cache_read_only(cache_selector: CacheSelector) -> PermissionScope:
-    permissions = CachePermission(
-        cache_selector=cache_selector,
+def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> Permission:
+    return CachePermission(
+        cache_selector=CacheSelector(cache=cache),
         role=CacheRole.READ_ONLY,
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))
 
 
-def cache_write_only(cache_selector: CacheSelector) -> PermissionScope:
-    permissions = CachePermission(
-        cache_selector=cache_selector,
+def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> Permission:
+    return CachePermission(
+        cache_selector=CacheSelector(cache=cache),
         role=CacheRole.WRITE_ONLY,
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))
 
 
-def topic_publish_subscribe(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
-    permissions = TopicPermission(
-        cache_selector=cache_selector,
+def topic_publish_subscribe(
+    cache: Union[AllCaches, CacheName, str],
+    topic: Union[TopicName, AllTopics, str]
+) -> Permission:
+    return TopicPermission(
+        cache_selector=CacheSelector(cache=cache),
         role=TopicRole.PUBLISH_SUBSCRIBE,
-        topic_selector=topic_selector,
+        topic_selector=TopicSelector(topic=topic),
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))
 
 
-def topic_subscribe_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
-    permissions = TopicPermission(
-        cache_selector=cache_selector,
+def topic_subscribe_only(
+    cache: Union[AllCaches, CacheName, str],
+    topic: Union[TopicName, AllTopics, str]
+) -> Permission:
+    return TopicPermission(
+        cache_selector=CacheSelector(cache=cache),
         role=TopicRole.SUBSCRIBE_ONLY,
-        topic_selector=topic_selector,
+        topic_selector=TopicSelector(topic=topic),
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))
 
 
-def topic_publish_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
-    permissions = TopicPermission(
-        cache_selector=cache_selector,
+def topic_publish_only(
+    cache: Union[AllCaches, CacheName, str],
+    topic: Union[TopicName, AllTopics, str]
+) -> Permission:
+    return TopicPermission(
+        cache_selector=CacheSelector(cache=cache),
         role=TopicRole.PUBLISH_ONLY,
-        topic_selector=topic_selector,
+        topic_selector=TopicSelector(topic=topic),
     )
-    return PermissionScope(permission_scope=Permissions([permissions]))

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -17,6 +17,7 @@ def cache_read_write(cache_selector: CacheSelector) -> PermissionScope:
     )
     return PermissionScope(permission_scope=Permissions([permissions]))
 
+
 def cache_read_only(cache_selector: CacheSelector) -> PermissionScope:
     permissions = CachePermission(
         cache_selector=cache_selector,
@@ -24,12 +25,14 @@ def cache_read_only(cache_selector: CacheSelector) -> PermissionScope:
     )
     return PermissionScope(permission_scope=Permissions([permissions]))
 
+
 def cache_write_only(cache_selector: CacheSelector) -> PermissionScope:
     permissions = CachePermission(
         cache_selector=cache_selector,
         role=CacheRole.WRITE_ONLY,
     )
     return PermissionScope(permission_scope=Permissions([permissions]))
+
 
 def topic_publish_subscribe(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
     permissions = TopicPermission(
@@ -39,6 +42,7 @@ def topic_publish_subscribe(cache_selector: CacheSelector, topic_selector: Topic
     )
     return PermissionScope(permission_scope=Permissions([permissions]))
 
+
 def topic_subscribe_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
     permissions = TopicPermission(
         cache_selector=cache_selector,
@@ -46,6 +50,7 @@ def topic_subscribe_only(cache_selector: CacheSelector, topic_selector: TopicSel
         topic_selector=topic_selector,
     )
     return PermissionScope(permission_scope=Permissions([permissions]))
+
 
 def topic_publish_only(cache_selector: CacheSelector, topic_selector: TopicSelector) -> PermissionScope:
     permissions = TopicPermission(

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -16,82 +16,84 @@ from momento.auth.access_control.permission_scope import (
 )
 
 
-def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            CachePermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=CacheRole.READ_WRITE,
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
+class PermissionScopes:
+    @staticmethod
+    def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.READ_WRITE,
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)
 
+    @staticmethod
+    def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.READ_ONLY,
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)
 
-def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            CachePermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=CacheRole.READ_ONLY,
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
+    @staticmethod
+    def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                CachePermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=CacheRole.WRITE_ONLY,
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)
 
+    @staticmethod
+    def topic_publish_subscribe(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.PUBLISH_SUBSCRIBE,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)
 
-def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            CachePermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=CacheRole.WRITE_ONLY,
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
+    @staticmethod
+    def topic_subscribe_only(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.SUBSCRIBE_ONLY,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)
 
-
-def topic_publish_subscribe(
-    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
-) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            TopicPermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=TopicRole.PUBLISH_SUBSCRIBE,
-                topic_selector=TopicSelector(topic=topic),
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
-
-
-def topic_subscribe_only(
-    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
-) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            TopicPermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=TopicRole.SUBSCRIBE_ONLY,
-                topic_selector=TopicSelector(topic=topic),
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
-
-
-def topic_publish_only(
-    cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
-) -> PermissionScope:
-    scope = Permissions(
-        permissions=[
-            TopicPermission(
-                cache_selector=CacheSelector(cache=cache),
-                role=TopicRole.PUBLISH_ONLY,
-                topic_selector=TopicSelector(topic=topic),
-            )
-        ]
-    )
-    return PermissionScope(permission_scope=scope)
+    @staticmethod
+    def topic_publish_only(
+        cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
+    ) -> PermissionScope:
+        scope = Permissions(
+            permissions=[
+                TopicPermission(
+                    cache_selector=CacheSelector(cache=cache),
+                    role=TopicRole.PUBLISH_ONLY,
+                    topic_selector=TopicSelector(topic=topic),
+                )
+            ]
+        )
+        return PermissionScope(permission_scope=scope)

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -23,6 +23,14 @@ from momento.auth.access_control.permission_scope import (
 class PermissionScopes:
     @staticmethod
     def cache_read_write(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        """Create permissions for read-write access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 CachePermission(
@@ -35,6 +43,14 @@ class PermissionScopes:
 
     @staticmethod
     def cache_read_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        """Create permissions for read-only access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 CachePermission(
@@ -47,6 +63,14 @@ class PermissionScopes:
 
     @staticmethod
     def cache_write_only(cache: Union[AllCaches, CacheName, str]) -> PermissionScope:
+        """Create permissions for write-only access to specified cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 CachePermission(
@@ -61,6 +85,15 @@ class PermissionScopes:
     def topic_publish_subscribe(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> PermissionScope:
+        """Create permissions for publish-subscribe access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 TopicPermission(
@@ -76,6 +109,15 @@ class PermissionScopes:
     def topic_subscribe_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> PermissionScope:
+        """Create permissions for subscribe-only access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 TopicPermission(
@@ -91,6 +133,15 @@ class PermissionScopes:
     def topic_publish_only(
         cache: Union[AllCaches, CacheName, str], topic: Union[TopicName, AllTopics, str]
     ) -> PermissionScope:
+        """Create permissions for publish-only access to specified topic(s) and cache(s).
+
+        Args:
+            cache (Union[AllCaches, CacheName, str]): The cache(s) to grant permission to.
+            topic (Union[TopicName, AllTopics, str]): The topic(s) to grant permission to.
+
+        Returns:
+            DisposableTokenScope: A set of permissions to grant to a disposable token.
+        """
         scope = Permissions(
             permissions=[
                 TopicPermission(

--- a/src/momento/auth/access_control/permission_scopes.py
+++ b/src/momento/auth/access_control/permission_scopes.py
@@ -1,3 +1,7 @@
+"""Permission Scopes.
+
+Convenience methods for creating permission scopes.
+"""
 from typing import Union
 
 from momento.auth.access_control.permission_scope import (

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -82,3 +82,6 @@ class CredentialProvider:
 
     def _obscure(self, value: str) -> str:
         return f"{value[:10]}...{value[-10:]}"
+
+    def get_auth_token(self) -> str:
+        return self.auth_token

--- a/src/momento/auth/credential_provider.py
+++ b/src/momento/auth/credential_provider.py
@@ -15,12 +15,14 @@ class CredentialProvider:
     auth_token: str
     control_endpoint: str
     cache_endpoint: str
+    token_endpoint: str
 
     @staticmethod
     def from_environment_variable(
         env_var_name: str,
         control_endpoint: Optional[str] = None,
         cache_endpoint: Optional[str] = None,
+        token_endpoint: Optional[str] = None,
     ) -> CredentialProvider:
         """Reads and parses a Momento auth token stored as an environment variable.
 
@@ -29,6 +31,8 @@ class CredentialProvider:
             control_endpoint (Optional[str], optional): Optionally overrides the default control endpoint.
             Defaults to None.
             cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.
+            Defaults to None.
+            token_endpoint (Optional[str], optional): Optionally overrides the default token endpoint.
             Defaults to None.
 
         Raises:
@@ -40,13 +44,14 @@ class CredentialProvider:
         api_key = os.getenv(env_var_name)
         if not api_key:
             raise RuntimeError(f"Missing required environment variable {env_var_name}")
-        return CredentialProvider.from_string(api_key, control_endpoint, cache_endpoint)
+        return CredentialProvider.from_string(api_key, control_endpoint, cache_endpoint, token_endpoint)
 
     @staticmethod
     def from_string(
         auth_token: str,
         control_endpoint: Optional[str] = None,
         cache_endpoint: Optional[str] = None,
+        token_endpoint: Optional[str] = None,
     ) -> CredentialProvider:
         """Reads and parses a Momento auth token.
 
@@ -56,6 +61,8 @@ class CredentialProvider:
             Defaults to None.
             cache_endpoint (Optional[str], optional): Optionally overrides the default cache endpoint.
             Defaults to None.
+            token_endpoint (Optional[str], optional): Optionally overrides the default token endpoint.
+            Defaults to None.
 
         Returns:
             CredentialProvider
@@ -63,8 +70,9 @@ class CredentialProvider:
         token_and_endpoints = momento_endpoint_resolver.resolve(auth_token)
         control_endpoint = control_endpoint or token_and_endpoints.control_endpoint
         cache_endpoint = cache_endpoint or token_and_endpoints.cache_endpoint
+        token_endpoint = token_endpoint or token_and_endpoints.token_endpoint
         auth_token = token_and_endpoints.auth_token
-        return CredentialProvider(auth_token, control_endpoint, cache_endpoint)
+        return CredentialProvider(auth_token, control_endpoint, cache_endpoint, token_endpoint)
 
     def __repr__(self) -> str:
         attributes: Dict[str, str] = copy.copy(vars(self))  # type: ignore[misc]

--- a/src/momento/auth/momento_endpoint_resolver.py
+++ b/src/momento/auth/momento_endpoint_resolver.py
@@ -11,6 +11,7 @@ from momento.internal.services import Service
 
 _MOMENTO_CONTROL_ENDPOINT_PREFIX = "control."
 _MOMENTO_CACHE_ENDPOINT_PREFIX = "cache."
+_MOMENTO_TOKEN_ENDPOINT_PREFIX = "token."
 _CONTROL_ENDPOINT_CLAIM_ID = "cp"
 _CACHE_ENDPOINT_CLAIM_ID = "c"
 
@@ -19,6 +20,7 @@ _CACHE_ENDPOINT_CLAIM_ID = "c"
 class _TokenAndEndpoints:
     control_endpoint: str
     cache_endpoint: str
+    token_endpoint: str
     auth_token: str
 
 
@@ -38,6 +40,7 @@ def resolve(auth_token: str) -> _TokenAndEndpoints:
         return _TokenAndEndpoints(
             control_endpoint=_MOMENTO_CONTROL_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
             cache_endpoint=_MOMENTO_CACHE_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
+            token_endpoint=_MOMENTO_TOKEN_ENDPOINT_PREFIX + info["endpoint"],  # type: ignore[misc]
             auth_token=info["api_key"],  # type: ignore[misc]
         )
     else:
@@ -50,6 +53,7 @@ def _get_endpoint_from_token(auth_token: str) -> _TokenAndEndpoints:
         return _TokenAndEndpoints(
             control_endpoint=claims[_CONTROL_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
             cache_endpoint=claims[_CACHE_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
+            token_endpoint=_MOMENTO_TOKEN_ENDPOINT_PREFIX + claims[_CACHE_ENDPOINT_CLAIM_ID],  # type: ignore[misc]
             auth_token=auth_token,
         )
     except (DecodeError, KeyError) as e:

--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -70,10 +70,7 @@ class AuthClient:
         self._token_client.close()
 
     def generate_disposable_token(
-            self,
-            scope: DisposableTokenScope,
-            expiresIn: ExpiresIn,
-            disposable_token_props: Optional[DisposableTokenProps]
+        self, scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 

--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -56,7 +56,7 @@ class AuthClient:
         """
         self._logger = logs.logger
         self._token_client = _ScsTokenClient(configuration, credential_provider)
-        self._token_endpoint = credential_provider.token_endpoint
+        self._credential_provider = credential_provider
 
     def __enter__(self) -> AuthClient:
         return self
@@ -70,14 +70,16 @@ class AuthClient:
         self._token_client.close()
 
     def generate_disposable_token(
-        self, scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
+        self, scope: DisposableTokenScope, expires_in: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 
         Returns:
             GenerateDisposableTokenResponse
         """
-        return self._token_client.generate_disposable_token(scope, expiresIn, disposable_token_props)
+        return self._token_client.generate_disposable_token(
+            scope, expires_in, self._credential_provider, disposable_token_props
+        )
 
     def close(self) -> None:
         self.close()

--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -77,6 +77,11 @@ class AuthClient:
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 
+        Args:
+            scope (DisposableTokenScope): The permissions to grant to the new disposable token. Convenient factory methods are provided under the DisposableTokenScopes class.
+            expires_in (ExpiresIn): The time until the token expires.
+            disposable_token_props (Optional[DisposableTokenProps], optional): Additional properties for the disposable token, such as token_id. Defaults to None.
+
         Returns:
             GenerateDisposableTokenResponse
         """

--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Optional, Type
+
+from momento import logs
+from momento.auth.access_control.disposable_token_scope import DisposableTokenProps, DisposableTokenScope
+from momento.auth.credential_provider import CredentialProvider
+from momento.config.auth_configuration import AuthConfiguration
+from momento.internal.synchronous._scs_token_client import _ScsTokenClient
+from momento.responses.auth.generate_disposable_token import GenerateDisposableTokenResponse
+from momento.utilities.expiration import ExpiresIn
+
+
+class AuthClient:
+    """Auth Client.
+
+    Auth methods return a response object unique to each request.
+    The response object is resolved to a type-safe object of one of several
+    sub-types. See the documentation for each response type for details.
+
+    Pattern matching can be used to operate on the appropriate subtype.
+    For example, in python 3.10+ if you're generating a disposable auth token:
+
+        response = await client.generateDisposableToken(...)
+        match response:
+            case GenerateDisposableToken.Success():
+                ...the disposable auth token was generated...
+            case GenerateDisposableToken.Error():
+                ...there was an error trying to generate the auth token...
+
+    or equivalently in earlier versions of python::
+
+        response = await client.generateDisposableToken(...)
+        if isinstance(response, GenerateDisposableToken.Success):
+            ...
+        elif isinstance(response, GenerateDisposableToken.Error):
+            ...
+        else:
+            raise Exception("This should never happen")
+    """
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        """Instantiate a client.
+
+        Args:
+            configuration (AuthConfiguration): An object holding configuration settings for communication with the server.
+            credential_provider (CredentialProvider): An object holding the auth token and endpoint information.
+
+        Example::
+            from momento import AuthConfigurations, CredentialProvider, AuthClientAsync
+
+            configuration = AuthConfigurations.Laptop.latest()
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
+            client = AuthClientAsync(configuration, credential_provider)
+        """
+        self._logger = logs.logger
+        self._token_client = _ScsTokenClient(configuration, credential_provider)
+        self._token_endpoint = credential_provider.token_endpoint
+
+    def __enter__(self) -> AuthClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self._token_client.close()
+
+    def generate_disposable_token(
+            self,
+            scope: DisposableTokenScope,
+            expiresIn: ExpiresIn,
+            disposable_token_props: Optional[DisposableTokenProps]
+    ) -> GenerateDisposableTokenResponse:
+        """Generate a disposable auth token.
+
+        Returns:
+            GenerateDisposableTokenResponse
+        """
+        return self._token_client.generate_disposable_token(scope, expiresIn, disposable_token_props)
+
+    def close(self) -> None:
+        self.close()

--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -13,7 +13,7 @@ from momento.utilities.expiration import ExpiresIn
 
 
 class AuthClient:
-    """Auth Client.
+    """Synchronous Auth Client.
 
     Auth methods return a response object unique to each request.
     The response object is resolved to a type-safe object of one of several
@@ -22,7 +22,7 @@ class AuthClient:
     Pattern matching can be used to operate on the appropriate subtype.
     For example, in python 3.10+ if you're generating a disposable auth token:
 
-        response = await client.generateDisposableToken(...)
+        response = client.generateDisposableToken(...)
         match response:
             case GenerateDisposableToken.Success():
                 ...the disposable auth token was generated...
@@ -31,7 +31,7 @@ class AuthClient:
 
     or equivalently in earlier versions of python::
 
-        response = await client.generateDisposableToken(...)
+        response = client.generateDisposableToken(...)
         if isinstance(response, GenerateDisposableToken.Success):
             ...
         elif isinstance(response, GenerateDisposableToken.Error):
@@ -48,11 +48,11 @@ class AuthClient:
             credential_provider (CredentialProvider): An object holding the auth token and endpoint information.
 
         Example::
-            from momento import AuthConfigurations, CredentialProvider, AuthClientAsync
+            from momento import AuthConfigurations, CredentialProvider, AuthClient
 
             configuration = AuthConfigurations.Laptop.latest()
             credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
-            client = AuthClientAsync(configuration, credential_provider)
+            client = AuthClient(configuration, credential_provider)
         """
         self._logger = logs.logger
         self._token_client = _ScsTokenClient(configuration, credential_provider)
@@ -70,7 +70,10 @@ class AuthClient:
         self._token_client.close()
 
     def generate_disposable_token(
-        self, scope: DisposableTokenScope, expires_in: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
+        self,
+        scope: DisposableTokenScope,
+        expires_in: ExpiresIn,
+        disposable_token_props: Optional[DisposableTokenProps] = None,
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 
@@ -82,4 +85,4 @@ class AuthClient:
         )
 
     def close(self) -> None:
-        self.close()
+        self._token_client.close()

--- a/src/momento/auth_client_async.py
+++ b/src/momento/auth_client_async.py
@@ -70,10 +70,7 @@ class AuthClientAsync:
         await self._token_client.close()
 
     async def generate_disposable_token(
-            self,
-            scope: DisposableTokenScope,
-            expiresIn: ExpiresIn,
-            disposable_token_props: Optional[DisposableTokenProps]
+        self, scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 

--- a/src/momento/auth_client_async.py
+++ b/src/momento/auth_client_async.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Optional, Type
+
+from momento import logs
+from momento.auth.access_control.disposable_token_scope import DisposableTokenProps, DisposableTokenScope
+from momento.auth.credential_provider import CredentialProvider
+from momento.config.auth_configuration import AuthConfiguration
+from momento.internal.aio._scs_token_client import _ScsTokenClient
+from momento.responses.auth.generate_disposable_token import GenerateDisposableTokenResponse
+from momento.utilities.expiration import ExpiresIn
+
+
+class AuthClientAsync:
+    """Async Auth Client.
+
+    Auth methods return a response object unique to each request.
+    The response object is resolved to a type-safe object of one of several
+    sub-types. See the documentation for each response type for details.
+
+    Pattern matching can be used to operate on the appropriate subtype.
+    For example, in python 3.10+ if you're generating a disposable auth token:
+
+        response = await client.generateDisposableToken(...)
+        match response:
+            case GenerateDisposableToken.Success():
+                ...the disposable auth token was generated...
+            case GenerateDisposableToken.Error():
+                ...there was an error trying to generate the auth token...
+
+    or equivalently in earlier versions of python::
+
+        response = await client.generateDisposableToken(...)
+        if isinstance(response, GenerateDisposableToken.Success):
+            ...
+        elif isinstance(response, GenerateDisposableToken.Error):
+            ...
+        else:
+            raise Exception("This should never happen")
+    """
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        """Instantiate a client.
+
+        Args:
+            configuration (AuthConfiguration): An object holding configuration settings for communication with the server.
+            credential_provider (CredentialProvider): An object holding the auth token and endpoint information.
+
+        Example::
+            from momento import AuthConfigurations, CredentialProvider, AuthClientAsync
+
+            configuration = AuthConfigurations.Laptop.latest()
+            credential_provider = CredentialProvider.from_environment_variable("MOMENTO_API_KEY")
+            client = AuthClientAsync(configuration, credential_provider)
+        """
+        self._logger = logs.logger
+        self._token_client = _ScsTokenClient(configuration, credential_provider)
+        self._token_endpoint = credential_provider.token_endpoint
+
+    async def __aenter__(self) -> AuthClientAsync:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        await self._token_client.close()
+
+    async def generate_disposable_token(
+            self,
+            scope: DisposableTokenScope,
+            expiresIn: ExpiresIn,
+            disposable_token_props: Optional[DisposableTokenProps]
+    ) -> GenerateDisposableTokenResponse:
+        """Generate a disposable auth token.
+
+        Returns:
+            GenerateDisposableTokenResponse
+        """
+        return await self._token_client.generate_disposable_token(scope, expiresIn, disposable_token_props)
+
+    async def close(self) -> None:
+        await self._token_client.close()

--- a/src/momento/auth_client_async.py
+++ b/src/momento/auth_client_async.py
@@ -77,6 +77,11 @@ class AuthClientAsync:
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 
+        Args:
+            scope (DisposableTokenScope): The permissions to grant to the new disposable token. Convenient factory methods are provided under the DisposableTokenScopes class.
+            expires_in (ExpiresIn): The time until the token expires.
+            disposable_token_props (Optional[DisposableTokenProps], optional): Additional properties for the disposable token, such as token_id. Defaults to None.
+
         Returns:
             GenerateDisposableTokenResponse
         """

--- a/src/momento/auth_client_async.py
+++ b/src/momento/auth_client_async.py
@@ -56,7 +56,7 @@ class AuthClientAsync:
         """
         self._logger = logs.logger
         self._token_client = _ScsTokenClient(configuration, credential_provider)
-        self._token_endpoint = credential_provider.token_endpoint
+        self._credential_provider = credential_provider
 
     async def __aenter__(self) -> AuthClientAsync:
         return self
@@ -70,14 +70,19 @@ class AuthClientAsync:
         await self._token_client.close()
 
     async def generate_disposable_token(
-        self, scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]
+        self,
+        scope: DisposableTokenScope,
+        expires_in: ExpiresIn,
+        disposable_token_props: Optional[DisposableTokenProps] = None,
     ) -> GenerateDisposableTokenResponse:
         """Generate a disposable auth token.
 
         Returns:
             GenerateDisposableTokenResponse
         """
-        return await self._token_client.generate_disposable_token(scope, expiresIn, disposable_token_props)
+        return await self._token_client.generate_disposable_token(
+            scope, expires_in, self._credential_provider, disposable_token_props
+        )
 
     async def close(self) -> None:
         await self._token_client.close()

--- a/src/momento/config/auth_configuration.py
+++ b/src/momento/config/auth_configuration.py
@@ -91,4 +91,3 @@ class AuthConfiguration(AuthConfigurationBase):
             AuthConfiguration: the new AuthConfiguration.
         """
         return AuthConfiguration(self._transport_strategy.with_client_timeout(client_timeout), self._retry_strategy)
-

--- a/src/momento/config/auth_configuration.py
+++ b/src/momento/config/auth_configuration.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+from momento.config.transport.transport_strategy import TransportStrategy
+from momento.retry.retry_strategy import RetryStrategy
+
+
+class AuthConfigurationBase(ABC):
+    @abstractmethod
+    def get_retry_strategy(self) -> RetryStrategy:
+        pass
+
+    @abstractmethod
+    def with_retry_strategy(self, retry_strategy: RetryStrategy) -> AuthConfiguration:
+        pass
+
+    @abstractmethod
+    def get_transport_strategy(self) -> TransportStrategy:
+        pass
+
+    @abstractmethod
+    def with_transport_strategy(self, transport_strategy: TransportStrategy) -> AuthConfiguration:
+        pass
+
+    @abstractmethod
+    def with_client_timeout(self, client_timeout: timedelta) -> AuthConfiguration:
+        pass
+
+
+class AuthConfiguration(AuthConfigurationBase):
+    """AuthConfiguration options for Momento Simple Cache Client."""
+
+    def __init__(self, transport_strategy: TransportStrategy, retry_strategy: RetryStrategy):
+        """Instantiate a AuthConfiguration.
+
+        Args:
+            transport_strategy (TransportStrategy): AuthConfiguration options for networking with
+            the Momento service.
+            retry_strategy (RetryStrategy): the strategy to use when determining whether to retry a grpc call.
+        """
+        self._transport_strategy = transport_strategy
+        self._retry_strategy = retry_strategy
+
+    def get_retry_strategy(self) -> RetryStrategy:
+        """Access the retry strategy.
+
+        Returns:
+            RetryStrategy: the strategy to use when determining whether to retry a grpc call.
+        """
+        return self._retry_strategy
+
+    def with_retry_strategy(self, retry_strategy: RetryStrategy) -> AuthConfiguration:
+        """Copy constructor for overriding RetryStrategy.
+
+        Args:
+            retry_strategy (RetryStrategy): the new RetryStrategy.
+
+        Returns:
+            AuthConfiguration: the new AuthConfiguration with the specified RetryStrategy.
+        """
+        return AuthConfiguration(self._transport_strategy, retry_strategy)
+
+    def get_transport_strategy(self) -> TransportStrategy:
+        """Access the transport strategy.
+
+        Returns:
+            TransportStrategy: the current configuration options for wire interactions with the Momento service.
+        """
+        return self._transport_strategy
+
+    def with_transport_strategy(self, transport_strategy: TransportStrategy) -> AuthConfiguration:
+        """Copy constructor for overriding TransportStrategy.
+
+        Args:
+            transport_strategy (TransportStrategy): the new TransportStrategy.
+
+        Returns:
+            AuthConfiguration: the new AuthConfiguration with the specified TransportStrategy.
+        """
+        return AuthConfiguration(transport_strategy, self._retry_strategy)
+
+    def with_client_timeout(self, client_timeout: timedelta) -> AuthConfiguration:
+        """Copies the AuthConfiguration and sets the new client-side timeout in the copy's TransportStrategy.
+
+        Args:
+            client_timeout (timedelta): the new client-side timeout.
+
+        Return:
+            AuthConfiguration: the new AuthConfiguration.
+        """
+        return AuthConfiguration(self._transport_strategy.with_client_timeout(client_timeout), self._retry_strategy)
+

--- a/src/momento/config/auth_configurations.py
+++ b/src/momento/config/auth_configurations.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from momento.retry import FixedCountRetryStrategy
+
+from .auth_configuration import AuthConfiguration
+from .transport.transport_strategy import (
+    StaticGrpcConfiguration,
+    StaticTransportStrategy,
+)
+
+
+class AuthConfigurations:
+    """Container class for pre-built configurations."""
+
+    class Laptop(AuthConfiguration):
+        """Laptop config provides defaults suitable for a medium-to-high-latency dev environment.
+
+        Permissive timeouts, retries, and relaxed latency and throughput targets.
+        """
+
+        @staticmethod
+        def latest() -> AuthConfigurations.Laptop:
+            """Provides the latest recommended configuration for a laptop development environment.
+
+            This configuration will be updated every time there is a new version of the laptop configuration.
+            """
+            return AuthConfigurations.Laptop.v1()
+
+        @staticmethod
+        def v1() -> AuthConfigurations.Laptop:
+            """Provides the v1 recommended configuration for a laptop development environment.
+
+            This configuration is guaranteed not to change in future releases of the Momento Python SDK.
+            """
+            return AuthConfigurations.Laptop(
+                StaticTransportStrategy(StaticGrpcConfiguration(deadline=timedelta(seconds=15))),
+                FixedCountRetryStrategy(max_attempts=3),
+            )
+
+    class Lambda(AuthConfiguration):
+        """Lambda config provides defaults suitable for an AWS Lambda environment."""
+
+        @staticmethod
+        def latest() -> AuthConfigurations.Lambda:
+            """Provides the latest recommended configuration for an AWS Lambda development environment.
+
+            This configuration will be updated every time there is a new version of the Lambda configuration.
+            """
+            return AuthConfigurations.Lambda(
+                StaticTransportStrategy(
+                    StaticGrpcConfiguration(
+                        deadline=timedelta(milliseconds=1100),
+                        keepalive_permit_without_calls=False,
+                        keepalive_time=None,
+                        keepalive_timeout=None,
+                    )
+                ),
+                FixedCountRetryStrategy(max_attempts=3),
+            )
+
+    class InRegion:
+        """Default for application running in the same region as the Momento service.
+
+        InRegion provides defaults suitable for an environment where your client is running in the same region as the
+        Momento service.  It has more aggressive timeouts and retry behavior than the Laptop config.
+        """
+
+        class Default(AuthConfiguration):
+            """Prioritizes throughput and client resource utilization.
+
+            It has a slightly relaxed client-side timeout setting to maximize throughput.
+            """
+
+            @staticmethod
+            def latest() -> AuthConfigurations.InRegion.Default:
+                """Provides the latest recommended configuration for a typical in-region environment.
+
+                This configuration will be updated every time there is a new version of the in-region configuration.
+                """
+                return AuthConfigurations.InRegion.Default.v1()
+
+            @staticmethod
+            def v1() -> AuthConfigurations.InRegion.Default:
+                """Provides the v1 recommended configuration for a typical in-region environment.
+
+                This configuration is guaranteed not to change in future releases of the Momento Python SDK.
+                """
+                return AuthConfigurations.InRegion.Default(
+                    StaticTransportStrategy(StaticGrpcConfiguration(deadline=timedelta(milliseconds=1100))),
+                    FixedCountRetryStrategy(max_attempts=3),
+                )
+
+        class LowLatency(AuthConfiguration):
+            """Prioritizes keeping p99.9 latencies as low as possible.
+
+            It potentially sacrifices some throughput to achieve this.  It has a very aggressive client-side timeout.
+            Use this configuration if the most important factor is to ensure that cache unavailability doesn't
+            force unacceptably high latencies for your application.
+            """
+
+            @staticmethod
+            def latest() -> AuthConfigurations.InRegion.LowLatency:
+                """Provides the latest recommended configuration for an environment with low-latency requirements.
+
+                This configuration will be updated every time there is a new version of the low-latency configuration.
+                """
+                return AuthConfigurations.InRegion.LowLatency.v1()
+
+            @staticmethod
+            def v1() -> AuthConfigurations.InRegion.LowLatency:
+                """Provides the v1 recommended configuration for an environment with low-latency requirements.
+
+                This configuration is guaranteed not to change in future releases of the Momento Python SDK.
+                """
+                return AuthConfigurations.InRegion.LowLatency(
+                    StaticTransportStrategy(StaticGrpcConfiguration(deadline=timedelta(milliseconds=500))),
+                    FixedCountRetryStrategy(max_attempts=3),
+                )

--- a/src/momento/internal/_utilities/_client_type.py
+++ b/src/momento/internal/_utilities/_client_type.py
@@ -11,3 +11,4 @@ class ClientType(Enum):
 
     CACHE = "cache"
     TOPIC = "topic"
+    TOKEN = "token"

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -1,3 +1,7 @@
+"""Permissions conversion functions.
+
+Used to convert from the SDK permissions data classes to the protobuf permissions objects.
+"""
 from typing import Union
 
 from momento_wire_types import permissionmessages_pb2 as permissions_pb

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -1,174 +1,201 @@
-
 from typing import Union
 
 from momento_wire_types import permissionmessages_pb2 as permissions_pb
 
 from momento.auth.access_control.disposable_token_scope import (
-  CacheItemKey,
-  CacheItemKeyPrefix,
-  DisposableTokenCachePermission,
-  DisposableTokenCachePermissions,
-  DisposableTokenScope,
+    CacheItemKey,
+    CacheItemKeyPrefix,
+    DisposableTokenCachePermission,
+    DisposableTokenCachePermissions,
+    DisposableTokenScope,
 )
 from momento.auth.access_control.permission_scope import (
-  CacheName,
-  CachePermission,
-  CacheRole,
-  Permission,
-  Permissions,
-  PermissionScope,
-  PredefinedScope,
-  TopicName,
-  TopicPermission,
-  TopicRole,
+    CacheName,
+    CachePermission,
+    CacheRole,
+    Permission,
+    Permissions,
+    PermissionScope,
+    PredefinedScope,
+    TopicName,
+    TopicPermission,
+    TopicRole,
 )
 from tests.utils import str_to_bytes
 
 
 class SuperuserPermissions(PredefinedScope):
-  pass
+    pass
+
 
 def permissions_from_permission_scope(scope: PermissionScope) -> permissions_pb.Permissions:
-  result = permissions_pb.Permissions()
-  if isinstance(scope.permission_scope, SuperuserPermissions):
-    result.super_user = permissions_pb.SuperUserPermissions()
-    return result
-  elif isinstance(scope.permission_scope, Permissions) and not isinstance(scope.permission_scope, PredefinedScope):
-    converted_perms = [
-      token_permission_to_grpc_permission(permission) for permission in scope.permission_scope.permissions
-    ]
-    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
-    return result
-  else:
-    raise ValueError("Unrecognized permission scope")
+    result = permissions_pb.Permissions()
+    if isinstance(scope.permission_scope, SuperuserPermissions):
+        result.super_user = permissions_pb.SuperUserPermissions()
+        return result
+    elif isinstance(scope.permission_scope, Permissions) and not isinstance(scope.permission_scope, PredefinedScope):
+        converted_perms = [
+            token_permission_to_grpc_permission(permission) for permission in scope.permission_scope.permissions
+        ]
+        result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+        return result
+    else:
+        raise ValueError("Unrecognized permission scope")
+
 
 def token_permission_to_grpc_permission(permission: Permission) -> permissions_pb.PermissionsType:
     if isinstance(permission, TopicPermission):
-      topic_permission = topic_permission_to_grpc_permission(permission)
-      return permissions_pb.PermissionsType(topic_permissions=topic_permission)
+        topic_permission = topic_permission_to_grpc_permission(permission)
+        return permissions_pb.PermissionsType(topic_permissions=topic_permission)
     elif isinstance(permission, CachePermission):
-      cache_permission = cache_permission_to_grpc_permission(permission)
-      return permissions_pb.PermissionsType(cache_permissions=cache_permission)
+        cache_permission = cache_permission_to_grpc_permission(permission)
+        return permissions_pb.PermissionsType(cache_permissions=cache_permission)
+
 
 def cache_permission_to_grpc_permission(permission: CachePermission) -> permissions_pb.PermissionsType.CachePermissions:
-  grpc_permission = permissions_pb.PermissionsType.CachePermissions()
-  grpc_permission = assign_cache_role(permission, grpc_permission)
-  grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
-  return grpc_permission
+    grpc_permission = permissions_pb.PermissionsType.CachePermissions()
+    grpc_permission = assign_cache_role(permission, grpc_permission)
+    grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
+    return grpc_permission
+
 
 def assign_cache_role(
-    permission: CachePermission,
-    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+    permission: CachePermission, grpc_permission: permissions_pb.PermissionsType.CachePermissions
 ) -> permissions_pb.PermissionsType.CachePermissions:
-  if permission.role == CacheRole.READ_WRITE:
-    grpc_permission.role = permissions_pb.CacheReadWrite
-  elif permission.role == CacheRole.READ_ONLY:
-    grpc_permission.role = permissions_pb.CacheReadOnly
-  elif permission.role == CacheRole.WRITE_ONLY:
-    grpc_permission.role = permissions_pb.CacheWriteOnly
-  else:
-    raise ValueError("Unrecognized cache role")
-  return grpc_permission
+    if permission.role == CacheRole.READ_WRITE:
+        grpc_permission.role = permissions_pb.CacheReadWrite
+    elif permission.role == CacheRole.READ_ONLY:
+        grpc_permission.role = permissions_pb.CacheReadOnly
+    elif permission.role == CacheRole.WRITE_ONLY:
+        grpc_permission.role = permissions_pb.CacheWriteOnly
+    else:
+        raise ValueError("Unrecognized cache role")
+    return grpc_permission
+
 
 def assign_cache_selector_for_cache_permission(
     permission: Union[DisposableTokenCachePermission, CachePermission],
-    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+    grpc_permission: permissions_pb.PermissionsType.CachePermissions,
 ) -> permissions_pb.PermissionsType.CachePermissions:
-  if permission.cache_selector.is_all_caches():
-    grpc_permission.all_caches = permissions_pb.PermissionsType.All()
-  elif isinstance(permission.cache_selector.cache, str):
-    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache)
-  elif isinstance(permission.cache_selector.cache, CacheName):
-    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache.name)
-  else:
-    raise ValueError("Unrecognized cache selector")
-  return grpc_permission
+    if permission.cache_selector.is_all_caches():
+        grpc_permission.all_caches = permissions_pb.PermissionsType.All()
+    elif isinstance(permission.cache_selector.cache, str):
+        grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(
+            cache_name=permission.cache_selector.cache
+        )
+    elif isinstance(permission.cache_selector.cache, CacheName):
+        grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(
+            cache_name=permission.cache_selector.cache.name
+        )
+    else:
+        raise ValueError("Unrecognized cache selector")
+    return grpc_permission
+
 
 def topic_permission_to_grpc_permission(permission: TopicPermission) -> permissions_pb.PermissionsType.TopicPermissions:
-  result = permissions_pb.PermissionsType.TopicPermissions()
-  result = assign_topic_role(permission, result)
-  result = assign_topic_selector(permission, result)
-  result = assign_cache_selector_for_topic_permission(permission, result)
-  return result
+    result = permissions_pb.PermissionsType.TopicPermissions()
+    result = assign_topic_role(permission, result)
+    result = assign_topic_selector(permission, result)
+    result = assign_cache_selector_for_topic_permission(permission, result)
+    return result
+
 
 def assign_topic_role(
-    permission: TopicPermission,
-    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+    permission: TopicPermission, grpc_permission: permissions_pb.PermissionsType.TopicPermissions
 ) -> permissions_pb.PermissionsType.TopicPermissions:
-  if permission.role == TopicRole.PUBLISH_SUBSCRIBE:
-    grpc_permission.role = permissions_pb.TopicReadWrite
-  elif permission.role == TopicRole.SUBSCRIBE_ONLY:
-    grpc_permission.role = permissions_pb.TopicReadOnly
-  elif permission.role == TopicRole.PUBLISH_ONLY:
-    grpc_permission.role = permissions_pb.TopicWriteOnly
-  else:
-    raise ValueError("Unrecognized topic role")
-  return grpc_permission
+    if permission.role == TopicRole.PUBLISH_SUBSCRIBE:
+        grpc_permission.role = permissions_pb.TopicReadWrite
+    elif permission.role == TopicRole.SUBSCRIBE_ONLY:
+        grpc_permission.role = permissions_pb.TopicReadOnly
+    elif permission.role == TopicRole.PUBLISH_ONLY:
+        grpc_permission.role = permissions_pb.TopicWriteOnly
+    else:
+        raise ValueError("Unrecognized topic role")
+    return grpc_permission
+
 
 def assign_topic_selector(
-    permission: TopicPermission,
-    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+    permission: TopicPermission, grpc_permission: permissions_pb.PermissionsType.TopicPermissions
 ) -> permissions_pb.PermissionsType.TopicPermissions:
-  if permission.topic_selector.is_all_topics():
-    grpc_permission.all_topics = permissions_pb.PermissionsType.All()
-  elif isinstance(permission.topic_selector.topic, str):
-    grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic)
-  elif isinstance(permission.topic_selector.topic, TopicName):
-    grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic.name)
-  else:
-    raise ValueError("Unrecognized topic selector")
-  return grpc_permission
+    if permission.topic_selector.is_all_topics():
+        grpc_permission.all_topics = permissions_pb.PermissionsType.All()
+    elif isinstance(permission.topic_selector.topic, str):
+        grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(
+            topic_name=permission.topic_selector.topic
+        )
+    elif isinstance(permission.topic_selector.topic, TopicName):
+        grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(
+            topic_name=permission.topic_selector.topic.name
+        )
+    else:
+        raise ValueError("Unrecognized topic selector")
+    return grpc_permission
+
 
 def assign_cache_selector_for_topic_permission(
-    permission: TopicPermission,
-    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+    permission: TopicPermission, grpc_permission: permissions_pb.PermissionsType.TopicPermissions
 ) -> permissions_pb.PermissionsType.TopicPermissions:
-  if permission.cache_selector.is_all_caches():
-    grpc_permission.all_caches = permissions_pb.PermissionsType.All()
-  elif isinstance(permission.cache_selector.cache, str):
-    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache)
-  elif isinstance(permission.cache_selector.cache, CacheName):
-    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache.name)
-  else:
-    raise ValueError("Unrecognized cache selector")
-  return grpc_permission
+    if permission.cache_selector.is_all_caches():
+        grpc_permission.all_caches = permissions_pb.PermissionsType.All()
+    elif isinstance(permission.cache_selector.cache, str):
+        grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(
+            cache_name=permission.cache_selector.cache
+        )
+    elif isinstance(permission.cache_selector.cache, CacheName):
+        grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(
+            cache_name=permission.cache_selector.cache.name
+        )
+    else:
+        raise ValueError("Unrecognized cache selector")
+    return grpc_permission
+
 
 def permissions_from_disposable_token_scope(scope: DisposableTokenScope) -> permissions_pb.Permissions:
-  result = permissions_pb.Permissions()
-  if isinstance(scope.disposable_token_scope, DisposableTokenCachePermissions):
-    converted_perms = [
-      disposable_token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.disposable_token_permissions
-    ]
-    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
-    return result
-  elif isinstance(scope.disposable_token_scope, Permissions):
-    converted_perms = [
-      token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.permissions
-    ]
-    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
-    return result
-  else:
-    raise ValueError("Unrecognized disposable token permission scope")
+    result = permissions_pb.Permissions()
+    if isinstance(scope.disposable_token_scope, DisposableTokenCachePermissions):
+        converted_perms = [
+            disposable_token_permission_to_grpc_permission(permission)
+            for permission in scope.disposable_token_scope.disposable_token_permissions
+        ]
+        result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+        return result
+    elif isinstance(scope.disposable_token_scope, Permissions):
+        converted_perms = [
+            token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.permissions
+        ]
+        result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+        return result
+    else:
+        raise ValueError("Unrecognized disposable token permission scope")
 
-def disposable_token_permission_to_grpc_permission(permission: DisposableTokenCachePermission) -> permissions_pb.PermissionsType.CachePermissions:
-  grpc_permission = permissions_pb.PermissionsType.CachePermissions()
-  grpc_permission = assign_cache_role(permission, grpc_permission)
-  grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
-  grpc_permission = assign_cache_item_selector(permission, grpc_permission)
-  return grpc_permission
+
+def disposable_token_permission_to_grpc_permission(
+    permission: DisposableTokenCachePermission,
+) -> permissions_pb.PermissionsType.CachePermissions:
+    grpc_permission = permissions_pb.PermissionsType.CachePermissions()
+    grpc_permission = assign_cache_role(permission, grpc_permission)
+    grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
+    grpc_permission = assign_cache_item_selector(permission, grpc_permission)
+    return grpc_permission
+
 
 def assign_cache_item_selector(
-    permission: DisposableTokenCachePermission,
-    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+    permission: DisposableTokenCachePermission, grpc_permission: permissions_pb.PermissionsType.CachePermissions
 ) -> permissions_pb.PermissionsType.CachePermissions:
-  if permission.cache_item_selector.is_all_cache_items():
-    grpc_permission.all_items = permissions_pb.PermissionsType.All()
-  elif isinstance(permission.cache_item_selector.cache_item, str):
-    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes(permission.cache_item_selector.cache_item))
-  elif isinstance(permission.cache_item_selector.cache_item, CacheItemKey):
-    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes(permission.cache_item_selector.cache_item.key))
-  elif isinstance(permission.cache_item_selector.cache_item, CacheItemKeyPrefix):
-    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes(permission.cache_item_selector.cache_item.key_prefix))
-  else:
-    raise ValueError("Unrecognized cache item selector")
-  return grpc_permission
+    if permission.cache_item_selector.is_all_cache_items():
+        grpc_permission.all_items = permissions_pb.PermissionsType.All()
+    elif isinstance(permission.cache_item_selector.cache_item, str):
+        grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(
+            key=str_to_bytes(permission.cache_item_selector.cache_item)
+        )
+    elif isinstance(permission.cache_item_selector.cache_item, CacheItemKey):
+        grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(
+            key=str_to_bytes(permission.cache_item_selector.cache_item.key)
+        )
+    elif isinstance(permission.cache_item_selector.cache_item, CacheItemKeyPrefix):
+        grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(
+            key_prefix=str_to_bytes(permission.cache_item_selector.cache_item.key_prefix)
+        )
+    else:
+        raise ValueError("Unrecognized cache item selector")
+    return grpc_permission

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -125,32 +125,22 @@ def assign_topic_role(permission: TopicPermission) -> permissions_pb.TopicRole:
         raise ValueError("Unrecognized topic role:", permission.role)
 
 
-def assign_topic_selector(
-    permission: TopicPermission
-) -> permissions_pb.PermissionsType.TopicSelector:
+def assign_topic_selector(permission: TopicPermission) -> permissions_pb.PermissionsType.TopicSelector:
     if isinstance(permission.topic_selector.topic, str):
-        return permissions_pb.PermissionsType.TopicSelector(
-            topic_name=permission.topic_selector.topic
-        )
+        return permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic)
     elif isinstance(permission.topic_selector.topic, TopicName):
-        return permissions_pb.PermissionsType.TopicSelector(
-            topic_name=permission.topic_selector.topic.name
-        )
+        return permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic.name)
     else:
         raise ValueError("Unrecognized topic selector:", permission.topic_selector)
 
 
 def assign_cache_selector(
-    permission: Union[CachePermission, TopicPermission, DisposableTokenCachePermission]
+    permission: Union[CachePermission, TopicPermission, DisposableTokenCachePermission],
 ) -> permissions_pb.PermissionsType.CacheSelector:
     if isinstance(permission.cache_selector.cache, str):
-        return permissions_pb.PermissionsType.CacheSelector(
-                cache_name=permission.cache_selector.cache
-            )
+        return permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache)
     elif isinstance(permission.cache_selector.cache, CacheName):
-        return permissions_pb.PermissionsType.CacheSelector(
-                cache_name=permission.cache_selector.cache.name
-            )
+        return permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache.name)
     else:
         raise ValueError("Unrecognized cache selector:", permission.cache_selector)
 
@@ -163,18 +153,14 @@ def permissions_from_disposable_token_scope(scope: DisposableTokenScope) -> perm
         ]
         if len(converted_perms) == 0:
             raise ValueError("Permissions must have at least one permission")
-        return permissions_pb.Permissions(
-            explicit=permissions_pb.ExplicitPermissions(permissions=converted_perms)
-        )
+        return permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(permissions=converted_perms))
     elif isinstance(scope.disposable_token_scope, Permissions):
         converted_perms = [
             token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.permissions
         ]
         if len(converted_perms) == 0:
             raise ValueError("Permissions must have at least one permission")
-        return permissions_pb.Permissions(
-            explicit=permissions_pb.ExplicitPermissions(permissions=converted_perms)
-        )
+        return permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(permissions=converted_perms))
     else:
         raise ValueError("Unrecognized disposable token permission scope:", scope)
 
@@ -221,7 +207,7 @@ def disposable_token_permission_to_grpc_permission(
 
 
 def assign_cache_item_selector(
-    permission: DisposableTokenCachePermission
+    permission: DisposableTokenCachePermission,
 ) -> permissions_pb.PermissionsType.CacheItemSelector:
     if isinstance(permission.cache_item_selector.cache_item, CacheItemKey):
         return permissions_pb.PermissionsType.CacheItemSelector(

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -1,0 +1,174 @@
+
+from typing import Union
+
+from momento_wire_types import permissionmessages_pb2 as permissions_pb
+
+from momento.auth.access_control.disposable_token_scope import (
+  CacheItemKey,
+  CacheItemKeyPrefix,
+  DisposableTokenCachePermission,
+  DisposableTokenCachePermissions,
+  DisposableTokenScope,
+)
+from momento.auth.access_control.permission_scope import (
+  CacheName,
+  CachePermission,
+  CacheRole,
+  Permission,
+  Permissions,
+  PermissionScope,
+  PredefinedScope,
+  TopicName,
+  TopicPermission,
+  TopicRole,
+)
+from tests.utils import str_to_bytes
+
+
+class SuperuserPermissions(PredefinedScope):
+  pass
+
+def permissions_from_permission_scope(scope: PermissionScope) -> permissions_pb.Permissions:
+  result = permissions_pb.Permissions()
+  if isinstance(scope.permission_scope, SuperuserPermissions):
+    result.super_user = permissions_pb.SuperUserPermissions()
+    return result
+  elif isinstance(scope.permission_scope, Permissions) and not isinstance(scope.permission_scope, PredefinedScope):
+    converted_perms = [
+      token_permission_to_grpc_permission(permission) for permission in scope.permission_scope.permissions
+    ]
+    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+    return result
+  else:
+    raise ValueError("Unrecognized permission scope")
+
+def token_permission_to_grpc_permission(permission: Permission) -> permissions_pb.PermissionsType:
+    if isinstance(permission, TopicPermission):
+      topic_permission = topic_permission_to_grpc_permission(permission)
+      return permissions_pb.PermissionsType(topic_permissions=topic_permission)
+    elif isinstance(permission, CachePermission):
+      cache_permission = cache_permission_to_grpc_permission(permission)
+      return permissions_pb.PermissionsType(cache_permissions=cache_permission)
+
+def cache_permission_to_grpc_permission(permission: CachePermission) -> permissions_pb.PermissionsType.CachePermissions:
+  grpc_permission = permissions_pb.PermissionsType.CachePermissions()
+  grpc_permission = assign_cache_role(permission, grpc_permission)
+  grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
+  return grpc_permission
+
+def assign_cache_role(
+    permission: CachePermission,
+    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+) -> permissions_pb.PermissionsType.CachePermissions:
+  if permission.role == CacheRole.READ_WRITE:
+    grpc_permission.role = permissions_pb.CacheReadWrite
+  elif permission.role == CacheRole.READ_ONLY:
+    grpc_permission.role = permissions_pb.CacheReadOnly
+  elif permission.role == CacheRole.WRITE_ONLY:
+    grpc_permission.role = permissions_pb.CacheWriteOnly
+  else:
+    raise ValueError("Unrecognized cache role")
+  return grpc_permission
+
+def assign_cache_selector_for_cache_permission(
+    permission: Union[DisposableTokenCachePermission, CachePermission],
+    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+) -> permissions_pb.PermissionsType.CachePermissions:
+  if permission.cache_selector.is_all_caches():
+    grpc_permission.all_caches = permissions_pb.PermissionsType.All()
+  elif isinstance(permission.cache_selector.cache, str):
+    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache)
+  elif isinstance(permission.cache_selector.cache, CacheName):
+    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache.name)
+  else:
+    raise ValueError("Unrecognized cache selector")
+  return grpc_permission
+
+def topic_permission_to_grpc_permission(permission: TopicPermission) -> permissions_pb.PermissionsType.TopicPermissions:
+  result = permissions_pb.PermissionsType.TopicPermissions()
+  result = assign_topic_role(permission, result)
+  result = assign_topic_selector(permission, result)
+  result = assign_cache_selector_for_topic_permission(permission, result)
+  return result
+
+def assign_topic_role(
+    permission: TopicPermission,
+    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+) -> permissions_pb.PermissionsType.TopicPermissions:
+  if permission.role == TopicRole.PUBLISH_SUBSCRIBE:
+    grpc_permission.role = permissions_pb.TopicReadWrite
+  elif permission.role == TopicRole.SUBSCRIBE_ONLY:
+    grpc_permission.role = permissions_pb.TopicReadOnly
+  elif permission.role == TopicRole.PUBLISH_ONLY:
+    grpc_permission.role = permissions_pb.TopicWriteOnly
+  else:
+    raise ValueError("Unrecognized topic role")
+  return grpc_permission
+
+def assign_topic_selector(
+    permission: TopicPermission,
+    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+) -> permissions_pb.PermissionsType.TopicPermissions:
+  if permission.topic_selector.is_all_topics():
+    grpc_permission.all_topics = permissions_pb.PermissionsType.All()
+  elif isinstance(permission.topic_selector.topic, str):
+    grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic)
+  elif isinstance(permission.topic_selector.topic, TopicName):
+    grpc_permission.topic_selector = permissions_pb.PermissionsType.TopicSelector(topic_name=permission.topic_selector.topic.name)
+  else:
+    raise ValueError("Unrecognized topic selector")
+  return grpc_permission
+
+def assign_cache_selector_for_topic_permission(
+    permission: TopicPermission,
+    grpc_permission: permissions_pb.PermissionsType.TopicPermissions
+) -> permissions_pb.PermissionsType.TopicPermissions:
+  if permission.cache_selector.is_all_caches():
+    grpc_permission.all_caches = permissions_pb.PermissionsType.All()
+  elif isinstance(permission.cache_selector.cache, str):
+    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache)
+  elif isinstance(permission.cache_selector.cache, CacheName):
+    grpc_permission.cache_selector = permissions_pb.PermissionsType.CacheSelector(cache_name=permission.cache_selector.cache.name)
+  else:
+    raise ValueError("Unrecognized cache selector")
+  return grpc_permission
+
+def permissions_from_disposable_token_scope(scope: DisposableTokenScope) -> permissions_pb.Permissions:
+  result = permissions_pb.Permissions()
+  if isinstance(scope.disposable_token_scope, DisposableTokenCachePermissions):
+    converted_perms = [
+      disposable_token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.disposable_token_permissions
+    ]
+    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+    return result
+  elif isinstance(scope.disposable_token_scope, Permissions):
+    converted_perms = [
+      token_permission_to_grpc_permission(permission) for permission in scope.disposable_token_scope.permissions
+    ]
+    result.explicit = permissions_pb.ExplicitPermissions(permissions=converted_perms)
+    return result
+  else:
+    raise ValueError("Unrecognized disposable token permission scope")
+
+def disposable_token_permission_to_grpc_permission(permission: DisposableTokenCachePermission) -> permissions_pb.PermissionsType.CachePermissions:
+  grpc_permission = permissions_pb.PermissionsType.CachePermissions()
+  grpc_permission = assign_cache_role(permission, grpc_permission)
+  grpc_permission = assign_cache_selector_for_cache_permission(permission, grpc_permission)
+  grpc_permission = assign_cache_item_selector(permission, grpc_permission)
+  return grpc_permission
+
+def assign_cache_item_selector(
+    permission: DisposableTokenCachePermission,
+    grpc_permission: permissions_pb.PermissionsType.CachePermissions
+) -> permissions_pb.PermissionsType.CachePermissions:
+  if permission.cache_item_selector.is_all_cache_items():
+    grpc_permission.all_items = permissions_pb.PermissionsType.All()
+  elif isinstance(permission.cache_item_selector.cache_item, str):
+    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes(permission.cache_item_selector.cache_item))
+  elif isinstance(permission.cache_item_selector.cache_item, CacheItemKey):
+    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes(permission.cache_item_selector.cache_item.key))
+  elif isinstance(permission.cache_item_selector.cache_item, CacheItemKeyPrefix):
+    grpc_permission.item_selector = permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes(permission.cache_item_selector.cache_item.key_prefix))
+  else:
+    raise ValueError("Unrecognized cache item selector")
+  return grpc_permission

--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -8,9 +8,11 @@ import grpc
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import cachepubsub_pb2_grpc as pubsub_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
+from momento_wire_types import token_pb2_grpc as token_client
 
 from momento.auth import CredentialProvider
 from momento.config import Configuration, TopicConfiguration
+from momento.config.auth_configuration import AuthConfiguration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors.exceptions import ConnectionException
 from momento.internal._utilities import PYTHON_RUNTIME_VERSION, ClientType, momento_version
@@ -178,6 +180,30 @@ class _PubsubGrpcStreamManager:
 
     def async_stub(self) -> pubsub_client.PubsubStub:
         return pubsub_client.PubsubStub(self._secure_channel)  # type: ignore[no-untyped-call]
+
+
+class _TokenGrpcManager:
+    """Internal gRPC token manager."""
+
+    version = momento_version
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        self._secure_channel = grpc.aio.secure_channel(
+            target=credential_provider.token_endpoint,
+            credentials=grpc.ssl_channel_credentials(),
+            interceptors=_interceptors(
+                credential_provider.auth_token, ClientType.TOKEN, configuration.get_retry_strategy()
+            ),
+            options=grpc_control_channel_options_from_grpc_config(
+                grpc_config=configuration.get_transport_strategy().get_grpc_configuration(),
+            ),
+        )
+
+    async def close(self) -> None:
+        await self._secure_channel.close()
+
+    def async_stub(self) -> token_client.TokenStub:
+        return token_client.TokenStub(self._secure_channel)  # type: ignore[no-untyped-call]
 
 
 def _interceptors(

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -33,18 +33,20 @@ class _ScsTokenClient:
     async def generate_disposable_token(
         self,
         permission_scope: DisposableTokenScope,
-        expiresIn: ExpiresIn,
-        disposable_token_props: Optional[DisposableTokenProps],
+        expires_in: ExpiresIn,
+        credentialProvider: CredentialProvider,
+        disposable_token_props: Optional[DisposableTokenProps] = None,
     ) -> GenerateDisposableTokenResponse:
         try:
-            validate_disposable_token_expiry(expiresIn)
+            validate_disposable_token_expiry(expires_in)
             self._logger.info("Creating disposable token")
 
             token_id = disposable_token_props.token_id if disposable_token_props else None
-            expires = token_pb._GenerateDisposableTokenRequest.Expires(expiresIn.valid_for_seconds())
+            expires = token_pb._GenerateDisposableTokenRequest.Expires(valid_for_seconds=expires_in.valid_for_seconds())
             permissions = permissions_from_disposable_token_scope(permission_scope)
 
             request = token_pb._GenerateDisposableTokenRequest(
+                auth_token=credentialProvider.get_auth_token(),
                 expires=expires,
                 permissions=permissions,
                 token_id=token_id,

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -1,0 +1,57 @@
+from typing import Optional
+
+from momento_wire_types import token_pb2 as token_pb
+from momento_wire_types import token_pb2_grpc as token_grpc
+
+from momento import logs
+from momento.auth.access_control.disposable_token_scope import DisposableTokenProps, DisposableTokenScope
+from momento.auth.credential_provider import CredentialProvider
+from momento.config.auth_configuration import AuthConfiguration
+from momento.errors.error_converter import convert_error
+from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
+from momento.internal.aio._scs_grpc_manager import _TokenGrpcManager
+from momento.internal.services import Service
+from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
+from momento.utilities.expiration import ExpiresIn
+from momento.utilities.shared_sync_asyncio import validate_disposable_token_expiry
+
+
+class _ScsTokenClient:
+    """Momento Internal token client."""
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        endpoint = credential_provider.token_endpoint
+        self._logger = logs.logger
+        self._logger.debug("Token client instantiated with endpoint: %s", endpoint)
+        self._grpc_manager = _TokenGrpcManager(configuration, credential_provider)
+        self._endpoint = endpoint
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    async def generate_disposable_token(self, permission_scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]) -> GenerateDisposableTokenResponse:
+        try:
+            validate_disposable_token_expiry(expiresIn)
+            self._logger.info("Creating disposable token")
+
+            token_id = disposable_token_props.token_id if disposable_token_props else None
+            expires = token_pb._GenerateDisposableTokenRequest.Expires(expiresIn.valid_for_seconds())
+            permissions = permissions_from_disposable_token_scope(permission_scope)
+
+            request = token_pb._GenerateDisposableTokenRequest(
+                expires=expires,
+                permissions=permissions,
+                token_id=token_id,
+            )
+            response = await self._build_stub().GenerateDisposableToken(request) # type: ignore[misc]
+            return GenerateDisposableToken.Success.from_grpc_response(response) # type: ignore[misc]
+        except Exception as e:
+            self._logger.debug("Failed to generate disposable token with exception: %s", e)
+            return GenerateDisposableToken.Error(convert_error(e, Service.AUTH))
+
+    def _build_stub(self) -> token_grpc.TokenStub:
+        return self._grpc_manager.async_stub()
+
+    async def close(self) -> None:
+        await self._grpc_manager.close()

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -30,7 +30,12 @@ class _ScsTokenClient:
     def endpoint(self) -> str:
         return self._endpoint
 
-    async def generate_disposable_token(self, permission_scope: DisposableTokenScope, expiresIn: ExpiresIn, disposable_token_props: Optional[DisposableTokenProps]) -> GenerateDisposableTokenResponse:
+    async def generate_disposable_token(
+        self,
+        permission_scope: DisposableTokenScope,
+        expiresIn: ExpiresIn,
+        disposable_token_props: Optional[DisposableTokenProps],
+    ) -> GenerateDisposableTokenResponse:
         try:
             validate_disposable_token_expiry(expiresIn)
             self._logger.info("Creating disposable token")
@@ -44,8 +49,8 @@ class _ScsTokenClient:
                 permissions=permissions,
                 token_id=token_id,
             )
-            response = await self._build_stub().GenerateDisposableToken(request) # type: ignore[misc]
-            return GenerateDisposableToken.Success.from_grpc_response(response) # type: ignore[misc]
+            response = await self._build_stub().GenerateDisposableToken(request)  # type: ignore[misc]
+            return GenerateDisposableToken.Success.from_grpc_response(response)  # type: ignore[misc]
         except Exception as e:
             self._logger.debug("Failed to generate disposable token with exception: %s", e)
             return GenerateDisposableToken.Error(convert_error(e, Service.AUTH))

--- a/src/momento/internal/codegen.py
+++ b/src/momento/internal/codegen.py
@@ -122,7 +122,7 @@ name_replacements = NameReplacement(
         ("^async_(.*)", "\\1"),
         ("(.*?)_async_(.*)", "\\1_\\2"),
         ("(.*?)_async$", "\\1"),
-        ("^((?:Cache)Client)Async$", "\\1"),
+        ("^((?:Cache|Auth|Topic)Client)Async$", "\\1"),
         ("^(TUnique(?:Cache)Name)Async$", "\\1"),
         ("__aenter__", "__enter__"),
         ("__aexit__", "__exit__"),
@@ -132,8 +132,8 @@ name_replacements = NameReplacement(
 
 simple_string_replacements = SimpleStringReplacement(
     [
-        ("((?:Cache)Client)Async", "\\1"),
-        (r"(.*?)Async(\s+(?:Cache)\s+Client.*?)", "\\1Synchronous\\2"),
+        ("((?:Cache|Auth|Topic)Client)Async", "\\1"),
+        (r"(.*?)Async(\s+(?:Cache|Auth|Topic)\s+Client.*?)", "\\1Synchronous\\2"),
         (r"(.*?)\bawait\s+(.*?)", "\\1\\2"),
     ]
 )

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -222,10 +222,10 @@ class _TokenGrpcManager:
             ),
         )
 
-    async def close(self) -> None:
-        await self._secure_channel.close()
+    def close(self) -> None:
+        self._secure_channel.close()
 
-    def async_stub(self) -> token_client.TokenStub:
+    def stub(self) -> token_client.TokenStub:
         return token_client.TokenStub(self._secure_channel)  # type: ignore[no-untyped-call]
 
 

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -8,10 +8,12 @@ import grpc
 from momento_wire_types import cacheclient_pb2_grpc as cache_client
 from momento_wire_types import cachepubsub_pb2_grpc as pubsub_client
 from momento_wire_types import controlclient_pb2_grpc as control_client
+from momento_wire_types import token_pb2_grpc as token_client
 
 from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration, TopicConfiguration
+from momento.config.auth_configuration import AuthConfiguration
 from momento.config.transport.transport_strategy import StaticGrpcConfiguration
 from momento.errors.exceptions import ConnectionException
 from momento.internal._utilities import PYTHON_RUNTIME_VERSION, ClientType, momento_version
@@ -201,6 +203,30 @@ class _PubsubGrpcStreamManager:
 
     def stub(self) -> pubsub_client.PubsubStub:
         return self._stub
+
+
+class _TokenGrpcManager:
+    """Internal gRPC token manager."""
+
+    version = momento_version
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        self._secure_channel = grpc.aio.secure_channel(
+            target=credential_provider.token_endpoint,
+            credentials=grpc.ssl_channel_credentials(),
+            interceptors=_interceptors(
+                credential_provider.auth_token, ClientType.TOKEN, configuration.get_retry_strategy()
+            ),
+            options=grpc_control_channel_options_from_grpc_config(
+                grpc_config=configuration.get_transport_strategy().get_grpc_configuration(),
+            ),
+        )
+
+    async def close(self) -> None:
+        await self._secure_channel.close()
+
+    def async_stub(self) -> token_client.TokenStub:
+        return token_client.TokenStub(self._secure_channel)  # type: ignore[no-untyped-call]
 
 
 def _interceptors(

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -31,10 +31,10 @@ class _ScsTokenClient:
         return self._endpoint
 
     def generate_disposable_token(
-            self,
-            permission_scope: DisposableTokenScope,
-            expiresIn: ExpiresIn,
-            disposable_token_props: Optional[DisposableTokenProps]
+        self,
+        permission_scope: DisposableTokenScope,
+        expiresIn: ExpiresIn,
+        disposable_token_props: Optional[DisposableTokenProps],
     ) -> GenerateDisposableTokenResponse:
         try:
             validate_disposable_token_expiry(expiresIn)
@@ -49,8 +49,8 @@ class _ScsTokenClient:
                 permissions=permissions,
                 token_id=token_id,
             )
-            response = self._build_stub().GenerateDisposableToken(request) # type: ignore[misc]
-            return GenerateDisposableToken.Success.from_grpc_response(response) # type: ignore[misc]
+            response = self._build_stub().GenerateDisposableToken(request)  # type: ignore[misc]
+            return GenerateDisposableToken.Success.from_grpc_response(response)  # type: ignore[misc]
         except Exception as e:
             self._logger.debug("Failed to generate disposable token with exception: %s", e)
             return GenerateDisposableToken.Error(convert_error(e, Service.AUTH))
@@ -60,5 +60,3 @@ class _ScsTokenClient:
 
     def close(self) -> None:
         self._grpc_manager.close()
-
-

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -33,18 +33,20 @@ class _ScsTokenClient:
     def generate_disposable_token(
         self,
         permission_scope: DisposableTokenScope,
-        expiresIn: ExpiresIn,
+        expires_in: ExpiresIn,
+        credentialProvider: CredentialProvider,
         disposable_token_props: Optional[DisposableTokenProps],
     ) -> GenerateDisposableTokenResponse:
         try:
-            validate_disposable_token_expiry(expiresIn)
+            validate_disposable_token_expiry(expires_in)
             self._logger.info("Creating disposable token")
 
             token_id = disposable_token_props.token_id if disposable_token_props else None
-            expires = token_pb._GenerateDisposableTokenRequest.Expires(expiresIn.valid_for_seconds())
+            expires = token_pb._GenerateDisposableTokenRequest.Expires(expires_in.valid_for_seconds())
             permissions = permissions_from_disposable_token_scope(permission_scope)
 
             request = token_pb._GenerateDisposableTokenRequest(
+                auth_token=credentialProvider.get_auth_token(),
                 expires=expires,
                 permissions=permissions,
                 token_id=token_id,

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+from momento_wire_types import token_pb2 as token_pb
+from momento_wire_types import token_pb2_grpc as token_grpc
+
+from momento import logs
+from momento.auth import CredentialProvider
+from momento.auth.access_control.disposable_token_scope import DisposableTokenProps, DisposableTokenScope
+from momento.config.auth_configuration import AuthConfiguration
+from momento.errors import convert_error
+from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
+from momento.internal.services import Service
+from momento.internal.synchronous._scs_grpc_manager import _TokenGrpcManager
+from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
+from momento.utilities.expiration import ExpiresIn
+from momento.utilities.shared_sync_asyncio import validate_disposable_token_expiry
+
+
+class _ScsTokenClient:
+    """Momento Internal token client."""
+
+    def __init__(self, configuration: AuthConfiguration, credential_provider: CredentialProvider):
+        endpoint = credential_provider.token_endpoint
+        self._logger = logs.logger
+        self._logger.debug("Simple token client instantiated with endpoint: %s", endpoint)
+        self._grpc_manager = _TokenGrpcManager(configuration, credential_provider)
+        self._endpoint = endpoint
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    def generate_disposable_token(
+            self,
+            permission_scope: DisposableTokenScope,
+            expiresIn: ExpiresIn,
+            disposable_token_props: Optional[DisposableTokenProps]
+    ) -> GenerateDisposableTokenResponse:
+        try:
+            validate_disposable_token_expiry(expiresIn)
+            self._logger.info("Creating disposable token")
+
+            token_id = disposable_token_props.token_id if disposable_token_props else None
+            expires = token_pb._GenerateDisposableTokenRequest.Expires(expiresIn.valid_for_seconds())
+            permissions = permissions_from_disposable_token_scope(permission_scope)
+
+            request = token_pb._GenerateDisposableTokenRequest(
+                expires=expires,
+                permissions=permissions,
+                token_id=token_id,
+            )
+            response = self._build_stub().GenerateDisposableToken(request) # type: ignore[misc]
+            return GenerateDisposableToken.Success.from_grpc_response(response) # type: ignore[misc]
+        except Exception as e:
+            self._logger.debug("Failed to generate disposable token with exception: %s", e)
+            return GenerateDisposableToken.Error(convert_error(e, Service.AUTH))
+
+    def _build_stub(self) -> token_grpc.TokenStub:
+        return self._grpc_manager.stub()
+
+    def close(self) -> None:
+        self._grpc_manager.close()
+
+

--- a/src/momento/responses/__init__.py
+++ b/src/momento/responses/__init__.py
@@ -13,6 +13,7 @@ you can access the concrete types in the namespace of the name, eg:
 
 from momento.responses.control.cache.flush import CacheFlush, CacheFlushResponse
 
+from .auth.generate_disposable_token import GenerateDisposableTokenResponse
 from .control.cache.create import CreateCache, CreateCacheResponse
 from .control.cache.delete import DeleteCache, DeleteCacheResponse
 from .control.cache.list import ListCaches, ListCachesResponse
@@ -125,7 +126,7 @@ from .pubsub.subscription_item import (
     TopicSubscriptionItem,
     TopicSubscriptionItemResponse,
 )
-from .response import CacheResponse, ControlResponse, PubsubResponse
+from .response import AuthResponse, CacheResponse, ControlResponse, PubsubResponse
 
 __all__ = [
     "CreateCache",
@@ -224,4 +225,6 @@ __all__ = [
     "CacheResponse",
     "ControlResponse",
     "PubsubResponse",
+    "AuthResponse",
+    "GenerateDisposableTokenResponse",
 ]

--- a/src/momento/responses/auth/generate_disposable_token.py
+++ b/src/momento/responses/auth/generate_disposable_token.py
@@ -61,7 +61,9 @@ class GenerateDisposableToken(ABC):
             self.expiresAt = expiresAt
 
         @staticmethod
-        def from_grpc_response(grpc_response: token_pb._GenerateDisposableTokenResponse) -> GenerateDisposableToken.Success:
+        def from_grpc_response(
+            grpc_response: token_pb._GenerateDisposableTokenResponse,
+        ) -> GenerateDisposableToken.Success:
             """Initializes GenerateDisposableTokenResponse to handle generate disposable token response.
 
             Args:

--- a/src/momento/responses/auth/generate_disposable_token.py
+++ b/src/momento/responses/auth/generate_disposable_token.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from abc import ABC
+from dataclasses import dataclass
 
 from momento_wire_types import token_pb2 as token_pb
 
@@ -45,6 +46,7 @@ class GenerateDisposableTokenResponse(AuthResponse):
 class GenerateDisposableToken(ABC):
     """Groups all `GenerateDisposableTokenResponse` derived types under a common namespace."""
 
+    @dataclass
     class Success(GenerateDisposableTokenResponse):
         """Indicates the request was successful."""
 

--- a/src/momento/responses/auth/generate_disposable_token.py
+++ b/src/momento/responses/auth/generate_disposable_token.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from abc import ABC
+
+from momento_wire_types import token_pb2 as token_pb
+
+from momento.responses.response import AuthResponse
+from momento.utilities.shared_sync_asyncio import ExpiresAt
+
+from ..mixins import ErrorResponseMixin
+
+
+class GenerateDisposableTokenResponse(AuthResponse):
+    """Parent response type for a generate disposable token request.
+
+    The response object is resolved to a type-safe object of one of
+    the following subtypes:
+    - `GenerateDisposableToken.Success`
+    - `GenerateDisposableToken.Error`
+
+    Pattern matching can be used to operate on the appropriate subtype.
+    For example, in python 3.10+::
+
+        match response:
+            case GenerateDisposableToken.Success():
+                ...
+            case GenerateDisposableToken.Error():
+                ...
+            case _:
+                # Shouldn't happen
+
+    or equivalently in earlier versions of python::
+
+        if isinstance(response, GenerateDisposableToken.Success):
+            ...
+        elif isinstance(response, GenerateDisposableToken.Error):
+            ...
+        else:
+            # Shouldn't happen
+    """
+
+
+class GenerateDisposableToken(ABC):
+    """Groups all `GenerateDisposableTokenResponse` derived types under a common namespace."""
+
+    authToken: str
+    """The generated disposable token."""
+
+    endpoint: str
+    """The endpoint the Momento client should use when making requests."""
+
+    expiresAt: ExpiresAt
+    """The time at which the disposable token will expire."""
+
+    class Success(GenerateDisposableTokenResponse):
+        """Indicates the request was successful."""
+
+        @staticmethod
+        def from_grpc_response(grpc_response: token_pb._GenerateDisposableTokenResponse) -> GenerateDisposableToken.Success:
+            """Initializes GenerateDisposableTokenResponse to handle generate disposable token response.
+
+            Args:
+                grpc_response: Protobuf based response returned by token service.
+            """
+            return GenerateDisposableToken.Success(authToken=grpc_response.authToken, endpoint=grpc_response.endpoint, expiresAt=ExpiresAt(grpc_response.valid_until))
+
+    class Error(GenerateDisposableTokenResponse, ErrorResponseMixin):
+        """Contains information about an error returned from a request.
+
+        This includes:
+        - `error_code`: `MomentoErrorCode` value for the error.
+        - `messsage`: a detailed error message.
+        """

--- a/src/momento/responses/auth/generate_disposable_token.py
+++ b/src/momento/responses/auth/generate_disposable_token.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import json
 from abc import ABC
 
 from momento_wire_types import token_pb2 as token_pb
@@ -46,19 +48,19 @@ class GenerateDisposableToken(ABC):
     class Success(GenerateDisposableTokenResponse):
         """Indicates the request was successful."""
 
-        authToken: str
+        auth_token: str
         """The generated disposable token."""
 
         endpoint: str
         """The endpoint the Momento client should use when making requests."""
 
-        expiresAt: ExpiresAt
+        expires_at: ExpiresAt
         """The time at which the disposable token will expire."""
 
-        def __init__(self, authToken: str, endpoint: str, expiresAt: ExpiresAt):
-            self.authToken = authToken
+        def __init__(self, auth_token: str, endpoint: str, expires_at: ExpiresAt):
+            self.auth_token = auth_token
             self.endpoint = endpoint
-            self.expiresAt = expiresAt
+            self.expires_at = expires_at
 
         @staticmethod
         def from_grpc_response(
@@ -69,8 +71,11 @@ class GenerateDisposableToken(ABC):
             Args:
                 grpc_response: Protobuf based response returned by token service.
             """
+            to_b64_encode = {"endpoint": grpc_response.endpoint, "api_key": grpc_response.api_key}
+            byte_string = json.dumps(to_b64_encode).encode("utf-8")
+            auth_token = base64.b64encode(byte_string).decode("utf-8")
             return GenerateDisposableToken.Success(
-                grpc_response.authToken, grpc_response.endpoint, ExpiresAt(grpc_response.valid_until)
+                auth_token, grpc_response.endpoint, ExpiresAt(grpc_response.valid_until)
             )
 
     class Error(GenerateDisposableTokenResponse, ErrorResponseMixin):

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -130,3 +130,6 @@ class ControlResponse(Response):
 
 class PubsubResponse(Response):
     ...
+
+class AuthResponse(Response):
+    ...

--- a/src/momento/responses/response.py
+++ b/src/momento/responses/response.py
@@ -131,5 +131,6 @@ class ControlResponse(Response):
 class PubsubResponse(Response):
     ...
 
+
 class AuthResponse(Response):
     ...

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
 import math
-from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
 
-class Expiration(ABC):
+@dataclass
+class Expiration():
     """Represents an expiration time for a token."""
 
     def __init__(self, does_expire: bool) -> None:
         self._does_expire = does_expire
 
-    @abstractmethod
     def does_expire(self) -> bool:
-        pass
+        return self._does_expire
 
 
 class ExpiresIn(Expiration):
@@ -29,9 +29,6 @@ class ExpiresIn(Expiration):
             self.validFor = math.inf
         else:
             self.validFor = validFor
-
-    def does_expire(self) -> bool:
-        return self._does_expire
 
     def valid_for_seconds(self) -> int:
         return int(self.validFor)
@@ -73,9 +70,6 @@ class ExpiresAt(Expiration):
 
     # Must be a float in order to use math.inf to indicate non-expiration
     expires_at: float
-
-    def does_expire(self) -> bool:
-        return self._does_expire
 
     def __init__(self, epochTimestamp: Optional[float] = None) -> None:
         super().__init__(epochTimestamp is not None and epochTimestamp != 0)

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -22,12 +22,13 @@ class Expiration(ABC):
 class ExpiresIn(Expiration):
     """Represents an expiration time for a token that expires in a certain amount of time."""
 
-    validFor: int
+    # Must be a float in order to use math.inf to indicate non-expiration
+    validFor: float
 
-    def __init__(self, validFor: Optional[int] = int(math.inf)) -> None:
-        super().__init__(validFor != int(math.inf))
+    def __init__(self, validFor: Optional[float] = math.inf) -> None:
+        super().__init__(validFor != math.inf)
         if validFor is None:
-            self.validFor = int(math.inf)
+            self.validFor = math.inf
         else:
             self.validFor = validFor
 
@@ -35,11 +36,11 @@ class ExpiresIn(Expiration):
         return self._does_expire
 
     def valid_for_seconds(self) -> int:
-        return self.validFor
+        return int(self.validFor)
 
     @staticmethod
     def never() -> ExpiresIn:
-        return ExpiresIn(int(math.inf))
+        return ExpiresIn(math.inf)
 
     @staticmethod
     def seconds(validForSeconds: int) -> ExpiresIn:
@@ -72,21 +73,22 @@ class ExpiresIn(Expiration):
 class ExpiresAt(Expiration):
     """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
 
-    expiresAt: int
+    # Must be a float in order to use math.inf to indicate non-expiration
+    expiresAt: float
 
     def does_expire(self) -> bool:
         return self._does_expire
 
-    def __init__(self, epochTimestamp: Optional[int] = None) -> None:
+    def __init__(self, epochTimestamp: Optional[float] = None) -> None:
         super().__init__(epochTimestamp is not None and epochTimestamp != 0)
         if self._does_expire and epochTimestamp is not None:
             self.expiresAt = epochTimestamp
         else:
-            self.expiresAt = int(math.inf)
+            self.expiresAt = math.inf
 
     def epoch(self) -> int:
         """Returns epoch timestamp of when api token expires."""
-        return self.expiresAt
+        return int(self.expiresAt)
 
     @staticmethod
     def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 
 @dataclass
-class Expiration():
+class Expiration:
     """Represents an expiration time for a token."""
 
     def __init__(self, does_expire: bool) -> None:

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -22,17 +22,15 @@ class ExpiresIn(Expiration):
     """Represents an expiration time for a token that expires in a certain amount of time."""
 
     # Must be a float in order to use math.inf to indicate non-expiration
-    valid_for: float
-
     def __init__(self, valid_for: Optional[float] = math.inf) -> None:
         super().__init__(valid_for != math.inf)
         if valid_for is None:
-            self.valid_for = math.inf
+            self._valid_for = math.inf
         else:
-            self.valid_for = valid_for
+            self._valid_for = valid_for
 
     def valid_for_seconds(self) -> int:
-        return int(self.valid_for)
+        return int(self._valid_for)
 
     @staticmethod
     def never() -> ExpiresIn:
@@ -71,18 +69,16 @@ class ExpiresAt(Expiration):
     """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
 
     # Must be a float in order to use math.inf to indicate non-expiration
-    expires_at: float
-
     def __init__(self, epoch_timestamp: Optional[float] = None) -> None:
         super().__init__(epoch_timestamp is not None and epoch_timestamp != 0)
         if self._does_expire and epoch_timestamp is not None:
-            self.expires_at = epoch_timestamp
+            self._expires_at = epoch_timestamp
         else:
-            self.expires_at = math.inf
+            self._expires_at = math.inf
 
     def epoch(self) -> int:
         """Returns epoch timestamp of when api token expires."""
-        return int(self.expires_at)
+        return int(self._expires_at)
 
     @staticmethod
     def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -74,7 +74,7 @@ class ExpiresAt(Expiration):
     """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
 
     # Must be a float in order to use math.inf to indicate non-expiration
-    expiresAt: float
+    expires_at: float
 
     def does_expire(self) -> bool:
         return self._does_expire
@@ -82,13 +82,13 @@ class ExpiresAt(Expiration):
     def __init__(self, epochTimestamp: Optional[float] = None) -> None:
         super().__init__(epochTimestamp is not None and epochTimestamp != 0)
         if self._does_expire and epochTimestamp is not None:
-            self.expiresAt = epochTimestamp
+            self.expires_at = epochTimestamp
         else:
-            self.expiresAt = math.inf
+            self.expires_at = math.inf
 
     def epoch(self) -> int:
         """Returns epoch timestamp of when api token expires."""
-        return int(self.expiresAt)
+        return int(self.expires_at)
 
     @staticmethod
     def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -9,8 +9,6 @@ from typing import Optional
 class Expiration(ABC):
     """Represents an expiration time for a token."""
 
-    _does_expire: bool
-
     def __init__(self, does_expire: bool) -> None:
         self._does_expire = does_expire
 

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -22,47 +22,47 @@ class ExpiresIn(Expiration):
     """Represents an expiration time for a token that expires in a certain amount of time."""
 
     # Must be a float in order to use math.inf to indicate non-expiration
-    validFor: float
+    valid_for: float
 
-    def __init__(self, validFor: Optional[float] = math.inf) -> None:
-        super().__init__(validFor != math.inf)
-        if validFor is None:
-            self.validFor = math.inf
+    def __init__(self, valid_for: Optional[float] = math.inf) -> None:
+        super().__init__(valid_for != math.inf)
+        if valid_for is None:
+            self.valid_for = math.inf
         else:
-            self.validFor = validFor
+            self.valid_for = valid_for
 
     def valid_for_seconds(self) -> int:
-        return int(self.validFor)
+        return int(self.valid_for)
 
     @staticmethod
     def never() -> ExpiresIn:
         return ExpiresIn(math.inf)
 
     @staticmethod
-    def seconds(validForSeconds: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in seconds. If seconds are undefined, or null, then token never expires."""
-        return ExpiresIn(validForSeconds)
+    def seconds(valid_for_seconds: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified valid_for period in seconds. If seconds are undefined, or null, then token never expires."""
+        return ExpiresIn(valid_for_seconds)
 
     @staticmethod
-    def minutes(validForMinutes: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in minutes."""
-        return ExpiresIn(validForMinutes * 60)
+    def minutes(valid_for_minutes: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified valid_for period in minutes."""
+        return ExpiresIn(valid_for_minutes * 60)
 
     @staticmethod
-    def hours(validForHours: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in hours."""
-        return ExpiresIn(validForHours * 3600)
+    def hours(valid_for_hours: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified valid_for period in hours."""
+        return ExpiresIn(valid_for_hours * 3600)
 
     @staticmethod
-    def days(validForDays: int) -> ExpiresIn:
-        """Constructs an ExpiresIn with a specified validFor period in days."""
-        return ExpiresIn(validForDays * 86400)
+    def days(valid_for_days: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified valid_for period in days."""
+        return ExpiresIn(valid_for_days * 86400)
 
     @staticmethod
-    def epoch(expiresBy: int) -> ExpiresIn:
-        """Constructs an ExpiresIn with a specified expiresBy period in epoch format."""
+    def epoch(expires_by: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified expires_by period in epoch format."""
         current_epoch = int(datetime.now().timestamp())
-        seconds_until_epoch = expiresBy - current_epoch
+        seconds_until_epoch = expires_by - current_epoch
         return ExpiresIn(seconds_until_epoch)
 
 
@@ -73,10 +73,10 @@ class ExpiresAt(Expiration):
     # Must be a float in order to use math.inf to indicate non-expiration
     expires_at: float
 
-    def __init__(self, epochTimestamp: Optional[float] = None) -> None:
-        super().__init__(epochTimestamp is not None and epochTimestamp != 0)
-        if self._does_expire and epochTimestamp is not None:
-            self.expires_at = epochTimestamp
+    def __init__(self, epoch_timestamp: Optional[float] = None) -> None:
+        super().__init__(epoch_timestamp is not None and epoch_timestamp != 0)
+        if self._does_expire and epoch_timestamp is not None:
+            self.expires_at = epoch_timestamp
         else:
             self.expires_at = math.inf
 

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
+
+
+class Expiration(ABC):
+    """Represents an expiration time for a token."""
+
+    _does_expire: bool
+
+    def __init__(self, does_expire: bool) -> None:
+        self._does_expire = does_expire
+
+    @abstractmethod
+    def does_expire(self) -> bool:
+        pass
+
+
+class ExpiresIn(Expiration):
+    """Represents an expiration time for a token that expires in a certain amount of time."""
+
+    validFor: int
+
+    def __init__(self, validFor: Optional[int] = int(math.inf)) -> None:
+        super().__init__(validFor != int(math.inf))
+        if validFor is None:
+            self.validFor = int(math.inf)
+        else:
+            self.validFor = validFor
+
+    def does_expire(self) -> bool:
+        return self._does_expire
+
+    def valid_for_seconds(self) -> int:
+        return self.validFor
+
+    @staticmethod
+    def never() -> ExpiresIn:
+        return ExpiresIn(int(math.inf))
+
+    @staticmethod
+    def seconds(validForSeconds: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in seconds. If seconds are undefined, or null, then token never expires."""
+        return ExpiresIn(validForSeconds)
+
+    @staticmethod
+    def minutes(validForMinutes: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in minutes."""
+        return ExpiresIn(validForMinutes * 60)
+
+    @staticmethod
+    def hours(validForHours: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in hours."""
+        return ExpiresIn(validForHours * 3600)
+
+    @staticmethod
+    def days(validForDays: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified validFor period in days."""
+        return ExpiresIn(validForDays * 86400)
+
+    @staticmethod
+    def epoch(expiresBy: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified expiresBy period in epoch format."""
+        current_epoch = int(datetime.now().timestamp())
+        seconds_until_epoch = expiresBy - current_epoch
+        return ExpiresIn(seconds_until_epoch)
+
+
+class ExpiresAt(Expiration):
+    """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
+
+    expiresAt: int
+
+    def does_expire(self) -> bool:
+        return self._does_expire
+
+    def __init__(self, epochTimestamp: Optional[int] = None) -> None:
+        super().__init__(epochTimestamp is not None and epochTimestamp != 0)
+        if self._does_expire and epochTimestamp is not None:
+            self.expiresAt = epochTimestamp
+        else:
+            self.expiresAt = int(math.inf)
+
+    def epoch(self) -> int:
+        """Returns epoch timestamp of when api token expires."""
+        return self.expiresAt
+
+    @staticmethod
+    def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:
+        """Constructs an ExpiresAt with the specified epoch timestamp. If timestamp is undefined, then epoch timestamp will instead be Infinity."""
+        return ExpiresAt(epoch)

--- a/src/momento/utilities/expiration.py
+++ b/src/momento/utilities/expiration.py
@@ -17,6 +17,7 @@ class Expiration():
         return self._does_expire
 
 
+@dataclass
 class ExpiresIn(Expiration):
     """Represents an expiration time for a token that expires in a certain amount of time."""
 
@@ -65,6 +66,7 @@ class ExpiresIn(Expiration):
         return ExpiresIn(seconds_until_epoch)
 
 
+@dataclass
 class ExpiresAt(Expiration):
     """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
 

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import math
-from abc import ABC, abstractmethod
-from datetime import time, timedelta
-from typing import Optional
+from datetime import timedelta
+
+from momento.utilities.expiration import ExpiresIn
 
 DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS = 30
 
@@ -12,87 +11,10 @@ def validate_eager_connection_timeout(timeout: timedelta) -> None:
     if timeout.total_seconds() < 0:
         raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
 
-
-class Expiration(ABC):
-    """Represents an expiration time for a token."""
-
-    _does_expire: bool
-
-    def __init__(self, does_expire: bool) -> None:
-        self._does_expire = does_expire
-
-    @abstractmethod
-    def does_expire(self) -> bool:
-        pass
-
-
-class ExpiresIn(Expiration):
-    """Represents an expiration time for a token that expires in a certain amount of time."""
-
-    validFor: int
-
-    def __init__(self, validFor: Optional[int] = math.inf) -> None:
-        super().__init__(validFor != math.inf)
-        self.validFor = validFor
-
-    def does_expire(self) -> bool:
-        return self._does_expire
-
-    def valid_for_seconds(self) -> int:
-        return self.validFor
-
-    @staticmethod
-    def never() -> ExpiresIn:
-        return ExpiresIn(math.inf)
-
-    @staticmethod
-    def seconds(validForSeconds: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in seconds. If seconds are undefined, or null, then token never expires."""
-        return ExpiresIn(validForSeconds)
-
-    @staticmethod
-    def minutes(validForMinutes: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in minutes."""
-        return ExpiresIn(validForMinutes * 60)
-
-    @staticmethod
-    def hours(validForHours: int) -> ExpiresIn:
-        """Constructs a ExpiresIn with a specified validFor period in hours."""
-        return ExpiresIn(validForHours * 3600)
-
-    @staticmethod
-    def days(validForDays: int) -> ExpiresIn:
-        """Constructs an ExpiresIn with a specified validFor period in days."""
-        return ExpiresIn(validForDays * 86400)
-
-    @staticmethod
-    def epoch(expiresBy: int) -> ExpiresIn:
-        """Constructs an ExpiresIn with a specified expiresBy period in epoch format."""
-        current_epoch = int(time.time())
-        seconds_until_epoch = expiresBy - current_epoch
-        return ExpiresIn(seconds_until_epoch)
-
-
-class ExpiresAt(Expiration):
-    """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
-
-    expiresAt: int
-
-    def does_expire(self) -> bool:
-        return self._does_expire
-
-    def __init__(self, epochTimestamp: Optional[int] = None) -> None:
-        super().__init__(epochTimestamp is not None and epochTimestamp != 0)
-        if self._does_expire:
-            self.expiresAt = epochTimestamp
-        else:
-            self.expiresAt = math.inf
-
-    def epoch(self) -> int:
-        """Returns epoch timestamp of when api token expires."""
-        return self.expiresAt
-
-    @staticmethod
-    def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:
-        """Constructs an ExpiresAt with the specified epoch timestamp. If timestamp is undefined, then epoch timestamp will instead be Infinity."""
-        return ExpiresAt(epoch)
+def validate_disposable_token_expiry(expiresIn: ExpiresIn) -> None:
+    if not expiresIn.does_expire():
+        raise ValueError("Disposable tokens must have an expiry")
+    if expiresIn.valid_for_seconds() < 0:
+        raise ValueError("Disposable token expiry must be positive")
+    if expiresIn.valid_for_seconds() > 60*60:
+        raise ValueError("Disposable tokens must expire within 1 hour")

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -11,10 +11,11 @@ def validate_eager_connection_timeout(timeout: timedelta) -> None:
     if timeout.total_seconds() < 0:
         raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
 
+
 def validate_disposable_token_expiry(expiresIn: ExpiresIn) -> None:
     if not expiresIn.does_expire():
         raise ValueError("Disposable tokens must have an expiry")
     if expiresIn.valid_for_seconds() < 0:
         raise ValueError("Disposable token expiry must be positive")
-    if expiresIn.valid_for_seconds() > 60*60:
+    if expiresIn.valid_for_seconds() > 60 * 60:
         raise ValueError("Disposable tokens must expire within 1 hour")

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -12,10 +12,10 @@ def validate_eager_connection_timeout(timeout: timedelta) -> None:
         raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
 
 
-def validate_disposable_token_expiry(expiresIn: ExpiresIn) -> None:
-    if not expiresIn.does_expire():
+def validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
+    if not expires_in.does_expire():
         raise ValueError("Disposable tokens must have an expiry")
-    if expiresIn.valid_for_seconds() < 0:
+    if expires_in.valid_for_seconds() < 0:
         raise ValueError("Disposable token expiry must be positive")
-    if expiresIn.valid_for_seconds() > 60 * 60:
+    if expires_in.valid_for_seconds() > 60 * 60:
         raise ValueError("Disposable tokens must expire within 1 hour")

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -1,4 +1,9 @@
-from datetime import timedelta
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from datetime import time, timedelta
+from typing import Optional
 
 DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS = 30
 
@@ -6,3 +11,88 @@ DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS = 30
 def validate_eager_connection_timeout(timeout: timedelta) -> None:
     if timeout.total_seconds() < 0:
         raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
+
+
+class Expiration(ABC):
+    """Represents an expiration time for a token."""
+
+    _does_expire: bool
+
+    def __init__(self, does_expire: bool) -> None:
+        self._does_expire = does_expire
+
+    @abstractmethod
+    def does_expire(self) -> bool:
+        pass
+
+
+class ExpiresIn(Expiration):
+    """Represents an expiration time for a token that expires in a certain amount of time."""
+
+    validFor: int
+
+    def __init__(self, validFor: Optional[int] = math.inf) -> None:
+        super().__init__(validFor != math.inf)
+        self.validFor = validFor
+
+    def does_expire(self) -> bool:
+        return self._does_expire
+
+    def valid_for_seconds(self) -> int:
+        return self.validFor
+
+    @staticmethod
+    def never() -> ExpiresIn:
+        return ExpiresIn(math.inf)
+
+    @staticmethod
+    def seconds(validForSeconds: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in seconds. If seconds are undefined, or null, then token never expires."""
+        return ExpiresIn(validForSeconds)
+
+    @staticmethod
+    def minutes(validForMinutes: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in minutes."""
+        return ExpiresIn(validForMinutes * 60)
+
+    @staticmethod
+    def hours(validForHours: int) -> ExpiresIn:
+        """Constructs a ExpiresIn with a specified validFor period in hours."""
+        return ExpiresIn(validForHours * 3600)
+
+    @staticmethod
+    def days(validForDays: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified validFor period in days."""
+        return ExpiresIn(validForDays * 86400)
+
+    @staticmethod
+    def epoch(expiresBy: int) -> ExpiresIn:
+        """Constructs an ExpiresIn with a specified expiresBy period in epoch format."""
+        current_epoch = int(time.time())
+        seconds_until_epoch = expiresBy - current_epoch
+        return ExpiresIn(seconds_until_epoch)
+
+
+class ExpiresAt(Expiration):
+    """Represents an expiration time for a token that expires at a certain UNIX epoch timestamp."""
+
+    expiresAt: int
+
+    def does_expire(self) -> bool:
+        return self._does_expire
+
+    def __init__(self, epochTimestamp: Optional[int] = None) -> None:
+        super().__init__(epochTimestamp is not None and epochTimestamp != 0)
+        if self._does_expire:
+            self.expiresAt = epochTimestamp
+        else:
+            self.expiresAt = math.inf
+
+    def epoch(self) -> int:
+        """Returns epoch timestamp of when api token expires."""
+        return self.expiresAt
+
+    @staticmethod
+    def from_epoch(epoch: Optional[int] = None) -> ExpiresAt:
+        """Constructs an ExpiresAt with the specified epoch timestamp. If timestamp is undefined, then epoch timestamp will instead be Infinity."""
+        return ExpiresAt(epoch)

--- a/tests/momento/auth_client/test_auth_client.py
+++ b/tests/momento/auth_client/test_auth_client.py
@@ -1,0 +1,204 @@
+from datetime import timedelta
+
+from momento import errors
+from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
+from momento.auth.access_control.permission_scope import AllCaches
+from momento.auth.access_control.permission_scopes import cache_read_only
+from momento.auth.credential_provider import CredentialProvider
+from momento.auth_client import AuthClient
+from momento.cache_client import CacheClient
+from momento.config.configurations import Configurations
+from momento.config.topic_configurations import TopicConfigurations
+from momento.responses.auth.generate_disposable_token import GenerateDisposableToken
+from momento.responses.data.scalar.get import CacheGet
+from momento.responses.data.scalar.set import CacheSet
+from momento.responses.pubsub.publish import TopicPublish
+from momento.responses.pubsub.subscribe import TopicSubscribe
+from momento.topic_client import TopicClient
+from momento.utilities.expiration import ExpiresIn
+
+from tests.utils import uuid_str
+
+###### Beginning of helper functions ######
+
+
+def cache_client_from_disposable_token(token: str) -> CacheClient:
+    return CacheClient(
+        Configurations.Laptop.latest(),
+        CredentialProvider.from_string(token),
+        timedelta(seconds=30),
+    )
+
+
+def topic_client_from_disposable_token(token: str) -> TopicClient:
+    return TopicClient(
+        TopicConfigurations.Default.latest(),
+        CredentialProvider.from_string(token),
+    )
+
+
+def generate_disposable_token_success(auth_client: AuthClient, scope: DisposableTokenScope) -> str:
+    resp = auth_client.generate_disposable_token(scope, ExpiresIn.minutes(2))
+    assert isinstance(resp, GenerateDisposableToken.Success)
+    return resp.auth_token
+
+
+def assert_get_success(cache_client: CacheClient, cache_name: str, key: str) -> None:
+    get_resp = cache_client.get(cache_name, key)
+    assert not isinstance(get_resp, CacheGet.Error)
+
+
+def assert_get_failure(cache_client: CacheClient, cache_name: str, key: str) -> None:
+    get_resp = cache_client.get(cache_name, key)
+    assert isinstance(get_resp, CacheGet.Error)
+    assert get_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+def assert_set_success(cache_client: CacheClient, cache_name: str, key: str, value: str) -> None:
+    set_resp = cache_client.set(cache_name, key, value)
+    assert isinstance(set_resp, CacheSet.Success)
+
+
+def assert_set_failure(cache_client: CacheClient, cache_name: str, key: str, value: str) -> None:
+    set_resp = cache_client.set(cache_name, key, value)
+    assert isinstance(set_resp, CacheSet.Error)
+    assert set_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+def assert_publish_success(topic_client: TopicClient, cache_name: str, topic_name: str) -> None:
+    publish_resp = topic_client.publish(cache_name, topic_name, uuid_str())
+    assert isinstance(publish_resp, TopicPublish.Success)
+
+
+def assert_publish_failure(topic_client: TopicClient, cache_name: str, topic_name: str) -> None:
+    publish_resp = topic_client.publish(cache_name, topic_name, uuid_str())
+    assert isinstance(publish_resp, TopicPublish.Error)
+    assert publish_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+def assert_subscribe_success(topic_client: TopicClient, cache_name: str, topic_name: str) -> None:
+    subscribe_resp = topic_client.subscribe(cache_name, topic_name)
+    assert not isinstance(subscribe_resp, TopicSubscribe.Error)
+
+
+def assert_subscribe_failure(topic_client: TopicClient, cache_name: str, topic_name: str) -> None:
+    subscribe_resp = topic_client.subscribe(cache_name, topic_name)
+    assert isinstance(subscribe_resp, TopicSubscribe.Error)
+    assert subscribe_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+###### Beginning of tests ######
+
+
+def test_generate_disposable_token_read_only_all_caches(
+    client: CacheClient,  # need this to create the test caches
+    auth_client: AuthClient,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScope(permission_scope=cache_read_only(AllCaches()).get_permissions_objects())
+    token = generate_disposable_token_success(auth_client, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed regardless of cache
+    assert_get_success(cc, cache_name, key)
+    assert_get_success(cc, alternate_cache_name, key)
+    # Sets should fail regardless of cache
+    assert_set_failure(cc, cache_name, key, value)
+    assert_set_failure(cc, alternate_cache_name, key, value)
+    assert True
+
+
+def test_generate_disposable_token_read_only_specific_cache(auth_client: AuthClient) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_only_specific_key_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_only_key_prefix_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_write_only_all_caches(auth_client: AuthClient) -> None:
+    assert True
+
+
+def test_generate_disposable_token_write_only_specific_cache(auth_client: AuthClient) -> None:
+    assert True
+
+
+def test_generate_disposable_token_write_only_specific_key_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_write_only_key_prefix_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_write_all_caches(auth_client: AuthClient) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_write_specific_cache(auth_client: AuthClient) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_write_specific_key_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_read_write_key_prefix_specific_cache(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_publish_only_specific_cache_specific_topic(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_publish_only_all_caches_all_topics(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_subscribe_only_specific_cache_specific_topic(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_subscribe_only_all_caches_all_topics(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_publish_subscribe_specific_cache_specific_topic(
+    auth_client: AuthClient,
+) -> None:
+    assert True
+
+
+def test_generate_disposable_token_topic_publish_subscribe_all_caches_all_topics(
+    auth_client: AuthClient,
+) -> None:
+    assert True

--- a/tests/momento/auth_client/test_auth_client_async.py
+++ b/tests/momento/auth_client/test_auth_client_async.py
@@ -1,0 +1,204 @@
+from datetime import timedelta
+
+from momento import errors
+from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
+from momento.auth.access_control.permission_scope import AllCaches
+from momento.auth.access_control.permission_scopes import cache_read_only
+from momento.auth.credential_provider import CredentialProvider
+from momento.auth_client_async import AuthClientAsync
+from momento.cache_client_async import CacheClientAsync
+from momento.config.configurations import Configurations
+from momento.config.topic_configurations import TopicConfigurations
+from momento.responses.auth.generate_disposable_token import GenerateDisposableToken
+from momento.responses.data.scalar.get import CacheGet
+from momento.responses.data.scalar.set import CacheSet
+from momento.responses.pubsub.publish import TopicPublish
+from momento.responses.pubsub.subscribe import TopicSubscribe
+from momento.topic_client_async import TopicClientAsync
+from momento.utilities.expiration import ExpiresIn
+
+from tests.utils import uuid_str
+
+###### Beginning of helper functions ######
+
+
+def cache_client_from_disposable_token(token: str) -> CacheClientAsync:
+    return CacheClientAsync(
+        Configurations.Laptop.latest(),
+        CredentialProvider.from_string(token),
+        timedelta(seconds=30),
+    )
+
+
+def topic_client_from_disposable_token(token: str) -> TopicClientAsync:
+    return TopicClientAsync(
+        TopicConfigurations.Default.latest(),
+        CredentialProvider.from_string(token),
+    )
+
+
+async def generate_disposable_token_success(auth_client_async: AuthClientAsync, scope: DisposableTokenScope) -> str:
+    resp = await auth_client_async.generate_disposable_token(scope, ExpiresIn.minutes(2))
+    assert isinstance(resp, GenerateDisposableToken.Success)
+    return resp.auth_token
+
+
+async def assert_get_success(cache_client_async: CacheClientAsync, cache_name: str, key: str) -> None:
+    get_resp = await cache_client_async.get(cache_name, key)
+    assert not isinstance(get_resp, CacheGet.Error)
+
+
+async def assert_get_failure(cache_client_async: CacheClientAsync, cache_name: str, key: str) -> None:
+    get_resp = await cache_client_async.get(cache_name, key)
+    assert isinstance(get_resp, CacheGet.Error)
+    assert get_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+async def assert_set_success(cache_client_async: CacheClientAsync, cache_name: str, key: str, value: str) -> None:
+    set_resp = await cache_client_async.set(cache_name, key, value)
+    assert isinstance(set_resp, CacheSet.Success)
+
+
+async def assert_set_failure(cache_client_async: CacheClientAsync, cache_name: str, key: str, value: str) -> None:
+    set_resp = await cache_client_async.set(cache_name, key, value)
+    assert isinstance(set_resp, CacheSet.Error)
+    assert set_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+async def assert_publish_success(topic_client_async: TopicClientAsync, cache_name: str, topic_name: str) -> None:
+    publish_resp = await topic_client_async.publish(cache_name, topic_name, uuid_str())
+    assert isinstance(publish_resp, TopicPublish.Success)
+
+
+async def assert_publish_failure(topic_client_async: TopicClientAsync, cache_name: str, topic_name: str) -> None:
+    publish_resp = await topic_client_async.publish(cache_name, topic_name, uuid_str())
+    assert isinstance(publish_resp, TopicPublish.Error)
+    assert publish_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+async def assert_subscribe_success(topic_client_async: TopicClientAsync, cache_name: str, topic_name: str) -> None:
+    subscribe_resp = await topic_client_async.subscribe(cache_name, topic_name)
+    assert not isinstance(subscribe_resp, TopicSubscribe.Error)
+
+
+async def assert_subscribe_failure(topic_client_async: TopicClientAsync, cache_name: str, topic_name: str) -> None:
+    subscribe_resp = await topic_client_async.subscribe(cache_name, topic_name)
+    assert isinstance(subscribe_resp, TopicSubscribe.Error)
+    assert subscribe_resp.error_code == errors.MomentoErrorCode.PERMISSION_ERROR
+
+
+###### Beginning of tests ######
+
+
+async def test_generate_disposable_token_read_only_all_caches(
+    client_async: CacheClientAsync,  # need this to create the test caches
+    auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScope(permission_scope=cache_read_only(AllCaches()).get_permissions_objects())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed regardless of cache
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_success(cc, alternate_cache_name, key)
+    # Sets should fail regardless of cache
+    await assert_set_failure(cc, cache_name, key, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
+    assert True
+
+
+async def test_generate_disposable_token_read_only_specific_cache(auth_client_async: AuthClientAsync) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_only_specific_key_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_only_key_prefix_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_write_only_all_caches(auth_client_async: AuthClientAsync) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_write_only_specific_cache(auth_client_async: AuthClientAsync) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_write_only_specific_key_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_write_only_key_prefix_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_write_all_caches(auth_client_async: AuthClientAsync) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_write_specific_cache(auth_client_async: AuthClientAsync) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_write_specific_key_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_read_write_key_prefix_specific_cache(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_publish_only_specific_cache_specific_topic(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_publish_only_all_caches_all_topics(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_subscribe_only_specific_cache_specific_topic(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_subscribe_only_all_caches_all_topics(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_publish_subscribe_specific_cache_specific_topic(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True
+
+
+async def test_generate_disposable_token_topic_publish_subscribe_all_caches_all_topics(
+    auth_client_async: AuthClientAsync,
+) -> None:
+    assert True

--- a/tests/momento/auth_client/test_auth_client_async.py
+++ b/tests/momento/auth_client/test_auth_client_async.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from momento import errors
 from momento.auth.access_control.disposable_token_scope import DisposableTokenScope
 from momento.auth.access_control.disposable_token_scopes import DisposableTokenScopes
-from momento.auth.access_control.permission_scope import AllCaches
+from momento.auth.access_control.permission_scope import AllCaches, AllTopics
 from momento.auth.credential_provider import CredentialProvider
 from momento.auth_client_async import AuthClientAsync
 from momento.cache_client_async import CacheClientAsync
@@ -135,88 +135,392 @@ async def test_generate_disposable_token_read_only_specific_cache(
 
 
 async def test_generate_disposable_token_read_only_specific_key_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = uuid_str()
+    key2 = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_read_only(cache_name, key)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed only for the specified cache and key
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_failure(cc, cache_name, key2)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should fail regardless of cache
+    await assert_set_failure(cc, cache_name, key, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_read_only_key_prefix_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = "a-prefix-" + uuid_str()
+    key2 = "a-prefix-" + uuid_str()
+    key3 = "another-prefix-" + uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_prefix_read_only(cache_name, "a-prefix-")
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed only for the specified cache and key prefix
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_success(cc, cache_name, key2)
+    await assert_get_failure(cc, cache_name, key3)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should fail regardless of cache
+    await assert_set_failure(cc, cache_name, key, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
-async def test_generate_disposable_token_write_only_all_caches(auth_client_async: AuthClientAsync) -> None:
-    assert True
+async def test_generate_disposable_token_write_only_all_caches(
+    client_async: CacheClientAsync,  # need this to create the test caches
+    auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_write_only(AllCaches())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should fail regardless of cache
+    await assert_get_failure(cc, cache_name, key)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed regardless of cache
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_success(cc, alternate_cache_name, key, value)
 
 
-async def test_generate_disposable_token_write_only_specific_cache(auth_client_async: AuthClientAsync) -> None:
-    assert True
+async def test_generate_disposable_token_write_only_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
+    auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_write_only(cache_name)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should fail regardless of cache
+    await assert_get_failure(cc, cache_name, key)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_write_only_specific_key_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = uuid_str()
+    key2 = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_write_only(cache_name, key)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should fail regardless of cache
+    await assert_get_failure(cc, cache_name, key)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache and key
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_failure(cc, cache_name, key2, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_write_only_key_prefix_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = "a-prefix-" + uuid_str()
+    key2 = "a-prefix-" + uuid_str()
+    key3 = "another-prefix-" + uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_prefix_write_only(cache_name, "a-prefix-")
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should fail regardless of cache
+    await assert_get_failure(cc, cache_name, key)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache and key prefix
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_success(cc, cache_name, key2, value)
+    await assert_set_failure(cc, cache_name, key3, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
-async def test_generate_disposable_token_read_write_all_caches(auth_client_async: AuthClientAsync) -> None:
-    assert True
+async def test_generate_disposable_token_read_write_all_caches(
+    client_async: CacheClientAsync,  # need this to create the test caches
+    auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_read_write(AllCaches())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed regardless of cache
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_success(cc, alternate_cache_name, key)
+
+    # Sets should succeed regardless of cache
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_success(cc, alternate_cache_name, key, value)
 
 
-async def test_generate_disposable_token_read_write_specific_cache(auth_client_async: AuthClientAsync) -> None:
-    assert True
+async def test_generate_disposable_token_read_write_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
+    auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
+) -> None:
+    key = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_read_write(cache_name)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed only for the specified cache
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_read_write_specific_key_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = uuid_str()
+    key2 = uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_read_write(cache_name, key)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed only for the specified cache and key
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_failure(cc, cache_name, key2)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache and key
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_failure(cc, cache_name, key2, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_read_write_key_prefix_specific_cache(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    key = "a-prefix-" + uuid_str()
+    key2 = "a-prefix-" + uuid_str()
+    key3 = "another-prefix-" + uuid_str()
+    value = uuid_str()
+
+    scope = DisposableTokenScopes.cache_key_prefix_read_write(cache_name, "a-prefix-")
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    cc = cache_client_from_disposable_token(token)
+
+    # Gets should succeed only for the specified cache and key prefix
+    await assert_get_success(cc, cache_name, key)
+    await assert_get_success(cc, cache_name, key2)
+    await assert_get_failure(cc, cache_name, key3)
+    await assert_get_failure(cc, alternate_cache_name, key)
+
+    # Sets should succeed only for the specified cache and key prefix
+    await assert_set_success(cc, cache_name, key, value)
+    await assert_set_success(cc, cache_name, key2, value)
+    await assert_set_failure(cc, cache_name, key3, value)
+    await assert_set_failure(cc, alternate_cache_name, key, value)
 
 
 async def test_generate_disposable_token_topic_publish_only_specific_cache_specific_topic(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_publish_only(cache_name, topic_name)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should succeed only for the specified cache and topic
+    await assert_publish_success(tc, cache_name, topic_name)
+    await assert_publish_failure(tc, cache_name, topic_name2)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should fail regardless of cache
+    await assert_subscribe_failure(tc, cache_name, topic_name)
+    await assert_subscribe_failure(tc, alternate_cache_name, topic_name)
 
 
 async def test_generate_disposable_token_topic_publish_only_all_caches_all_topics(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_publish_only(AllCaches(), AllTopics())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should succeed regardless of cache and topic
+    await assert_publish_success(tc, cache_name, topic_name)
+    await assert_publish_success(tc, cache_name, topic_name2)
+    await assert_publish_success(tc, alternate_cache_name, topic_name)
+    await assert_publish_success(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should fail regardless of cache
+    await assert_subscribe_failure(tc, cache_name, topic_name)
+    await assert_subscribe_failure(tc, alternate_cache_name, topic_name)
 
 
 async def test_generate_disposable_token_topic_subscribe_only_specific_cache_specific_topic(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_subscribe_only(cache_name, topic_name)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should fail regardless of cache and topic
+    await assert_publish_failure(tc, cache_name, topic_name)
+    await assert_publish_failure(tc, cache_name, topic_name2)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should succeed only for the specified cache and topic
+    await assert_subscribe_success(tc, cache_name, topic_name)
+    await assert_subscribe_failure(tc, cache_name, topic_name2)
+    await assert_subscribe_failure(tc, alternate_cache_name, topic_name)
 
 
 async def test_generate_disposable_token_topic_subscribe_only_all_caches_all_topics(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_subscribe_only(AllCaches(), AllTopics())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should fail regardless of cache and topic
+    await assert_publish_failure(tc, cache_name, topic_name)
+    await assert_publish_failure(tc, cache_name, topic_name2)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should succeed regardless of cache and topic
+    await assert_subscribe_success(tc, cache_name, topic_name)
+    await assert_subscribe_success(tc, cache_name, topic_name2)
+    await assert_subscribe_success(tc, alternate_cache_name, topic_name)
+    await assert_subscribe_success(tc, alternate_cache_name, topic_name2)
 
 
 async def test_generate_disposable_token_topic_publish_subscribe_specific_cache_specific_topic(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_publish_subscribe(cache_name, topic_name)
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should succeed only for the specified cache and topic
+    await assert_publish_success(tc, cache_name, topic_name)
+    await assert_publish_failure(tc, cache_name, topic_name2)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name)
+    await assert_publish_failure(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should succeed only for the specified cache and topic
+    await assert_subscribe_success(tc, cache_name, topic_name)
+    await assert_subscribe_failure(tc, cache_name, topic_name2)
+    await assert_subscribe_failure(tc, alternate_cache_name, topic_name)
+    await assert_subscribe_failure(tc, alternate_cache_name, topic_name)
 
 
 async def test_generate_disposable_token_topic_publish_subscribe_all_caches_all_topics(
+    client_async: CacheClientAsync,  # need this to create the test caches
     auth_client_async: AuthClientAsync,
+    cache_name: str,
+    alternate_cache_name: str,
 ) -> None:
-    assert True
+    topic_name = uuid_str()
+    topic_name2 = uuid_str()
+
+    scope = DisposableTokenScopes.topic_publish_subscribe(AllCaches(), AllTopics())
+    token = await generate_disposable_token_success(auth_client_async, scope)
+    tc = topic_client_from_disposable_token(token)
+
+    # Publishes should succeed regardless of cache and topic
+    await assert_publish_success(tc, cache_name, topic_name)
+    await assert_publish_success(tc, cache_name, topic_name2)
+    await assert_publish_success(tc, alternate_cache_name, topic_name)
+    await assert_publish_success(tc, alternate_cache_name, topic_name2)
+
+    # Subscribes should succeed regardless of cache and topic
+    await assert_subscribe_success(tc, cache_name, topic_name)
+    await assert_subscribe_success(tc, cache_name, topic_name2)
+    await assert_subscribe_success(tc, alternate_cache_name, topic_name)
+    await assert_subscribe_success(tc, alternate_cache_name, topic_name)

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -1,26 +1,23 @@
-from momento.auth.access_control.disposable_token_scope import DisposableTokenCachePermissions, DisposableTokenScope
-from momento.auth.access_control.disposable_token_scopes import (
-    cache_key_prefix_read_only,
-    cache_key_prefix_read_write,
-    cache_key_prefix_write_only,
-    cache_key_read_only,
-    cache_key_read_write,
-    cache_key_write_only,
+from momento.auth.access_control.disposable_token_scope import (
+    CacheItemKey,
+    CacheItemKeyPrefix,
+    CacheItemSelector,
+    DisposableTokenCachePermission,
+    DisposableTokenCachePermissions,
+    DisposableTokenScope,
 )
 from momento.auth.access_control.permission_scope import (
     ALL_DATA_READ_WRITE,
     AllCaches,
     AllTopics,
+    CachePermission,
+    CacheRole,
+    CacheSelector,
     Permissions,
     PermissionScope,
-)
-from momento.auth.access_control.permission_scopes import (
-    cache_read_only,
-    cache_read_write,
-    cache_write_only,
-    topic_publish_only,
-    topic_publish_subscribe,
-    topic_subscribe_only,
+    TopicPermission,
+    TopicRole,
+    TopicSelector,
 )
 from momento.internal._utilities._permissions import (
     SuperuserPermissions,
@@ -106,12 +103,28 @@ def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissi
         PermissionScope(
             permission_scope=Permissions(
                 permissions=[
-                    cache_read_only(AllCaches()),
-                    cache_read_write(cache="foo"),
-                    topic_subscribe_only(cache=AllCaches(), topic=AllTopics()),
-                    topic_publish_subscribe(cache="foo", topic=AllTopics()),
-                    topic_publish_subscribe(cache=AllCaches(), topic="bar"),
-                    topic_publish_subscribe(cache="dog", topic="cat"),
+                    CachePermission(role=CacheRole.READ_ONLY, cache_selector=CacheSelector(AllCaches())),
+                    CachePermission(role=CacheRole.READ_WRITE, cache_selector=CacheSelector("foo")),
+                    TopicPermission(
+                        role=TopicRole.SUBSCRIBE_ONLY,
+                        cache_selector=CacheSelector(AllCaches()),
+                        topic_selector=TopicSelector(AllTopics()),
+                    ),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_SUBSCRIBE,
+                        cache_selector=CacheSelector("foo"),
+                        topic_selector=TopicSelector(AllTopics()),
+                    ),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_SUBSCRIBE,
+                        cache_selector=CacheSelector(AllCaches()),
+                        topic_selector=TopicSelector("bar"),
+                    ),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_SUBSCRIBE,
+                        cache_selector=CacheSelector("dog"),
+                        topic_selector=TopicSelector("cat"),
+                    ),
                 ]
             )
         )
@@ -160,11 +173,23 @@ def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permis
         PermissionScope(
             permission_scope=Permissions(
                 permissions=[
-                    cache_write_only(AllCaches()),
-                    cache_write_only(cache="foo"),
-                    topic_publish_only(cache="foo", topic=AllTopics()),
-                    topic_publish_only(cache=AllCaches(), topic="bar"),
-                    topic_publish_only(cache="dog", topic="cat"),
+                    CachePermission(role=CacheRole.WRITE_ONLY, cache_selector=CacheSelector(AllCaches())),
+                    CachePermission(role=CacheRole.WRITE_ONLY, cache_selector=CacheSelector("foo")),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_ONLY,
+                        cache_selector=CacheSelector("foo"),
+                        topic_selector=TopicSelector(AllTopics()),
+                    ),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_ONLY,
+                        cache_selector=CacheSelector(AllCaches()),
+                        topic_selector=TopicSelector("bar"),
+                    ),
+                    TopicPermission(
+                        role=TopicRole.PUBLISH_ONLY,
+                        cache_selector=CacheSelector("dog"),
+                        topic_selector=TopicSelector("cat"),
+                    ),
                 ]
             )
         )
@@ -197,8 +222,16 @@ def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and
         DisposableTokenScope(
             permission_scope=DisposableTokenCachePermissions(
                 permissions=[
-                    cache_key_write_only(cache=AllCaches(), key="specific_key"),
-                    cache_key_prefix_write_only(cache="foo", key_prefix="specific_key_prefix"),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.WRITE_ONLY,
+                        cache=CacheSelector(AllCaches()),
+                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                    ),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.WRITE_ONLY,
+                        cache=CacheSelector("foo"),
+                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                    ),
                 ]
             )
         )
@@ -231,8 +264,16 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_
         DisposableTokenScope(
             permission_scope=DisposableTokenCachePermissions(
                 permissions=[
-                    cache_key_read_only(cache=AllCaches(), key="specific_key"),
-                    cache_key_prefix_read_only(cache="foo", key_prefix="specific_key_prefix"),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.READ_ONLY,
+                        cache=CacheSelector(AllCaches()),
+                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                    ),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.READ_ONLY,
+                        cache=CacheSelector("foo"),
+                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                    ),
                 ]
             )
         )
@@ -265,8 +306,16 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and
         DisposableTokenScope(
             permission_scope=DisposableTokenCachePermissions(
                 permissions=[
-                    cache_key_read_write(cache=AllCaches(), key="specific_key"),
-                    cache_key_prefix_read_write(cache="foo", key_prefix="specific_key_prefix"),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.READ_WRITE,
+                        cache=CacheSelector(AllCaches()),
+                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                    ),
+                    DisposableTokenCachePermission(
+                        role=CacheRole.READ_WRITE,
+                        cache=CacheSelector("foo"),
+                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                    ),
                 ]
             )
         )

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -31,7 +31,7 @@ from tests.utils import str_to_bytes
 
 def test_creates_expected_grpc_permissions_for_internal_superuser_permissions() -> None:
     expected_permission = permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)
-    constructed_permission = permissions_from_permission_scope(PermissionScope(permission_scope=SuperuserPermissions()))
+    constructed_permission = permissions_from_permission_scope(PermissionScope(SuperuserPermissions()))
     assert expected_permission == constructed_permission
 
 
@@ -46,14 +46,14 @@ def test_creates_expected_grpc_permissions_for_all_data_read_write() -> None:
         all_caches=permissions_pb.PermissionsType.All(),
     )
     expected_permission = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=expected_cache_permission),
                 permissions_pb.PermissionsType(topic_permissions=expected_topic_permission),
             ]
         )
     )
-    constructed_permission = permissions_from_permission_scope(PermissionScope(permission_scope=ALL_DATA_READ_WRITE))
+    constructed_permission = permissions_from_permission_scope(PermissionScope(ALL_DATA_READ_WRITE))
     assert expected_permission == constructed_permission
 
 
@@ -87,8 +87,8 @@ def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissi
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_any_cache),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_cache_foo),
                 permissions_pb.PermissionsType(topic_permissions=grpc_read_any_topic),
@@ -101,8 +101,8 @@ def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissi
 
     constructed_permissions = permissions_from_permission_scope(
         PermissionScope(
-            permission_scope=Permissions(
-                permissions=[
+            Permissions(
+                [
                     CachePermission(role=CacheRole.READ_ONLY, cache_selector=CacheSelector(AllCaches())),
                     CachePermission(role=CacheRole.READ_WRITE, cache_selector=CacheSelector("foo")),
                     TopicPermission(
@@ -158,8 +158,8 @@ def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permis
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo),
                 permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_all_topics_cache_foo),
@@ -171,8 +171,8 @@ def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permis
 
     constructed_permissions = permissions_from_permission_scope(
         PermissionScope(
-            permission_scope=Permissions(
-                permissions=[
+            Permissions(
+                [
                     CachePermission(role=CacheRole.WRITE_ONLY, cache_selector=CacheSelector(AllCaches())),
                     CachePermission(role=CacheRole.WRITE_ONLY, cache_selector=CacheSelector("foo")),
                     TopicPermission(
@@ -210,8 +210,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo_specific_key_prefix),
             ]
@@ -220,17 +220,17 @@ def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and
 
     constructed_permissions = permissions_from_disposable_token_scope(
         DisposableTokenScope(
-            permission_scope=DisposableTokenCachePermissions(
-                permissions=[
+            DisposableTokenCachePermissions(
+                [
                     DisposableTokenCachePermission(
-                        role=CacheRole.WRITE_ONLY,
-                        cache=CacheSelector(AllCaches()),
-                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                        CacheSelector(AllCaches()),
+                        CacheRole.WRITE_ONLY,
+                        CacheItemSelector(CacheItemKey("specific_key")),
                     ),
                     DisposableTokenCachePermission(
-                        role=CacheRole.WRITE_ONLY,
-                        cache=CacheSelector("foo"),
-                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                        CacheSelector("foo"),
+                        CacheRole.WRITE_ONLY,
+                        CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
                     ),
                 ]
             )
@@ -252,8 +252,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_only_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_only_cache_foo_specific_key_prefix),
             ]
@@ -262,17 +262,17 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_
 
     constructed_permissions = permissions_from_disposable_token_scope(
         DisposableTokenScope(
-            permission_scope=DisposableTokenCachePermissions(
-                permissions=[
+            DisposableTokenCachePermissions(
+                [
                     DisposableTokenCachePermission(
-                        role=CacheRole.READ_ONLY,
-                        cache=CacheSelector(AllCaches()),
-                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                        CacheSelector(AllCaches()),
+                        CacheRole.READ_ONLY,
+                        CacheItemSelector(CacheItemKey("specific_key")),
                     ),
                     DisposableTokenCachePermission(
-                        role=CacheRole.READ_ONLY,
-                        cache=CacheSelector("foo"),
-                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                        CacheSelector("foo"),
+                        CacheRole.READ_ONLY,
+                        CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
                     ),
                 ]
             )
@@ -294,8 +294,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(
-            permissions=[
+        explicit=permissions_pb.ExplicitPermissions(permissions=
+            [
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_write_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_write_cache_foo_specific_key_prefix),
             ]
@@ -304,17 +304,17 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and
 
     constructed_permissions = permissions_from_disposable_token_scope(
         DisposableTokenScope(
-            permission_scope=DisposableTokenCachePermissions(
-                permissions=[
+            DisposableTokenCachePermissions(
+                [
                     DisposableTokenCachePermission(
-                        role=CacheRole.READ_WRITE,
-                        cache=CacheSelector(AllCaches()),
-                        item=CacheItemSelector(CacheItemKey("specific_key")),
+                        CacheSelector(AllCaches()),
+                        CacheRole.READ_WRITE,
+                        CacheItemSelector(CacheItemKey("specific_key")),
                     ),
                     DisposableTokenCachePermission(
-                        role=CacheRole.READ_WRITE,
-                        cache=CacheSelector("foo"),
-                        item=CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
+                        CacheSelector("foo"),
+                        CacheRole.READ_WRITE,
+                        CacheItemSelector(CacheItemKeyPrefix("specific_key_prefix")),
                     ),
                 ]
             )

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -1,0 +1,243 @@
+from momento.auth.access_control.disposable_token_scope import DisposableTokenCachePermissions, DisposableTokenScope
+from momento.auth.access_control.disposable_token_scopes import (
+    cache_key_prefix_read_only,
+    cache_key_prefix_read_write,
+    cache_key_prefix_write_only,
+    cache_key_read_only,
+    cache_key_read_write,
+    cache_key_write_only,
+)
+from momento.auth.access_control.permission_scope import (
+    ALL_DATA_READ_WRITE,
+    AllCaches,
+    AllTopics,
+    Permissions,
+    PermissionScope,
+)
+from momento.auth.access_control.permission_scopes import (
+    cache_read_only,
+    cache_read_write,
+    cache_write_only,
+    topic_publish_only,
+    topic_publish_subscribe,
+    topic_subscribe_only,
+)
+from momento.internal._utilities._permissions import (
+    SuperuserPermissions,
+    permissions_from_disposable_token_scope,
+    permissions_from_permission_scope,
+)
+from momento_wire_types import permissionmessages_pb2 as permissions_pb
+
+from tests.utils import str_to_bytes
+
+
+def test_creates_expected_grpc_permissions_for_internal_superuser_permissions() -> None:
+    expected_permission = permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)
+    constructed_permission = permissions_from_permission_scope(PermissionScope(permission_scope=SuperuserPermissions()))
+    assert expected_permission == constructed_permission
+
+
+def test_creates_expected_grpc_permissions_for_all_data_read_write() -> None:
+    expected_topic_permission = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicReadWrite,
+        all_topics=permissions_pb.PermissionsType.All(),
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    expected_cache_permission = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadWrite,
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    expected_permission = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=expected_cache_permission),
+            permissions_pb.PermissionsType(topic_permissions=expected_topic_permission),
+        ]
+    ))
+    constructed_permission = permissions_from_permission_scope(PermissionScope(permission_scope=ALL_DATA_READ_WRITE))
+    assert expected_permission == constructed_permission
+
+
+def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissions() -> None:
+    grpc_read_any_cache = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadOnly,
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    grpc_write_cache_foo = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadWrite,
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+    )
+    grpc_read_any_topic = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicReadOnly,
+        all_topics=permissions_pb.PermissionsType.All(),
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    grpc_read_write_any_topic_in_cache_foo = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicReadWrite,
+        all_topics=permissions_pb.PermissionsType.All(),
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+    )
+    grpc_read_write_topic_bar_in_any_cache = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicReadWrite,
+        topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="bar"),
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    grpc_read_write_topic_cat_in_cache_dog = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicReadWrite,
+        topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="cat"),
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
+    )
+    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=grpc_read_any_cache),
+            permissions_pb.PermissionsType(cache_permissions=grpc_write_cache_foo),
+            permissions_pb.PermissionsType(topic_permissions=grpc_read_any_topic),
+            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_any_topic_in_cache_foo),
+            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_bar_in_any_cache),
+            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_cat_in_cache_dog),
+        ]
+    ))
+
+    constructed_permissions = permissions_from_permission_scope(
+        PermissionScope(permission_scope=Permissions(permissions=[
+            cache_read_only(AllCaches()),
+            cache_read_write(cache="foo"),
+            topic_subscribe_only(cache=AllCaches(), topic=AllTopics()),
+            topic_publish_subscribe(cache="foo", topic=AllTopics()),
+            topic_publish_subscribe(cache=AllCaches(), topic="bar"),
+            topic_publish_subscribe(cache="dog", topic="cat"),
+        ]))
+    )
+
+    assert expected_permissions == constructed_permissions
+
+
+def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permissions() -> None:
+    grpc_write_only_all_caches = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheWriteOnly,
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    grpc_write_only_cache_foo = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheWriteOnly,
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+    )
+    grpc_publish_only_all_topics_cache_foo = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicWriteOnly,
+        all_topics=permissions_pb.PermissionsType.All(),
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+    )
+    grpc_publish_only_topic_bar_all_caches = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicWriteOnly,
+        topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="bar"),
+        all_caches=permissions_pb.PermissionsType.All(),
+    )
+    grpc_publish_only_cache_dog_topic_cat = permissions_pb.PermissionsType.TopicPermissions(
+        role=permissions_pb.TopicWriteOnly,
+        topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="cat"),
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
+    )
+    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches),
+            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo),
+            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_all_topics_cache_foo),
+            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_topic_bar_all_caches),
+            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_cache_dog_topic_cat),
+        ]
+    ))
+
+    constructed_permissions = permissions_from_permission_scope(
+        PermissionScope(permission_scope=Permissions(permissions=[
+            cache_write_only(AllCaches()),
+            cache_write_only(cache="foo"),
+            topic_publish_only(cache="foo", topic=AllTopics()),
+            topic_publish_only(cache=AllCaches(), topic="bar"),
+            topic_publish_only(cache="dog", topic="cat"),
+        ]))
+    )
+
+    assert expected_permissions == constructed_permissions
+
+
+def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and_topic_specific_permissions() -> None:
+    grpc_write_only_all_caches_specific_key = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheWriteOnly,
+        all_caches=permissions_pb.PermissionsType.All(),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes("specific_key")),
+    )
+    grpc_write_only_cache_foo_specific_key_prefix = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheWriteOnly,
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
+    )
+    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches_specific_key),
+            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo_specific_key_prefix),
+        ]
+    ))
+
+    constructed_permissions = permissions_from_disposable_token_scope(
+        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
+            cache_key_write_only(cache=AllCaches(), key="specific_key"),
+            cache_key_prefix_write_only(cache="foo", key_prefix="specific_key_prefix"),
+        ]))
+    )
+
+    assert expected_permissions == constructed_permissions
+
+
+def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_topic_specific_permissions() -> None:
+    grpc_read_only_all_caches_specific_key = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadOnly,
+        all_caches=permissions_pb.PermissionsType.All(),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes("specific_key")),
+    )
+    grpc_read_only_cache_foo_specific_key_prefix = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadOnly,
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
+    )
+    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=grpc_read_only_all_caches_specific_key),
+            permissions_pb.PermissionsType(cache_permissions=grpc_read_only_cache_foo_specific_key_prefix),
+        ]
+    ))
+
+    constructed_permissions = permissions_from_disposable_token_scope(
+        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
+            cache_key_read_only(cache=AllCaches(), key="specific_key"),
+            cache_key_prefix_read_only(cache="foo", key_prefix="specific_key_prefix"),
+        ]))
+    )
+
+    assert expected_permissions == constructed_permissions
+
+
+def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and_topic_specific_permissions() -> None:
+    grpc_read_write_all_caches_specific_key = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadWrite,
+        all_caches=permissions_pb.PermissionsType.All(),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key=str_to_bytes("specific_key")),
+    )
+    grpc_read_write_cache_foo_specific_key_prefix = permissions_pb.PermissionsType.CachePermissions(
+        role=permissions_pb.CacheReadWrite,
+        cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
+        item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
+    )
+    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
+        permissions=[
+            permissions_pb.PermissionsType(cache_permissions=grpc_read_write_all_caches_specific_key),
+            permissions_pb.PermissionsType(cache_permissions=grpc_read_write_cache_foo_specific_key_prefix),
+        ]
+    ))
+
+    constructed_permissions = permissions_from_disposable_token_scope(
+        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
+            cache_key_read_write(cache=AllCaches(), key="specific_key"),
+            cache_key_prefix_read_write(cache="foo", key_prefix="specific_key_prefix"),
+        ]))
+    )
+
+    assert expected_permissions == constructed_permissions

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -46,8 +46,8 @@ def test_creates_expected_grpc_permissions_for_all_data_read_write() -> None:
         all_caches=permissions_pb.PermissionsType.All(),
     )
     expected_permission = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=expected_cache_permission),
                 permissions_pb.PermissionsType(topic_permissions=expected_topic_permission),
             ]
@@ -87,8 +87,8 @@ def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissi
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_any_cache),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_cache_foo),
                 permissions_pb.PermissionsType(topic_permissions=grpc_read_any_topic),
@@ -158,8 +158,8 @@ def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permis
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo),
                 permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_all_topics_cache_foo),
@@ -210,8 +210,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo_specific_key_prefix),
             ]
@@ -252,8 +252,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_only_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_only_cache_foo_specific_key_prefix),
             ]
@@ -294,8 +294,8 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
     expected_permissions = permissions_pb.Permissions(
-        explicit=permissions_pb.ExplicitPermissions(permissions=
-            [
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_write_all_caches_specific_key),
                 permissions_pb.PermissionsType(cache_permissions=grpc_read_write_cache_foo_specific_key_prefix),
             ]

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -48,12 +48,14 @@ def test_creates_expected_grpc_permissions_for_all_data_read_write() -> None:
         role=permissions_pb.CacheReadWrite,
         all_caches=permissions_pb.PermissionsType.All(),
     )
-    expected_permission = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=expected_cache_permission),
-            permissions_pb.PermissionsType(topic_permissions=expected_topic_permission),
-        ]
-    ))
+    expected_permission = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=expected_cache_permission),
+                permissions_pb.PermissionsType(topic_permissions=expected_topic_permission),
+            ]
+        )
+    )
     constructed_permission = permissions_from_permission_scope(PermissionScope(permission_scope=ALL_DATA_READ_WRITE))
     assert expected_permission == constructed_permission
 
@@ -87,26 +89,32 @@ def test_creates_expected_grpc_permissions_for_cache_and_topic_specific_permissi
         topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="cat"),
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
-    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=grpc_read_any_cache),
-            permissions_pb.PermissionsType(cache_permissions=grpc_write_cache_foo),
-            permissions_pb.PermissionsType(topic_permissions=grpc_read_any_topic),
-            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_any_topic_in_cache_foo),
-            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_bar_in_any_cache),
-            permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_cat_in_cache_dog),
-        ]
-    ))
+    expected_permissions = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=grpc_read_any_cache),
+                permissions_pb.PermissionsType(cache_permissions=grpc_write_cache_foo),
+                permissions_pb.PermissionsType(topic_permissions=grpc_read_any_topic),
+                permissions_pb.PermissionsType(topic_permissions=grpc_read_write_any_topic_in_cache_foo),
+                permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_bar_in_any_cache),
+                permissions_pb.PermissionsType(topic_permissions=grpc_read_write_topic_cat_in_cache_dog),
+            ]
+        )
+    )
 
     constructed_permissions = permissions_from_permission_scope(
-        PermissionScope(permission_scope=Permissions(permissions=[
-            cache_read_only(AllCaches()),
-            cache_read_write(cache="foo"),
-            topic_subscribe_only(cache=AllCaches(), topic=AllTopics()),
-            topic_publish_subscribe(cache="foo", topic=AllTopics()),
-            topic_publish_subscribe(cache=AllCaches(), topic="bar"),
-            topic_publish_subscribe(cache="dog", topic="cat"),
-        ]))
+        PermissionScope(
+            permission_scope=Permissions(
+                permissions=[
+                    cache_read_only(AllCaches()),
+                    cache_read_write(cache="foo"),
+                    topic_subscribe_only(cache=AllCaches(), topic=AllTopics()),
+                    topic_publish_subscribe(cache="foo", topic=AllTopics()),
+                    topic_publish_subscribe(cache=AllCaches(), topic="bar"),
+                    topic_publish_subscribe(cache="dog", topic="cat"),
+                ]
+            )
+        )
     )
 
     assert expected_permissions == constructed_permissions
@@ -136,24 +144,30 @@ def test_creates_expected_grpc_permissions_for_write_only_cache_and_topic_permis
         topic_selector=permissions_pb.PermissionsType.TopicSelector(topic_name="cat"),
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="dog"),
     )
-    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches),
-            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo),
-            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_all_topics_cache_foo),
-            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_topic_bar_all_caches),
-            permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_cache_dog_topic_cat),
-        ]
-    ))
+    expected_permissions = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches),
+                permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo),
+                permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_all_topics_cache_foo),
+                permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_topic_bar_all_caches),
+                permissions_pb.PermissionsType(topic_permissions=grpc_publish_only_cache_dog_topic_cat),
+            ]
+        )
+    )
 
     constructed_permissions = permissions_from_permission_scope(
-        PermissionScope(permission_scope=Permissions(permissions=[
-            cache_write_only(AllCaches()),
-            cache_write_only(cache="foo"),
-            topic_publish_only(cache="foo", topic=AllTopics()),
-            topic_publish_only(cache=AllCaches(), topic="bar"),
-            topic_publish_only(cache="dog", topic="cat"),
-        ]))
+        PermissionScope(
+            permission_scope=Permissions(
+                permissions=[
+                    cache_write_only(AllCaches()),
+                    cache_write_only(cache="foo"),
+                    topic_publish_only(cache="foo", topic=AllTopics()),
+                    topic_publish_only(cache=AllCaches(), topic="bar"),
+                    topic_publish_only(cache="dog", topic="cat"),
+                ]
+            )
+        )
     )
 
     assert expected_permissions == constructed_permissions
@@ -170,18 +184,24 @@ def test_creates_expected_grpc_permissions_for_key_specific_write_only_cache_and
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
-    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches_specific_key),
-            permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo_specific_key_prefix),
-        ]
-    ))
+    expected_permissions = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=grpc_write_only_all_caches_specific_key),
+                permissions_pb.PermissionsType(cache_permissions=grpc_write_only_cache_foo_specific_key_prefix),
+            ]
+        )
+    )
 
     constructed_permissions = permissions_from_disposable_token_scope(
-        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
-            cache_key_write_only(cache=AllCaches(), key="specific_key"),
-            cache_key_prefix_write_only(cache="foo", key_prefix="specific_key_prefix"),
-        ]))
+        DisposableTokenScope(
+            permission_scope=DisposableTokenCachePermissions(
+                permissions=[
+                    cache_key_write_only(cache=AllCaches(), key="specific_key"),
+                    cache_key_prefix_write_only(cache="foo", key_prefix="specific_key_prefix"),
+                ]
+            )
+        )
     )
 
     assert expected_permissions == constructed_permissions
@@ -198,18 +218,24 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_only_cache_and_
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
-    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=grpc_read_only_all_caches_specific_key),
-            permissions_pb.PermissionsType(cache_permissions=grpc_read_only_cache_foo_specific_key_prefix),
-        ]
-    ))
+    expected_permissions = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=grpc_read_only_all_caches_specific_key),
+                permissions_pb.PermissionsType(cache_permissions=grpc_read_only_cache_foo_specific_key_prefix),
+            ]
+        )
+    )
 
     constructed_permissions = permissions_from_disposable_token_scope(
-        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
-            cache_key_read_only(cache=AllCaches(), key="specific_key"),
-            cache_key_prefix_read_only(cache="foo", key_prefix="specific_key_prefix"),
-        ]))
+        DisposableTokenScope(
+            permission_scope=DisposableTokenCachePermissions(
+                permissions=[
+                    cache_key_read_only(cache=AllCaches(), key="specific_key"),
+                    cache_key_prefix_read_only(cache="foo", key_prefix="specific_key_prefix"),
+                ]
+            )
+        )
     )
 
     assert expected_permissions == constructed_permissions
@@ -226,18 +252,24 @@ def test_creates_expected_grpc_permissions_for_key_specific_read_write_cache_and
         cache_selector=permissions_pb.PermissionsType.CacheSelector(cache_name="foo"),
         item_selector=permissions_pb.PermissionsType.CacheItemSelector(key_prefix=str_to_bytes("specific_key_prefix")),
     )
-    expected_permissions = permissions_pb.Permissions(explicit=permissions_pb.ExplicitPermissions(
-        permissions=[
-            permissions_pb.PermissionsType(cache_permissions=grpc_read_write_all_caches_specific_key),
-            permissions_pb.PermissionsType(cache_permissions=grpc_read_write_cache_foo_specific_key_prefix),
-        ]
-    ))
+    expected_permissions = permissions_pb.Permissions(
+        explicit=permissions_pb.ExplicitPermissions(
+            permissions=[
+                permissions_pb.PermissionsType(cache_permissions=grpc_read_write_all_caches_specific_key),
+                permissions_pb.PermissionsType(cache_permissions=grpc_read_write_cache_foo_specific_key_prefix),
+            ]
+        )
+    )
 
     constructed_permissions = permissions_from_disposable_token_scope(
-        DisposableTokenScope(permission_scope=DisposableTokenCachePermissions(permissions=[
-            cache_key_read_write(cache=AllCaches(), key="specific_key"),
-            cache_key_prefix_read_write(cache="foo", key_prefix="specific_key_prefix"),
-        ]))
+        DisposableTokenScope(
+            permission_scope=DisposableTokenCachePermissions(
+                permissions=[
+                    cache_key_read_write(cache=AllCaches(), key="specific_key"),
+                    cache_key_prefix_read_write(cache="foo", key_prefix="specific_key_prefix"),
+                ]
+            )
+        )
     )
 
     assert expected_permissions == constructed_permissions


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1016

Will follow up with examples/docs updates.

To add the generate_disposable_token api, we needed to implement the AuthClient and permissions classes as well.

Note: Go sdk's permissions structure includes topic name prefix as well, but JS sdk does not. Should topic name prefix be added here?