### PR TITLE
ci: remove trailing comma in manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -16,5 +16,5 @@
       "hidden": false
     }
   ],
-  "extra-files": ["src/momento/__init__.py"],
+  "extra-files": ["src/momento/__init__.py"]
 }


### PR DESCRIPTION
Removes trailing comma in manifest, which was an error.

Release-Version: 1.23.4
