### PR TITLE
fix: do not use test util in package

### DIFF
--- a/src/momento/auth_client.py
+++ b/src/momento/auth_client.py
@@ -9,7 +9,7 @@ from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.internal.synchronous._scs_token_client import _ScsTokenClient
 from momento.responses.auth.generate_disposable_token import GenerateDisposableTokenResponse
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 
 class AuthClient:

--- a/src/momento/auth_client_async.py
+++ b/src/momento/auth_client_async.py
@@ -9,7 +9,7 @@ from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.internal.aio._scs_token_client import _ScsTokenClient
 from momento.responses.auth.generate_disposable_token import GenerateDisposableTokenResponse
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 
 class AuthClientAsync:

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -8,10 +8,10 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
+from momento.internal._utilities._data_validation import validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,
-    validate_eager_connection_timeout,
 )
 
 try:

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -8,7 +8,7 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
-from momento.internal._utilities._data_validation import validate_eager_connection_timeout
+from momento.internal._utilities._data_validation import _validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,
@@ -206,7 +206,7 @@ class CacheClient:
             eager_connection_timeout = timedelta(seconds=30)
             client = CacheClient.create(configuration, credential_provider, ttl_seconds, eager_connection_timeout)
         """
-        validate_eager_connection_timeout(eager_connection_timeout)
+        _validate_eager_connection_timeout(eager_connection_timeout)
         # an explicit 0 means that the client disabled eager connections
         if eager_connection_timeout.total_seconds() != 0:
             client = CacheClient(configuration, credential_provider, default_ttl)

--- a/src/momento/cache_client.py
+++ b/src/momento/cache_client.py
@@ -8,7 +8,7 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
-from momento.internal._utilities._data_validation import _validate_eager_connection_timeout
+from momento.internal._utilities import _validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -8,10 +8,10 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
+from momento.internal._utilities._data_validation import validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,
-    validate_eager_connection_timeout,
 )
 
 try:

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -8,7 +8,7 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
-from momento.internal._utilities._data_validation import _validate_eager_connection_timeout
+from momento.internal._utilities import _validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,

--- a/src/momento/cache_client_async.py
+++ b/src/momento/cache_client_async.py
@@ -8,7 +8,7 @@ from momento import logs
 from momento.auth import CredentialProvider
 from momento.config import Configuration
 from momento.errors import UnknownException
-from momento.internal._utilities._data_validation import validate_eager_connection_timeout
+from momento.internal._utilities._data_validation import _validate_eager_connection_timeout
 from momento.requests import CollectionTtl, SortOrder
 from momento.utilities.shared_sync_asyncio import (
     DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS,
@@ -207,7 +207,7 @@ class CacheClientAsync:
             eager_connection_timeout = timedelta(seconds=30)
             client = CacheClientAsync.create(configuration, credential_provider, ttl_seconds, eager_connection_timeout)
         """
-        validate_eager_connection_timeout(eager_connection_timeout)
+        _validate_eager_connection_timeout(eager_connection_timeout)
         # an explicit 0 means that the client disabled eager connections
         if eager_connection_timeout.total_seconds() != 0:
             client = CacheClientAsync(configuration, credential_provider, default_ttl)

--- a/src/momento/internal/_utilities/__init__.py
+++ b/src/momento/internal/_utilities/__init__.py
@@ -7,6 +7,8 @@ from ._data_validation import (
     _gen_set_input_as_bytes,
     _validate_cache_name,
     _validate_dictionary_name,
+    _validate_disposable_token_expiry,
+    _validate_eager_connection_timeout,
     _validate_list_name,
     _validate_request_timeout,
     _validate_set_name,

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -15,6 +15,7 @@ from momento.typing import (
     TSortedSetElements,
     TSortedSetValues,
 )
+from momento.utilities.expiration import ExpiresIn
 
 DEFAULT_BYTES_CONVERSION_ERROR = "Could not convert the given type to bytes: "
 DEFAULT_LIST_CONVERSION_ERROR = "The given type is not list[str | bytes]: "
@@ -137,3 +138,17 @@ def _validate_request_timeout(request_timeout: Optional[timedelta]) -> None:
     if request_timeout is None:
         return
     _validate_timedelta_ttl(ttl=request_timeout, field_name="Request timeout")
+
+
+def validate_eager_connection_timeout(timeout: timedelta) -> None:
+    if timeout.total_seconds() < 0:
+        raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
+
+
+def validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
+    if not expires_in.does_expire():
+        raise ValueError("Disposable tokens must have an expiry")
+    if expires_in.valid_for_seconds() < 0:
+        raise ValueError("Disposable token expiry must be positive")
+    if expires_in.valid_for_seconds() > 60 * 60:
+        raise ValueError("Disposable tokens must expire within 1 hour")

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -15,7 +15,7 @@ from momento.typing import (
     TSortedSetElements,
     TSortedSetValues,
 )
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 DEFAULT_BYTES_CONVERSION_ERROR = "Could not convert the given type to bytes: "
 DEFAULT_LIST_CONVERSION_ERROR = "The given type is not list[str | bytes]: "

--- a/src/momento/internal/_utilities/_data_validation.py
+++ b/src/momento/internal/_utilities/_data_validation.py
@@ -140,12 +140,12 @@ def _validate_request_timeout(request_timeout: Optional[timedelta]) -> None:
     _validate_timedelta_ttl(ttl=request_timeout, field_name="Request timeout")
 
 
-def validate_eager_connection_timeout(timeout: timedelta) -> None:
+def _validate_eager_connection_timeout(timeout: timedelta) -> None:
     if timeout.total_seconds() < 0:
         raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
 
 
-def validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
+def _validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
     if not expires_in.does_expire():
         raise ValueError("Disposable tokens must have an expiry")
     if expires_in.valid_for_seconds() < 0:

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -25,7 +25,7 @@ from momento.auth.access_control.permission_scope import (
     TopicPermission,
     TopicRole,
 )
-from tests.utils import str_to_bytes
+from momento.utilities.shared_sync_asyncio import str_to_bytes
 
 
 class SuperuserPermissions(PredefinedScope):

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -8,12 +8,12 @@ from momento.auth.access_control.disposable_token_scope import DisposableTokenPr
 from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.errors.error_converter import convert_error
+from momento.internal._utilities._data_validation import validate_disposable_token_expiry
 from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
 from momento.internal.aio._scs_grpc_manager import _TokenGrpcManager
 from momento.internal.services import Service
 from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
 from momento.utilities.expiration import ExpiresIn
-from momento.utilities.shared_sync_asyncio import validate_disposable_token_expiry
 
 
 class _ScsTokenClient:

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -8,7 +8,7 @@ from momento.auth.access_control.disposable_token_scope import DisposableTokenPr
 from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.errors.error_converter import convert_error
-from momento.internal._utilities._data_validation import validate_disposable_token_expiry
+from momento.internal._utilities._data_validation import _validate_disposable_token_expiry
 from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
 from momento.internal.aio._scs_grpc_manager import _TokenGrpcManager
 from momento.internal.services import Service
@@ -38,7 +38,7 @@ class _ScsTokenClient:
         disposable_token_props: Optional[DisposableTokenProps] = None,
     ) -> GenerateDisposableTokenResponse:
         try:
-            validate_disposable_token_expiry(expires_in)
+            _validate_disposable_token_expiry(expires_in)
             self._logger.info("Creating disposable token")
 
             token_id = disposable_token_props.token_id if disposable_token_props else None

--- a/src/momento/internal/aio/_scs_token_client.py
+++ b/src/momento/internal/aio/_scs_token_client.py
@@ -13,7 +13,7 @@ from momento.internal._utilities._permissions import permissions_from_disposable
 from momento.internal.aio._scs_grpc_manager import _TokenGrpcManager
 from momento.internal.services import Service
 from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 
 class _ScsTokenClient:

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -8,7 +8,7 @@ from momento.auth.access_control.disposable_token_scope import DisposableTokenPr
 from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.errors.error_converter import convert_error
-from momento.internal._utilities._data_validation import validate_disposable_token_expiry
+from momento.internal._utilities._data_validation import _validate_disposable_token_expiry
 from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
 from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _TokenGrpcManager
@@ -38,7 +38,7 @@ class _ScsTokenClient:
         disposable_token_props: Optional[DisposableTokenProps] = None,
     ) -> GenerateDisposableTokenResponse:
         try:
-            validate_disposable_token_expiry(expires_in)
+            _validate_disposable_token_expiry(expires_in)
             self._logger.info("Creating disposable token")
 
             token_id = disposable_token_props.token_id if disposable_token_props else None

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -8,12 +8,12 @@ from momento.auth.access_control.disposable_token_scope import DisposableTokenPr
 from momento.auth.credential_provider import CredentialProvider
 from momento.config.auth_configuration import AuthConfiguration
 from momento.errors.error_converter import convert_error
+from momento.internal._utilities._data_validation import validate_disposable_token_expiry
 from momento.internal._utilities._permissions import permissions_from_disposable_token_scope
 from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _TokenGrpcManager
 from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
 from momento.utilities.expiration import ExpiresIn
-from momento.utilities.shared_sync_asyncio import validate_disposable_token_expiry
 
 
 class _ScsTokenClient:

--- a/src/momento/internal/synchronous/_scs_token_client.py
+++ b/src/momento/internal/synchronous/_scs_token_client.py
@@ -13,7 +13,7 @@ from momento.internal._utilities._permissions import permissions_from_disposable
 from momento.internal.services import Service
 from momento.internal.synchronous._scs_grpc_manager import _TokenGrpcManager
 from momento.responses.auth.generate_disposable_token import GenerateDisposableToken, GenerateDisposableTokenResponse
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 
 class _ScsTokenClient:

--- a/src/momento/responses/auth/generate_disposable_token.py
+++ b/src/momento/responses/auth/generate_disposable_token.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from momento_wire_types import token_pb2 as token_pb
 
 from momento.responses.response import AuthResponse
-from momento.utilities.expiration import ExpiresAt
+from momento.utilities import ExpiresAt
 
 from ..mixins import ErrorResponseMixin
 

--- a/src/momento/utilities/__init__.py
+++ b/src/momento/utilities/__init__.py
@@ -1,0 +1,2 @@
+from .expiration import Expiration, ExpiresAt, ExpiresIn
+from .shared_sync_asyncio import DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS, str_to_bytes

--- a/src/momento/utilities/__init__.py
+++ b/src/momento/utilities/__init__.py
@@ -1,2 +1,10 @@
 from .expiration import Expiration, ExpiresAt, ExpiresIn
 from .shared_sync_asyncio import DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS, str_to_bytes
+
+__all__ = [
+    "Expiration",
+    "ExpiresAt",
+    "ExpiresIn",
+    "DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS",
+    "str_to_bytes",
+]

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -1,24 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
-
-from momento.utilities.expiration import ExpiresIn
-
 DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS = 30
-
-
-def validate_eager_connection_timeout(timeout: timedelta) -> None:
-    if timeout.total_seconds() < 0:
-        raise ValueError("The eager connection timeout must be greater than or equal to 0 seconds.")
-
-
-def validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
-    if not expires_in.does_expire():
-        raise ValueError("Disposable tokens must have an expiry")
-    if expires_in.valid_for_seconds() < 0:
-        raise ValueError("Disposable token expiry must be positive")
-    if expires_in.valid_for_seconds() > 60 * 60:
-        raise ValueError("Disposable tokens must expire within 1 hour")
 
 
 def str_to_bytes(string: str) -> bytes:

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -19,3 +19,15 @@ def validate_disposable_token_expiry(expires_in: ExpiresIn) -> None:
         raise ValueError("Disposable token expiry must be positive")
     if expires_in.valid_for_seconds() > 60 * 60:
         raise ValueError("Disposable tokens must expire within 1 hour")
+
+
+def str_to_bytes(string: str) -> bytes:
+    """Convert a string to bytes.
+
+    Args:
+        string (str): The string to convert.
+
+    Returns:
+        bytes: A UTF-8 byte representation of the string.
+    """
+    return string.encode("utf-8")

--- a/src/momento/utilities/shared_sync_asyncio.py
+++ b/src/momento/utilities/shared_sync_asyncio.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 DEFAULT_EAGER_CONNECTION_TIMEOUT_SECONDS = 30
 
 

--- a/tests/momento/auth_client/test_auth_client.py
+++ b/tests/momento/auth_client/test_auth_client.py
@@ -15,7 +15,7 @@ from momento.responses.data.scalar.set import CacheSet
 from momento.responses.pubsub.publish import TopicPublish
 from momento.responses.pubsub.subscribe import TopicSubscribe
 from momento.topic_client import TopicClient
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 from tests.utils import uuid_str
 

--- a/tests/momento/auth_client/test_auth_client_async.py
+++ b/tests/momento/auth_client/test_auth_client_async.py
@@ -15,7 +15,7 @@ from momento.responses.data.scalar.set import CacheSet
 from momento.responses.pubsub.publish import TopicPublish
 from momento.responses.pubsub.subscribe import TopicSubscribe
 from momento.topic_client_async import TopicClientAsync
-from momento.utilities.expiration import ExpiresIn
+from momento.utilities import ExpiresIn
 
 from tests.utils import uuid_str
 


### PR DESCRIPTION
Ran into an error while writing new dev docs examples. Created a new `str_to_bytes` util function in the package proper rather than using the one from `tests.utils`. Bug appears to be fixed when running the examples against a locally built version of the package now.

```
File "/Users/anita/client-sdk-python/examples/.venv/lib/python3.10/site-packages/momento/internal/_utilities/_permissions.py", line 28, in <module>
    from tests.utils import str_to_bytes
ModuleNotFoundError: No module named 'tests'
```

Also moved the two validators to internal utils where the others are.