### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/src/momento/internal/_utilities/_grpc_channel_options.py
+++ b/src/momento/internal/_utilities/_grpc_channel_options.py
@@ -35,6 +35,10 @@ def grpc_data_channel_options_from_grpc_config(grpc_config: GrpcConfiguration) -
         )
     )
 
+    channel_options.append(
+        ("grpc.service_config_disable_resolution", 1)
+    )
+
     keepalive_permit = grpc_config.get_keepalive_permit_without_calls()
     if keepalive_permit is not None:
         channel_options.append(("grpc.keepalive_permit_without_calls", keepalive_permit))

--- a/src/momento/internal/_utilities/_grpc_channel_options.py
+++ b/src/momento/internal/_utilities/_grpc_channel_options.py
@@ -35,9 +35,7 @@ def grpc_data_channel_options_from_grpc_config(grpc_config: GrpcConfiguration) -
         )
     )
 
-    channel_options.append(
-        ("grpc.service_config_disable_resolution", 1)
-    )
+    channel_options.append(("grpc.service_config_disable_resolution", 1))
 
     keepalive_permit = grpc_config.get_keepalive_permit_without_calls()
     if keepalive_permit is not None:


### PR DESCRIPTION
## PR Description:
- Based on the commit [here](https://github.com/googleapis/gapic-generator/pull/2817/files), dynamic txt lookup for dns resolution flag is disabled by default in grpc-python. 
- This commit explicitly disables it too.

### tcpdump when running existing example without adding the flag explicitly:
```
sudo tcpdump -i any -vvv port 53 | grep -i cache.cell-alpha-dev.preprod.a.momentohq.com           ─╯
Password:
tcpdump: data link type PKTAP
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    10.0.0.249.62558 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 23436+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    10.0.0.249.62558 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 25894+ A? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.62558: [udp sum ok] 23436 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.62558: [udp sum ok] 25894 q: A? cache.cell-alpha-dev.preprod.a.momentohq.com. 1/0/0 cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (78)
    10.0.0.249.62558 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 62957+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com.local. (68)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.62558: [udp sum ok] 62957 NXDomain q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com.local. 0/1/0 ns: . [10m54s] SOA a.root-servers.net. nstld.verisign-grs.com. 2025030402 1800 900 604800 86400 (143)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.56705: [udp sum ok] 49140 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.56705: [udp sum ok] 44100 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
```
Observe no txt lookups with current version of python sdk [(v 1.25.0)](https://github.com/momentohq/client-sdk-python/releases/tag/v1.25.0)


### Relevant Research Links:
https://github.com/googleapis/gapic-generator/pull/2817


## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132