### PR TITLE
ci: set up with release please v4 and stub publish step

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
@@ -24,3 +24,42 @@ jobs:
           dev_docs_slug: python
           template_file: ./README.template.md
           output_file: ./README.md
+
+  release-please:
+    needs: [build]
+    runs-on: ubuntu-24.04
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: googleapis/release-please-action@v4
+        name: Release Please
+        id: release
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          release-type: python
+
+  publish-python:
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-24.04
+    env:
+      VERSION: ${{ needs.release-please.outputs.tag_name }}
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Publish package
+        run: |
+          set -e
+          set -x
+          if [ -z "$VERSION" ]
+          then
+            echo "Unable to determine SDK version!  Exiting!"
+            exit 1
+          fi
+          echo "Going to publish version=$VERSION"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,20 @@
+{
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": false
+    }
+  ],
+  "extra-files": ["src/momento/__init__.py"],
+}

--- a/src/momento/__init__.py
+++ b/src/momento/__init__.py
@@ -18,6 +18,8 @@ from .config import Configurations, TopicConfigurations
 from .topic_client import TopicClient
 from .topic_client_async import TopicClientAsync
 
+__version__ = "0.0.0"  # x-release-please-version
+
 logging.getLogger("momentosdk").addHandler(logging.NullHandler())
 logs.initialize_momento_logging()
 
@@ -31,4 +33,5 @@ __all__ = [
     "TopicClientAsync",
     "AuthClient",
     "AuthClientAsync",
+    "__version__",
 ]


### PR DESCRIPTION
Adds a release please job with v4.

Unlike v3, which we have in other repos, v4 requires a manifest
file for most of the options. We add that to the root of the
project. Also unlike v3, we also have to explicitly pass the release please
outputs from the release-please job to the publish job.

We have also verified setting the version in source. That happens with
the extra-files property in the manifest. The version in the main
`__init__` requires a stub version so the release please regex can
substitute it.

In an upcoming PR we will fill out the publish job in `on-push-to-main`.