### PR TITLE
ci: use release-please-config vs manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,24 +1,3 @@
 {
-  "release-type": "python",
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features",
-      "hidden": false
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes",
-      "hidden": false
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous",
-      "hidden": false
-    }
-  ],
-  "extra-files": [
-    "src/momento/__init__.py"
-  ],
   ".": "1.24.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous",
+          "hidden": false
+        }
+      ],
+      "extra-files": ["src/momento/__init__.py"]
+    }
+  }
+}


### PR DESCRIPTION
Put config settings in the config and only the version in the
manifest.

In v4 the manifest should have the release-please-maintained
package version, whereas the config should have everything else.

See:
- https://github.com/googleapis/release-please/blob/main/release-please-config.json
- https://github.com/googleapis/release-please-action/issues/941#issuecomment-2053795782
