### PR TITLE
fix: lint errors on 3.10+ for auth protos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,19 @@ module = "momento.internal._utilities._momento_version"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
+# reading an enum in a protobuf generated class
+module = "momento.internal._utilities._permissions"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 disallow_any_expr = false
 disallow_any_decorated = false
 disallow_untyped_decorators = false
 
+[[tool.mypy.overrides]]
+module = "tests.momento.auth_client.test_permissions"
+ignore_errors = true
 
 [tool.ruff]
 select = [

--- a/src/momento/internal/_utilities/_permissions.py
+++ b/src/momento/internal/_utilities/_permissions.py
@@ -34,7 +34,7 @@ class SuperuserPermissions(PredefinedScope):
 
 def permissions_from_permission_scope(scope: PermissionScope) -> permissions_pb.Permissions:
     if isinstance(scope.permission_scope, SuperuserPermissions):
-        return permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)
+        return permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)  # type: ignore[attr-defined,misc]
     elif isinstance(scope.permission_scope, Permissions) and not isinstance(scope.permission_scope, PredefinedScope):
         converted_perms = [
             token_permission_to_grpc_permission(permission) for permission in scope.permission_scope.permissions

--- a/tests/momento/auth_client/test_permissions.py
+++ b/tests/momento/auth_client/test_permissions.py
@@ -30,7 +30,7 @@ from tests.utils import str_to_bytes
 
 
 def test_creates_expected_grpc_permissions_for_internal_superuser_permissions() -> None:
-    expected_permission = permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)
+    expected_permission = permissions_pb.Permissions(super_user=permissions_pb.SuperUserPermissions.SuperUser)  # type: ignore[attr-defined]
     constructed_permission = permissions_from_permission_scope(PermissionScope(SuperuserPermissions()))
     assert expected_permission == constructed_permission
 


### PR DESCRIPTION
Adds per-module ignores for generated auth protobuf.
