### PR TITLE
chore: release-please workflow should pick up feat, fix, and chore commits

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
           release-type: python
+          default-branch: main
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
 
   publish:
     needs: [release-please]


### PR DESCRIPTION
Recently merged #485 (marked as a `chore` commit) but a release-please PR wasn't opened.
This PR adds the missing `changelog-types` field to the release-please github action to ensure all `feat`, `fix`, and `chore` commits are picked up in the next release.