### PR TITLE
chore: specify path to release-please manifest

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -35,14 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: googleapis/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         name: Release Please
         id: release
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
           release-type: python
-          default-branch: main
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
+          manifest-file: .release-please-manifest.json
 
   publish:
     needs: [release-please]

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -40,8 +40,6 @@ jobs:
         id: release
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-          release-type: python
-          manifest-file: .release-please-manifest.json
 
   publish:
     needs: [release-please]

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v3
         name: Release Please
         id: release
         with:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "release-type": "python",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
Follow up to #486 -- release-please still did not produce a new PR to cut a new release.

~~I think switching the release-please github actions version to `v3` to match what the other SDKs use will allow the `changelog-types` field to be picked up and parse our commits correctly.~~

~~Update: using `v4` shouldn't be a problem. I think we're just missing the argument to specify the path to the manifest, as shown in their [example](https://github.com/googleapis/release-please-action?tab=readme-ov-file#advanced-release-configuration).~~

Found an [issue](https://github.com/googleapis/release-please-action/issues/941) in the release-please action that seems to show the same problem (action ends with "No user facing commits found since ... - skipping"), and the solution was to move all the configs into the manifest. Our file still had `release-type` as part of the github action yaml block.