### PR TITLE
chore: add timeout to topic subscribe

### DIFF
--- a/src/momento/internal/aio/_scs_pubsub_client.py
+++ b/src/momento/internal/aio/_scs_pubsub_client.py
@@ -36,7 +36,7 @@ class _ScsPubsubClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = default_deadline.total_seconds()
+        self._default_deadline_seconds = int(default_deadline.total_seconds())
 
         # Default to a single channel and scale up if necessary. Each channel can support
         # 100 subscriptions. Issuing more subscribe requests than you have channels to handle
@@ -104,6 +104,7 @@ class _ScsPubsubClient:
             stub, decrement_stream_count = self._get_stream_stub()
             stream = stub.Subscribe(  # type: ignore[misc]
                 request,
+                timeout=self._default_deadline_seconds,
             )
 
             # Ping the stream to provide a nice error message if the cache does not exist.

--- a/src/momento/internal/aio/_scs_pubsub_client.py
+++ b/src/momento/internal/aio/_scs_pubsub_client.py
@@ -36,7 +36,7 @@ class _ScsPubsubClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         # Default to a single channel and scale up if necessary. Each channel can support
         # 100 subscriptions. Issuing more subscribe requests than you have channels to handle

--- a/src/momento/internal/synchronous/_scs_pubsub_client.py
+++ b/src/momento/internal/synchronous/_scs_pubsub_client.py
@@ -36,7 +36,7 @@ class _ScsPubsubClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = default_deadline.total_seconds()
+        self._default_deadline_seconds = int(default_deadline.total_seconds())
 
         # Default to a single channel and scale up if necessary. Each channel can support
         # 100 subscriptions. Issuing more subscribe requests than you have channels to handle
@@ -104,6 +104,7 @@ class _ScsPubsubClient:
             stub, decrement_stream_count = self._get_stream_stub()
             stream = stub.Subscribe(  # type: ignore[misc]
                 request,
+                timeout=self._default_deadline_seconds,
             )
 
             # Ping the stream to provide a nice error message if the cache does not exist.

--- a/src/momento/internal/synchronous/_scs_pubsub_client.py
+++ b/src/momento/internal/synchronous/_scs_pubsub_client.py
@@ -36,7 +36,7 @@ class _ScsPubsubClient:
         self._endpoint = endpoint
 
         default_deadline: timedelta = configuration.get_transport_strategy().get_grpc_configuration().get_deadline()
-        self._default_deadline_seconds = int(default_deadline.total_seconds())
+        self._default_deadline_seconds = default_deadline.total_seconds()
 
         # Default to a single channel and scale up if necessary. Each channel can support
         # 100 subscriptions. Issuing more subscribe requests than you have channels to handle

--- a/tests/momento/topic_client/test_topics_async.py
+++ b/tests/momento/topic_client/test_topics_async.py
@@ -1,10 +1,14 @@
+from datetime import timedelta
 from functools import partial
 
 from momento import CacheClientAsync, TopicClientAsync
+from momento.config.topic_configurations import TopicConfigurations
+from momento.errors.error_details import MomentoErrorCode
 from momento.responses import TopicPublish, TopicSubscribe, TopicSubscriptionItem
 from pytest import fixture
 from pytest_describe import behaves_like
 
+from tests.conftest import TEST_AUTH_PROVIDER
 from tests.utils import uuid_bytes, uuid_str
 
 from .shared_behaviors_async import (
@@ -129,3 +133,20 @@ def describe_subscribe() -> None:
 
         resp = await topic_client_async.subscribe(cache_name, topic)
         assert isinstance(resp, TopicSubscribe.SubscriptionAsync)
+
+    async def deadline_exceeded_when_timeout_is_shorter_than_subscribe_response(
+        client: CacheClientAsync, topic_client_async: TopicClientAsync, cache_name: str
+    ) -> None:
+        topic = uuid_str()
+
+        # Default config uses 5 second timeout, should succeed
+        resp = await topic_client_async.subscribe(cache_name, topic)
+        assert isinstance(resp, TopicSubscribe.SubscriptionAsync)
+
+        # Using a topic client configured with 1ms timeout should cause deadline exceeded error
+        async with TopicClientAsync(
+            TopicConfigurations.Default.latest().with_client_timeout(timedelta(milliseconds=1)), TEST_AUTH_PROVIDER
+        ) as short_timeout_client:
+            resp = await short_timeout_client.subscribe(cache_name, topic)
+            assert isinstance(resp, TopicSubscribe.Error)
+            assert resp.error_code == MomentoErrorCode.TIMEOUT_ERROR


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1149

The `timeout` argument to subscribe calls works to set a timeout, which is already passed into the topic client for the publish calls. 
Also added tests to verify that setting a short timeout will trigger the DEADLINE_EXCEEDED error for subscribe calls.