### PR TITLE
fix: set the release please base version in the manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -16,5 +16,6 @@
       "hidden": false
     }
   ],
-  "extra-files": ["src/momento/__init__.py"]
+  "extra-files": ["src/momento/__init__.py"],
+  ".": "1.23.3"
 }


### PR DESCRIPTION
Previously the manifest did not specify the base version for the first
release. We set that here explicitly so the first release has the
correct changelog.

Release-As: 1.23.4
