### PR TITLE
chore: send only-once headers per client type instead of just once

### DIFF
--- a/src/momento/internal/aio/_scs_grpc_manager.py
+++ b/src/momento/internal/aio/_scs_grpc_manager.py
@@ -280,7 +280,7 @@ def _interceptors(
         filter(
             None,
             [
-                AddHeaderClientInterceptor(headers),
+                AddHeaderClientInterceptor(headers, client_type),
                 RetryInterceptor(retry_strategy) if retry_strategy else None,
                 MiddlewareInterceptor(middleware, context) if middleware else None,
             ],
@@ -297,4 +297,4 @@ def _stream_interceptors(auth_token: str, client_type: ClientType) -> list[grpc.
         Header("agent", f"python:{client_type.value}:{momento_version}"),
         Header("runtime-version", f"python {PYTHON_RUNTIME_VERSION}"),
     ]
-    return [AddHeaderStreamingClientInterceptor(headers)]
+    return [AddHeaderStreamingClientInterceptor(headers, client_type)]

--- a/src/momento/internal/synchronous/_scs_grpc_manager.py
+++ b/src/momento/internal/synchronous/_scs_grpc_manager.py
@@ -292,7 +292,7 @@ def _interceptors(
         filter(
             None,
             [
-                AddHeaderClientInterceptor(headers),
+                AddHeaderClientInterceptor(headers, client_type),
                 RetryInterceptor(retry_strategy) if retry_strategy else None,
                 MiddlewareInterceptor(middleware, context) if middleware else None,
             ],
@@ -309,4 +309,4 @@ def _stream_interceptors(auth_token: str, client_type: ClientType) -> list[grpc.
         Header("agent", f"python:{client_type.value}:{momento_version}"),
         Header("runtime-version", f"python {PYTHON_RUNTIME_VERSION}"),
     ]
-    return [AddHeaderStreamingClientInterceptor(headers)]
+    return [AddHeaderStreamingClientInterceptor(headers, client_type)]


### PR DESCRIPTION
Use the client type when determining whether to send only-once headers. If this isn't taken into account, a cache client call will prevent a topics client from sending the agent header.