### PR TITLE
chore: fall back manual version when dist-info absent

### DIFF
--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -4,15 +4,21 @@ This module is used to detect the version of momento installed. It is used
 internally to add the version to the gRPC headers.
 """
 
+from importlib.metadata import PackageNotFoundError
+
 momento_version = ""
 
 try:
-    # For python < 3.8
-    import importlib_metadata
+    try:
+        # For python < 3.8
+        import importlib_metadata
 
-    momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
-except (ImportError, ModuleNotFoundError):
-    # For python >= 3.8
-    from importlib.metadata import version  # type: ignore[import]
+        momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
+    except ImportError:
+        # For python >= 3.8
+        from importlib.metadata import version  # type: ignore[import]
 
-    momento_version = version("momento")
+        momento_version = version("momento")
+except (ImportError, ModuleNotFoundError, PackageNotFoundError):
+    # Fall back to setting to the version manually
+    momento_version = "1.21.2"

--- a/src/momento/internal/_utilities/_momento_version.py
+++ b/src/momento/internal/_utilities/_momento_version.py
@@ -4,21 +4,34 @@ This module is used to detect the version of momento installed. It is used
 internally to add the version to the gRPC headers.
 """
 
-from importlib.metadata import PackageNotFoundError
-
 momento_version = ""
+DEFAULT_MOMENTO_VERSION = "1.21.2"
+
+
+def set_momento_version(version: str) -> None:
+    """Set the version of momento installed.
+
+    Args:
+        version: The version of momento installed.
+    """
+    global momento_version
+    momento_version = version
+
 
 try:
-    try:
-        # For python < 3.8
-        import importlib_metadata
+    # For python < 3.8
+    import importlib_metadata
 
-        momento_version = importlib_metadata.Distribution.from_name("momento").version  # type: ignore[no-untyped-call,misc]
-    except ImportError:
-        # For python >= 3.8
-        from importlib.metadata import version  # type: ignore[import]
-
-        momento_version = version("momento")
-except (ImportError, ModuleNotFoundError, PackageNotFoundError):
+    set_momento_version(importlib_metadata.Distribution.from_name("momento").version)  # type: ignore[no-untyped-call,misc]
+except ModuleNotFoundError:
     # Fall back to setting to the version manually
-    momento_version = "1.21.2"
+    set_momento_version(DEFAULT_MOMENTO_VERSION)
+except ImportError:
+    # For python >= 3.8
+    from importlib.metadata import PackageNotFoundError, version  # type: ignore[import]
+
+    try:
+        set_momento_version(version("momento"))
+    except PackageNotFoundError:
+        # Fall back to setting to the version manually
+        set_momento_version(DEFAULT_MOMENTO_VERSION)


### PR DESCRIPTION
We temporarily fall back to a manually provided version number when
the `dist-info` METADATA is absent. This situation occurs in some
frameworks like `serverless` which strip this for a slim build.

In the near future we will refactor this code so that CI sets the
version number in the file and we do not rely on metadata reflection.
